### PR TITLE
Clear registry before running VEP

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
@@ -300,6 +300,7 @@ sub run_test_set {
   my $has_var = $self->param('variation') ? 1 : 0;
   my $has_reg = $self->param('regulation') ? 1 : 0;
 
+  Bio::EnsEMBL::Registry->clear();
   # create a VEP Runner
   my $runner = Bio::EnsEMBL::VEP::Runner->new({
     species => $self->param('species'),
@@ -544,6 +545,7 @@ sub human_frequency_checks {
   my $has_var = $self->param('variation') ? 1 : 0;
   my $has_reg = $self->param('regulation') ? 1 : 0;
 
+  Bio::EnsEMBL::Registry->clear();
   # create a VEP Runner
   my $runner = Bio::EnsEMBL::VEP::Runner->new({
     species => $self->param('species'),


### PR DESCRIPTION
The QC step was failing because during a VEP run errors like _No sequence found for seq_region 13699:62522_ occurred. At the same time we would get warnings: _WARN: Species (homo_sapiens) and group (core) same for two separate databases_ There could have been a conflict between different core databases (core and otherfeature maybe). Calling clear on the registry is solving the problem. Although, I don't know exactly why.