### PR TITLE
Use cached seq_region_start and seq_region_end

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -567,9 +567,9 @@ sub split_variants {
 
         # give it a new allele string and coords
         $new_vf->allele_string($ref.'/'.$alt);
-        $new_vf->{start} = $start;
-        $new_vf->{end} = $end;
-        $new_vf->{alt_allele} = $alt;
+        $new_vf->{seq_region_start} = $new_vf->{start} = $start;
+        $new_vf->{seq_region_end}   = $new_vf->{end}   = $end;
+        $new_vf->{alt_allele}       = $alt;
 
         # $new_vf->{variation_name} = 'merge_'.$alt;
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1908,9 +1908,9 @@ sub rejoin_variants_in_InputBuffer {
       # do consequence stuff
       $self->get_all_output_hashes_by_VariationFeature($vf);
 
-      $vf->{allele_string} = $vf->{original_allele_string};
-      $vf->{start}         = $vf->{original_start};
-      $vf->{end}           = $vf->{original_end};
+      $vf->{allele_string}    = $vf->{original_allele_string};
+      $vf->{seq_region_start} = $vf->{start} = $vf->{original_start};
+      $vf->{seq_region_end}   = $vf->{end}   = $vf->{original_end};
 
       push @joined_list, $vf;
     }

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -740,6 +740,13 @@ sub post_process_vfs {
   # minimise alleles?
   $vfs = $self->minimise_alleles($vfs) if $self->{minimal};
 
+  # copy start, end coords to seq_region_start, seq_region_end
+  # otherwise for circular chromosomes the core API will try to do a DB lookup and die
+  foreach my $vf(@$vfs) {
+    $vf->seq_region_start($vf->{start});
+    $vf->seq_region_end($vf->{end});
+  }
+
   return $vfs;
 }
 
@@ -854,11 +861,13 @@ sub minimise_alleles {
         $new_vf->allele_string($ref.'/'.$alt);
         $new_vf->{start}                  = $start;
         $new_vf->{end}                    = $end;
+        $new_vf->{seq_region_start}       = $start;
+        $new_vf->{seq_region_end}         = $end;
         $new_vf->{original_allele_string} = $vf->{allele_string};
         $new_vf->{original_start}         = $vf->{start};
         $new_vf->{original_end}           = $vf->{end};
         $new_vf->{minimised}              = 1;
-
+        
         push @return, $new_vf;
       }
     }

--- a/t/InputBuffer.t
+++ b/t/InputBuffer.t
@@ -73,7 +73,9 @@ is_deeply($vfs->[0], bless( {
   'map_weight' => 1,
   'allele_string' => 'C/T',
   'end' => 25585733,
-  'start' => '25585733'
+  'start' => 25585733,
+  'seq_region_end' => 25585733,
+  'seq_region_start' => 25585733
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'next first variant');
 
 
@@ -89,7 +91,9 @@ is_deeply($vfs->[0], bless( {
   'map_weight' => 1,
   'allele_string' => 'A/G',
   'end' => 25592911,
-  'start' => '25592911'
+  'start' => 25592911,
+  'seq_region_end' => 25592911,
+  'seq_region_start' => 25592911
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'next again first variant');
 
 is_deeply($ib->min_max, [25592911, 25603910], 'min_max');
@@ -419,7 +423,9 @@ is_deeply($ib->buffer, [
     'alt_allele' => 'T',
     'map_weight' => 1,
     'allele_string' => 'C/T',
-    'start' => 1
+    'start' => 1,
+    'seq_region_start' => 1,
+    'seq_region_end' => 1,
   }, 'Bio::EnsEMBL::Variation::VariationFeature' ),
   bless( {
     'chr' => '1',
@@ -431,7 +437,9 @@ is_deeply($ib->buffer, [
     'alt_allele' => '-',
     'map_weight' => 1,
     'allele_string' => 'AGAAGAAAG/-',
-    'start' => 2
+    'start' => 2,
+    'seq_region_start' => 2,
+    'seq_region_end' => 10,
   }, 'Bio::EnsEMBL::Variation::VariationFeature' )
 ], 'minimal - split_variants');
 
@@ -461,7 +469,9 @@ is_deeply(
     'map_weight' => 1,
     'allele_string' => 'CAG/TAG/T',
     'end' => 3,
-    'start' => 1
+    'start' => 1,
+    'seq_region_start' => 1,
+    'seq_region_end' => 3,
   }, 'Bio::EnsEMBL::Variation::VariationFeature' ),
   'minimal - doesnt affect non-minimisable'
 );

--- a/t/Parser.t
+++ b/t/Parser.t
@@ -84,7 +84,9 @@ is_deeply(
     'original_start' => 1,
     'strand' => 1,
     'allele_string' => 'A/T',
-    'start' => 2
+    'start' => 2,
+    'seq_region_start' => 2,
+    'seq_region_end' => 1,
   }, 'Bio::EnsEMBL::Variation::VariationFeature'),
   "minimal"
 );

