### PR TITLE
Adding genebuild version for non-vertebrates to info.txt file

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
@@ -672,7 +672,7 @@ sub info {
 
     # core source versions
     if(my $core_mca = $self->get_adaptor('core', 'metacontainer')) {
-      foreach my $meta_key(qw(assembly.name gencode.version genebuild.initial_release_date)) {
+      foreach my $meta_key(qw(assembly.name gencode.version genebuild.initial_release_date genebuild.version)) {
         my $version = $core_mca->list_value_by_key($meta_key);
 
         my $new_key = $meta_key;


### PR DESCRIPTION
For VectorBase and Ensembl Genomes, the meta key 'initial_release_date' is often missing, and does not reliably indicate the geneset version if it does exist. The most useful key for this is 'genebuild.version'; since this is never used in Ensembl, if it exists it can overwrite 'initial_release_date' for EG, but otherwise the behavior of the module is unchanged.