### PR TITLE
Add support for --transcript_version

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm
@@ -60,14 +60,11 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 
 
-our ($CAN_USE_HTS, $CAN_USE_CIGAR, $CAN_USE_INTERVAL_TREE);
+our ($CAN_USE_HTS, $CAN_USE_INTERVAL_TREE);
 
 BEGIN {
   if (eval q{ require Bio::DB::HTS; 1 }) {
     $CAN_USE_HTS = 1;
-  }
-  if (eval q{ require Bio::Cigar; 1 }) {
-    $CAN_USE_CIGAR = 1;
   }
   if (eval q{ require Bio::EnsEMBL::VEP::TranscriptTree; 1 }) {
     $CAN_USE_INTERVAL_TREE = 1;
@@ -554,24 +551,24 @@ sub apply_edits {
   eval {$new_tr_spliced_seq = $tr->spliced_seq};
 
   my $cmp = !$@ && $new_tr_spliced_seq eq $bam_seq;
-  if($DEBUG) {
-    my $status = $cmp ? 'OK' : 'FAILED';
-    my $error = $@ ? "\t$@" : "";
-    $error =~ s/\s+$//g;
+  # if($DEBUG) {
+  #   my $status = $cmp ? 'OK' : 'FAILED';
+  #   my $error = $@ ? "\t$@" : "";
+  #   $error =~ s/\s+$//g;
 
-    print STDERR
-      "$status $stable_id STRAND $mapping_strand OPS ".
-      join(", ", map {$_.":".$seen_ops{$_}} sort keys %seen_ops).
-      " EDITS ".
-      (join(", ", map {$_->value} grep {$_->code eq '_rna_edit'} @{$tr->get_all_Attributes}) || 'NONE').
-      "$error\n";
+  #   print STDERR
+  #     "$status $stable_id STRAND $mapping_strand OPS ".
+  #     join(", ", map {$_.":".$seen_ops{$_}} sort keys %seen_ops).
+  #     " EDITS ".
+  #     (join(", ", map {$_->value} grep {$_->code eq '_rna_edit'} @{$tr->get_all_Attributes}) || 'NONE').
+  #     "$error\n";
 
-    if($status eq 'FAILED') {
-      open OUT, ">$stable_id.fa";
-      print OUT "\>BAM\n$bam_seq\n\>PRE\n$pre_edit_seq\n\>TR\n".$new_tr_spliced_seq;
-      close OUT;
-    }
-  }
+  #   if($status eq 'FAILED') {
+  #     open OUT, ">$stable_id.fa";
+  #     print OUT "\>BAM\n$bam_seq\n\>PRE\n$pre_edit_seq\n\>TR\n".$new_tr_spliced_seq;
+  #     close OUT;
+  #   }
+  # }
   
   if($cmp) {
     # flag successful

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -182,6 +182,7 @@ sub new {
     biotype
     tsl
     appris
+    transcript_version
     gene_phenotype
 
     total_length
@@ -1212,6 +1213,7 @@ sub BaseTranscriptVariationAllele_to_output_hash {
   # basics
   $hash->{Feature_type} = 'Transcript';
   $hash->{Feature}      = $tr->stable_id if $tr;
+  $hash->{Feature}     .= '.'.$tr->version if $hash->{Feature} && $self->{transcript_version} && $hash->{Feature} !~ /\.\d+$/;
 
   # get gene
   $hash->{Gene} = $tr->{_gene_stable_id};

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -346,6 +346,7 @@ sub output_hash_to_vcf_info_chunk {
       if(defined($data)) {
         $data =~ s/\,/\&/g;
         $data =~ s/\;/\%3B/g;
+        $data =~ s/\s+/\_/g;
       }
 
       push @chunk, $data;

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -889,6 +889,14 @@ is_deeply(
   'BaseTranscriptVariationAllele_to_output_hash'
 );
 
+$of->{transcript_version} = 1;
+is(
+  $of->BaseTranscriptVariationAllele_to_output_hash($vfoa, {Consequence => ['upstream_gene_variant']})->{Feature},
+  'ENST00000567517.1',
+  'BaseTranscriptVariationAllele_to_output_hash'
+);
+$of->{transcript_version} = 0;
+
 ($vf) = grep {$_->{variation_name} eq 'rs199510789'} @{$ib->buffer};
 ($vfoa) = grep {$_->feature->stable_id eq 'ENST00000419219'} @{$of->get_all_VariationFeatureOverlapAlleles($vf)};
 

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -206,6 +206,7 @@ is_deeply($runner->get_OutputFactory, bless( {
   'max_af' => undef,
   'use_transcript_ref' => undef,
   'af_gnomad' => undef,
+  'transcript_version' => undef,
 }, 'Bio::EnsEMBL::VEP::OutputFactory::VEP_output' ), 'get_OutputFactory');
 
 

--- a/vep
+++ b/vep
@@ -134,6 +134,7 @@ GetOptions(
   'biotype',                 # add biotype of transcript to output
   'hgnc',                    # add HGNC gene ID to extra column
   'symbol',                  # add gene symbol (e.g. HGNC)
+  'transcript_version',      # add transcript version to stable id in feature column
   'gene_phenotype',          # indicate if genes are phenotype-associated
   'hgvs',                    # add HGVS names to extra column
   'hgvsg',                   # add HGVS g. also


### PR DESCRIPTION
This flag will add version number to transcript IDs in the output file. Note it won't add them to RefSeq identifiers, as they already have the version number in the `$tr->stable_id` property. This may change in future, so something to be aware of.

This PR also includes a couple of minor unrelated fixes.