--- a/t/Parser_HGVS.t
+++ b/t/Parser_HGVS.t
@@ -91,10 +91,12 @@ SKIP: {
     '_source_id' => undef,
     'analysis' => undef,
     'end' => 25585733,
+    'seq_region_end' => 25585733,
     'minor_allele_frequency' => undef,
     'overlap_consequences' => undef,
     'minor_allele' => undef,
-    'start' => 25585733
+    'start' => 25585733,
+    'seq_region_start' => 25585733
   }, 'Bio::EnsEMBL::Variation::VariationFeature' );
 
   $vf = $p->next();
@@ -284,10 +286,12 @@ SKIP: {
     '_source_id' => undef,
     'analysis' => undef,
     'end' => 6674,
+    'seq_region_end' => 6674,
     'minor_allele_frequency' => undef,
     'overlap_consequences' => undef,
     'minor_allele' => undef,
-    'start' => 6674
+    'start' => 6674,
+    'seq_region_start' => 6674
   }, 'Bio::EnsEMBL::Variation::VariationFeature' );
 
   $vf = Bio::EnsEMBL::VEP::Parser::HGVS->new({
@@ -348,11 +352,13 @@ SKIP: {
     '_source_id' => undef,
     'chr' => '21',
     'end' => 43774705,
+    'seq_region_end' => 43774705,
     'analysis' => undef,
     'minor_allele_frequency' => undef,
     'overlap_consequences' => undef,
     'minor_allele' => undef,
-    'start' => 43774705
+    'start' => 43774705,
+    'seq_region_start' => 43774705
   }, 'Bio::EnsEMBL::Variation::VariationFeature' );
 
   $vf = $p->next;
@@ -412,10 +418,12 @@ SKIP: {
       '_source_id' => undef,
       'analysis' => undef,
       'end' => 25585733,
+      'seq_region_end' => 25585733,
       'minor_allele_frequency' => undef,
       'overlap_consequences' => undef,
       'minor_allele' => undef,
-      'start' => 25585733
+      'start' => 25585733,
+      'seq_region_start' => 25585733
     }, 'Bio::EnsEMBL::Variation::VariationFeature' ),
     'core db only - genomic hgvs'
   );

--- a/t/Parser_ID.t
+++ b/t/Parser_ID.t
@@ -92,10 +92,12 @@ SKIP: {
     'chr' => '21',
     '_source_id' => '1',
     'end' => 25585733,
+    'seq_region_end' => 25585733,
     'flank_match' => '1',
     'minor_allele_frequency' => '0.000998403',
     'minor_allele' => 'T',
     'start' => 25585733,
+    'seq_region_start' => 25585733,
     '_line' => ['rs142513484'],
     '_source_name' => 'dbSNP',
   }, 'Bio::EnsEMBL::Variation::VariationFeature' );

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -73,7 +73,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'C/T',
   'end' => 25585733,
