### PR TITLE
Fix for vep option --flag_pick_allele_gene

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -70,6 +70,7 @@ our @FLAG_FIELDS = (
   { flag => 'user',            fields => ['IMPACT','DISTANCE','STRAND','FLAGS'] },
   { flag => 'flag_pick',       fields => ['PICK'] },
   { flag => 'flag_pick_allele',fields => ['PICK'] },
+  { flag => 'flag_pick_allele_gene', fields => ['PICK'] },
   { flag => 'variant_class',   fields => ['VARIANT_CLASS']},
   { flag => 'minimal',         fields => ['MINIMISED']},
 


### PR DESCRIPTION
Dear Ensembl Developers,

the linked commit fixes the vep --flag_pick_allele_gene option that did not yield a PICK field in the (VCF) output.

Thanks, Michael