### PR TITLE
From release 95 onward, all the ensembl databases have a division

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
@@ -101,7 +101,7 @@ sub fetch_input {
     $species_hash{pipeline_dump_dir} = $pipeline_dump_dir;
   }
   else {
-    $species_hash{pipeline_dump_dir} = $self->param('pipeline_dir');
+    die "Can't find division for database ".$species_hash{dbname};
   }
 
   #Processing Collections

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DistributeDumps.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DistributeDumps.pm
@@ -53,9 +53,7 @@ sub run {
     }
   }
   else {
-    $dir = $self->required_param('pipeline_dir').'/dumps';
-    $self->DistributeProduction($dir);
-    $self->DistributeWeb($dir);
+    die "No division found, cannot distribute dumps";
   }
 }
 


### PR DESCRIPTION
@at7: This is regarding the issues with dump path for vertebrates in release 95. The code is not broken but because we have updated the division for vertebrates, we should run the pipeline with the division flag in the future. I've updated the code to make things a bit cleaner and will update the documentation once this PR is merged.