-  'start' => 25585733
+  'start' => 25585733,
+  'seq_region_end' => 25585733,
+  'seq_region_start' => 25585733
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'next');
 
 is(ref($p->next), 'Bio::EnsEMBL::Variation::VariationFeature', 'next again');
@@ -114,7 +116,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'C/-',
   'end' => 25587760,
-  'start' => 25587760
+  'start' => 25587760,
+  'seq_region_end' => 25587760,
+  'seq_region_start' => 25587760
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'deletion');
 
 # insertion
@@ -131,7 +135,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => '-/C',
   'end' => 25587759,
-  'start' => 25587760
+  'start' => 25587760,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587760
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'insertion');
 
 # deletion with SVTYPE field
@@ -148,7 +154,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'C/-',
   'end' => 25587760,
-  'start' => 25587760
+  'start' => 25587760,
+  'seq_region_end' => 25587760,
+  'seq_region_start' => 25587760
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'deletion ignore SVTYPE');
 
 # deletion with SVTYPE field
@@ -165,7 +173,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => '-/C',
   'end' => 25587759,
-  'start' => 25587760
+  'start' => 25587760,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587760
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'insertion ignore SVLEN');
 
 # multiple alts
@@ -182,7 +192,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'A/C/G',
   'end' => 25587759,
-  'start' => 25587759
+  'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'multiple alts');
 
 # mixed types - different first base
@@ -199,7 +211,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'A/C/GG',
   'end' => 25587759,
-  'start' => 25587759
+  'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'mixed types - different first base');
 
 # mixed types - different first base
@@ -216,7 +230,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => '-/C/T',
   'end' => 25587759,
-  'start' => 25587760
+  'start' => 25587760,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587760
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'mixed types - same first base');
 
 # stubby - nothing after ALT
@@ -233,7 +249,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'G/C',
   'end' => 25587759,
-  'start' => 25587759
+  'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'stubby');
 
 # non-variant
@@ -251,6 +269,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'G',
   'end' => 25587759,
   'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759,
   'non_variant' => 1,
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'non-variant');
 
@@ -276,6 +296,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'G/C/*',
   'end' => 25587759,
   'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), '*-type 1');
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
@@ -292,6 +314,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'G/C/<DEL:*>',
   'end' => 25587759,
   'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), '*-type 2 ');
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
@@ -309,6 +333,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'C/-/*',
   'end' => 25587760,
   'start' => 25587760,
