### PR TITLE
Ignore HGVS input that include square brackets

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
@@ -155,7 +155,7 @@ sub create_VariationFeatures {
   # remove whitespace
   $hgvs =~ s/\s+//g;
 
-  if ((index($hgvs, '[') != -1) || (index($hgvs, ']') != -1)) {
+  if ($hgvs =~ /(\[|\])/ ){
     $self->warning_msg("WARNING: Unable to parse HGVS notation \'$hgvs\'\n");
     return $self->create_VariationFeatures 
   }

--- a/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
@@ -155,6 +155,11 @@ sub create_VariationFeatures {
   # remove whitespace
   $hgvs =~ s/\s+//g;
 
+  if ((index($hgvs, '[') != -1) || (index($hgvs, ']') != -1)) {
+    $self->warning_msg("WARNING: Unable to parse HGVS notation \'$hgvs\'\n");
+    return $self->create_VariationFeatures 
+  }
+
   my $param_core_group = $self->param('core_type');
   my @core_groups = sort {($b eq $param_core_group) cmp ($a eq $param_core_group)} qw(core otherfeatures);
   


### PR DESCRIPTION
PR to filter out user-given HGVS that includes square brackets - causing issues on web

As #276 but with a cleaner commit history