### PR TITLE
Remove the extra 'Extra' key in the default VEP output (found with th…

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
@@ -106,7 +106,7 @@ sub output_hash_to_line {
   # add additional fields to "Extra" col at the end
   my %extra =
     map {$_ => $hash->{$_}}
-    grep {!$OUTPUT_COLS_HASH{$_}}
+    grep {!$OUTPUT_COLS_HASH{$_} && $_ ne 'Extra'}
     keys %$hash;
 
   my $field_order = $self->field_order;


### PR DESCRIPTION
…e G2P plugin)

e.g. `Extra=HASH(0x2819cdf0)`:
```
rs80338647	1:235806723	-	ENSG00000143669	ENST00000389793	Transcript	frameshift_variant	2588	2413	805	E/X	Gaa/aa	rs80338647,CD075459,COSM210418	IND=patient;ZYG=HOM;IMPACT=HIGH;STRAND=-1;SYMBOL=LYST;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1968;CLIN_SIG=pathogenic;SOMATIC=0,0,1;PHENO=1,1,1;Extra=HASH(0x2819cdf0);G2P_complete=1;G2P_flag=HOM;G2P_gene_req=BI
```