### PR TITLE
Use "defined" to test if there is a plugins list

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -543,7 +543,7 @@ sub get_OutputFactory {
 sub get_all_Plugins {
   my $self = shift;
 
-  if(!exists($self->{plugins})) {
+  if(!defined($self->{plugins})) {
     my @plugins = ();
 
     unshift @INC, $self->param('dir_plugins') || $self->param('dir').'/Plugins';

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -337,6 +337,10 @@ unlink($test_cfg->{user_file}.'.out');
 
 
 # plugins
+$runner = Bio::EnsEMBL::VEP::Runner->new($cfg_hash);
+$runner->{plugins} = undef;
+ok($runner->get_all_Plugins, 'get_all_Plugins - plugins may be undefined');
+
 $runner = Bio::EnsEMBL::VEP::Runner->new({%$cfg_hash, plugin => ['TestPlugin'], quiet => 1});
 
 is_deeply(


### PR DESCRIPTION
The plugins key could be created somewhere else but without defined value. This
could cause issue if the plugins list is later de-referenced.

This fix needs to go into release/87 too.