### PR TITLE
Improve Dockerfile: configure locales and a proper /opt installation dir

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,32 +3,50 @@ FROM ubuntu
 
 # update aptitude and install some required packages
 # a lot of them are required for Bio::DB::BigFile
-RUN apt-get update && apt-get -y install apache2 build-essential cpanminus curl git libmysqlclient-dev libpng12-dev libssl-dev manpages mysql-client openssl perl perl-base unzip vim wget
+RUN apt-get update && apt-get -y install \
+    apache2 \
+    build-essential \
+    cpanminus \
+    curl \
+    git \
+    libmysqlclient-dev \
+    libpng12-dev \
+    libssl-dev \
+    locales \
+    manpages \
+    mysql-client \
+    openssl \
+    perl \
+    perl-base \
+    unzip \
+    vim \
+    wget
+
 # install ensembl dependencies
 RUN cpanm DBI DBD::mysql
 
 # create vep user
-RUN useradd -r -m -U -d /home/vep -s /bin/bash -c "VEP User" -p '' vep
+RUN useradd -r -m -U -d /opt/vep -s /bin/bash -c "VEP User" -p '' vep
 RUN usermod -a -G sudo vep
 USER vep
-ENV HOME /home/vep
-WORKDIR $HOME
+ENV OPT /opt/vep
+WORKDIR $OPT
 
 # clone git repositories
 RUN mkdir -p src
-WORKDIR $HOME/src
+WORKDIR $OPT/src
 RUN git clone https://github.com/Ensembl/ensembl.git
 RUN git clone https://github.com/Ensembl/ensembl-vep.git
 
 # get VEP dependencies
-WORKDIR $HOME/src
+WORKDIR $OPT/src
 RUN ensembl-vep/travisci/get_dependencies.sh
-ENV PERL5LIB $PERL5LIB:$HOME/src/bioperl-live-release-1-6-924
-ENV KENT_SRC $HOME/src/kent-335_base/src
-ENV HTSLIB_DIR $HOME/src/htslib
+ENV PERL5LIB $PERL5LIB:$OPT/src/bioperl-live-release-1-6-924
+ENV KENT_SRC $OPT/src/kent-335_base/src
+ENV HTSLIB_DIR $OPT/src/htslib
 ENV MACHTYPE x86_64
 ENV CFLAGS "-fPIC"
-ENV DEPS $HOME/src
+ENV DEPS $OPT/src
 
 # and run the complilation/install as root
 USER root
@@ -39,7 +57,7 @@ WORKDIR $HTSLIB_DIR
 RUN make install
 
 # install bioperl-ext, faster alignments for haplo
-WORKDIR $HOME/src
+WORKDIR $OPT/src
 RUN git clone https://github.com/bioperl/bioperl-ext.git
 WORKDIR bioperl-ext/Bio/Ext/Align/
 RUN perl -pi -e"s|(cd libs.+)CFLAGS=\\\'|\$1CFLAGS=\\\'-fPIC |" Makefile.PL
@@ -48,22 +66,30 @@ RUN make
 RUN make install
 
 # install perl dependencies
-WORKDIR $HOME/src
+WORKDIR $OPT/src
 RUN cpanm --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
 RUN cpanm --installdeps --with-recommends --notest --cpanfile ensembl-vep/cpanfile .
+
+# configure locale, see https://github.com/rocker-org/rocker/issues/19
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+    locale-gen en_US.utf8 && \
+    /usr/sbin/update-locale LANG=en_US.UTF-8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
 
 # switch back to vep user
 USER vep
 
 # update bash profile
-RUN echo >> $HOME/.profile && \
-echo PATH=$HOME/src/ensembl-vep:\$PATH >> $HOME/.profile && \
-echo export PATH >> $HOME/.profile
+RUN echo >> $OPT/.profile && \
+    echo PATH=$OPT/src/ensembl-vep:\$PATH >> $OPT/.profile && \
+    echo export PATH >> $OPT/.profile
 
 # setup environment
-ENV PATH $HOME/src/ensembl-vep:$PATH
+ENV PATH $OPT/src/ensembl-vep:$PATH
 
 # run INSTALL.pl
-WORKDIR $HOME/src/ensembl-vep
+WORKDIR $OPT/src/ensembl-vep
 RUN chmod u+x *.pl
 RUN ./INSTALL.pl -a a -l


### PR DESCRIPTION
We use VEP in an HPC cluster that doesn't support docker. We use [singularity](http://singularity.lbl.gov/) instead, which supports running docker images. Currently, we have some issues with the conversion from the docker images, because of the following definitions in the Dockerfile:
1) The locales are no set properly.
```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_COLLATE = "C",
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
```

2) In singularity $HOME is inherited from the host, so we need some cumbersome settings to run the containers in other folder. And the Dockerfile is installing everything in `/home`.

In this PR, I made the following improvements for a _**better docker configuration**_, that hope will benefit people that uses singularity, or docker with different $HOME settings: 

**installing and setting up the locales and changing the installation directory from $HOME (`/home`) to $OPT (`/opt`)**