+  'seq_region_end' => 25587760,
+  'seq_region_start' => 25587760
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), '*-type with deletion');
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
@@ -326,6 +352,8 @@ is_deeply($vf, bless( {
   'allele_string' => '-/C/*',
   'end' => 25587759,
   'start' => 25587760,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587760
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), '*-type with insertion');
 
 # minimal
@@ -341,12 +369,14 @@ is_deeply($vf, bless( {
   'original_allele_string' => 'CAT/CCT',
   'original_end' => 25587760,
   'end' => 25587759,
+  'seq_region_end' => 25587759,
   'original_start' => '25587758',
   'strand' => 1,
   'variation_name' => 'test',
   'map_weight' => 1,
   'allele_string' => 'A/C',
-  'start' => 25587759
+  'start' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'minimal');
 
 
@@ -363,7 +393,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'C/T/CAA',
   'end' => 25587758,
-  'start' => 25587758
+  'start' => 25587758,
+  'seq_region_end' => 25587758,
+  'seq_region_start' => 25587758
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'minimal - multiple alts pass through here');
 
 
@@ -374,11 +406,13 @@ $expected = bless( {
   'inner_end' => 25587769,
   'outer_start' => 25587759,
   'end' => 25587769,
+  'seq_region_end' => 25587769,
   'inner_start' => 25587759,
   'strand' => 1,
   'class_SO_term' => 'duplication',
   'variation_name' => 'sv_dup',
-  'start' => 25587759
+  'start' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' );
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
@@ -425,11 +459,13 @@ is_deeply($vf, bless( {
   'inner_end' => 25587765,
   'outer_start' => 25587756,
   'end' => 25587769,
+  'seq_region_end' => 25587769,
   'inner_start' => 25587761,
   'strand' => 1,
   'class_SO_term' => 'duplication',
   'variation_name' => 'sv_dup',
-  'start' => 25587759
+  'start' => 25587759,
+  'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature fuzzy');
 
 no warnings 'once';
@@ -466,7 +502,9 @@ is_deeply($vf, bless( {
   'map_weight' => 1,
   'allele_string' => 'A/G',
   'end' => 25586000,
-  'start' => 25586000
+  'start' => 25586000,
+  'seq_region_end' => 25586000,
+  'seq_region_start' => 25586000
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'gp');
 
 # GP flag not found
@@ -507,6 +545,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'A/G',
   'end' => 25587759,
   'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759,
   'genotype' => ['A', 'G'],
   'individual' => 'dave',
   'phased' => 1,
@@ -522,6 +562,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'A/G',
   'end' => 25587759,
   'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759,
   'genotype' => ['G', 'G'],
   'individual' => 'barry',
   'phased' => 0,
@@ -537,6 +579,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'A',
   'end' => 25587759,
   'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759,
   'genotype' => ['A', 'A'],
   'individual' => 'jeff',
   'phased' => 0,
@@ -565,6 +609,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'A/A',
   'end' => 25587759,
   'start' => 25587759,
+  'seq_region_end' => 25587759,
+  'seq_region_start' => 25587759,
   'genotype' => ['A', 'A'],
   'individual' => 'jeff',
   'phased' => 0,

--- a/t/Parser_VEP_input.t
+++ b/t/Parser_VEP_input.t
@@ -63,6 +63,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'C/A',
   'end' => '25587759',
   'start' => '25587759',
+  'seq_region_end' => '25587759',
+  'seq_region_start' => '25587759',
   '_line' => [qw(21 25587759 25587759 C/A + test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'basic next test');
 
@@ -79,6 +81,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'C/A',
   'end' => '25587759',
   'start' => '25587759',
+  'seq_region_end' => '25587759',
+  'seq_region_start' => '25587759',
   '_line' => [qw(21 25587759 25587759 C/A - test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'negative strand (-)');
 
@@ -95,6 +99,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'C/A',
   'end' => '25587759',
   'start' => '25587759',
+  'seq_region_end' => '25587759',
+  'seq_region_start' => '25587759',
   '_line' => [qw(21 25587759 25587759 C/A -1 test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'negative strand (-1)');
 
@@ -111,6 +117,8 @@ is_deeply($vf, bless( {
   'allele_string' => 'C/A',
   'end' => '25587759',
   'start' => '25587759',
+  'seq_region_end' => '25587759',
+  'seq_region_start' => '25587759',
   '_line' => [qw(21 25587759 25587759 C/A)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'stubby');
 
@@ -126,6 +134,8 @@ is_deeply($vf, bless( {
   'class_SO_term' => 'duplication',
   'end' => '25587769',
   'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
   '_line' => [qw(21 25587759 25587769 DUP + test)]
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV dup');
 


### PR DESCRIPTION
Historically VEP has used $vf->{start} for coordinate lookup, and
mostly it works fine. Some of the TranscriptMapper methods
require $vf->seq_region_start(). Mostly this is OK as it just does
a slice-based lookup, but for circular slices e.g. in E.coli the
core API tries to do a DB lookup based on $vf->dbID, which
of course fails.

We get around it by caching seq_region_start on the VF itself.
This depends on an update the ensembl-variation
BaseVariationFeature module to implement that caching and avoid
defaulting to the parent method in Feature.

Have to be careful though, particularly when split_variants() and
minimise_alleles() create copies of VFs, hence the changes there.