### PR TITLE
ignore empty motifFeatures

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/RegFeat.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/RegFeat.pm
@@ -221,7 +221,7 @@ sub deserialized_obj_to_features {
         }
 
         $f->{_vep_feature_type} ||= $type;
-
+        next unless (defined $f->{start});
         push @features, $f;
       }
     }

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -53,7 +53,7 @@ use warnings;
 use base qw(Exporter);
 
 our $VEP_VERSION     = 95;
-our $VEP_SUB_VERSION = 2;
+our $VEP_SUB_VERSION = 3;
 
 our @EXPORT_OK = qw(
   @FLAG_FIELDS


### PR DESCRIPTION
This fix will ignore empty MotifFeatures. For release/96 we are more carful with dumping regulatory data into cache files and won't have to deal with reading empty MotifFeatures from cache files.