### PR TITLE
bugfix: Preventing stat dumping when outputting to stdout and no stats_file named

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -294,8 +294,8 @@ sub get_stats_file_handle {
 
 sub dump_stats {
   my $self = shift;
-
-  unless($self->param('no_stats')) {
+  
+  unless($self->param('no_stats') || (uc($self->param('output_file')) eq 'STDOUT')) {
 
     if($self->param('stats_text') || !$Bio::EnsEMBL::VEP::Stats::CAN_USE_CGI) {
       my $fh = $self->get_stats_file_handle('txt');

--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -295,7 +295,7 @@ sub get_stats_file_handle {
 sub dump_stats {
   my $self = shift;
   
-  unless($self->param('no_stats') || (uc($self->param('output_file')) eq 'STDOUT')) {
+  unless($self->param('no_stats') || ((uc($self->param('output_file')) eq 'STDOUT') && !$self->param('stats_file')) {
 
     if($self->param('stats_text') || !$Bio::EnsEMBL::VEP::Stats::CAN_USE_CGI) {
       my $fh = $self->get_stats_file_handle('txt');


### PR DESCRIPTION
bugfix: `dump_stats` will check whether the output will be to STDOUT; if the output is going to STDOUT and no stats_file is named, stats will not be written. Fixes #60 .