### PR TITLE
skip long and complex SV and enable overlaps in VCF

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -99,6 +99,7 @@ our %DEFAULTS = (
   terminal_width    => 48,
   vcf_info_field    => 'CSQ',
   ucsc_data_root    => 'http://hgdownload.cse.ucsc.edu/goldenpath/',
+  max_sv_size       => 10000000,
   
   # frequency filtering
   freq_freq         => 0.01,

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -119,6 +119,7 @@ our @FLAG_FIELDS = (
   { flag => 'check_existing',  fields => ['CLIN_SIG','SOMATIC','PHENO'] },
   { flag => 'pubmed',          fields => ['PUBMED'] },
   { flag => 'check_svs',       fields => ['SV'] },
+  { flag => 'overlaps',        fields => ['OverlapBP', 'OverlapPC']},
 
   # regulatory
   { flag => 'regulatory',      fields => ['BIOTYPE','MOTIF_NAME','MOTIF_POS','HIGH_INF_POS','MOTIF_SCORE_CHANGE'] },

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -197,6 +197,9 @@ sub next {
   if(my $parser = $self->parser) {
     while(@$buffer < $buffer_size && (my $vf = $parser->next)) {
 
+      # skip long and unsupported types of SV; doing this here to avoid stopping looping
+      next if $vf->{vep_skip};
+
       # new chromosome
       if($prev_chr && $vf->{chr} ne $prev_chr) {
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -485,7 +485,7 @@ sub create_StructuralVariationFeatures {
     _line          => $record,
   });
 
-  $svf->{vep_skip} = $skip if defined $skip;;
+  $svf->{vep_skip} = $skip if defined $skip;
 
   return $self->post_process_vfs([$svf]);
 }

--- a/t/Haplo_Runner.t
+++ b/t/Haplo_Runner.t
@@ -114,6 +114,7 @@ SKIP: {
     'gp' => undef,
     'individual' => undef,
     'phased' => undef,
+     'max_sv_size' => 10000000,
   }, 'Bio::EnsEMBL::VEP::Haplo::Parser::VCF' ), 'get_Parser');
 
   my $t = $runner->get_TranscriptTree;

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -535,6 +535,25 @@ ok(
 );
 
 
+## test feature overlaps available in output
+my $len_config = $ib->config;
+$len_config->{_params}->{overlaps} = 1;
+$ib = get_runner({
+ input_file => $test_cfg->create_input_file([qw(21 25585733 25585735 DEL 1)]),
+   dir => $test_cfg->{cache_root_dir},
+     fasta => $test_cfg->{fasta},
+     })->get_InputBuffer;
+     $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $len_config});
+     $ib->buffer->[0]->{transcript_variations} = {};
+
+ok(
+  $of->get_all_lines_by_InputBuffer($ib)->[0] =~ /3\|0.01,deletion/,
+  "SV overlap percent and length available"
+);
+
+
+
+
 ## test getting stuff from input
 ################################
 

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -507,6 +507,40 @@ is_deeply($lvf, bless( {
   'seq_region_start' => 25587759,
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - longer than specified maximum');
 
+## test complex SV
+no warnings 'once';
+open(SAVE, ">&STDERR") or die "Can't save STDERR\n";
+close STDERR;
+open STDERR, '>', \$tmp;
+
+my $cvf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1, max_sv_size => 1000, warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(1 774569 gnomAD_v2_CPX_1_1 N	<CPX> 1 PASS END=828435;SVTYPE=CPX;CHR2=1;SVLEN=53959)]),
+  valid_chromosomes => [1]
+})->next();
+delete($cvf->{adaptor}); delete($cvf->{_line});
+
+is_deeply($cvf, bless( {
+                 'outer_end' => '828435',
+                 'chr' => '1',
+                 'inner_end' => '828435',
+                 'outer_start' => '774570',
+                 'end' => 828435,
+                 'vep_skip' => 1,
+                 'seq_region_start' => 774570,
+                 'inner_start' => '774570',
+                 'strand' => 1,
+                 'seq_region_end' => 828435,
+                 'class_SO_term' => 'CPX',
+                 'variation_name' => 'gnomAD_v2_CPX_1_1',
+                 'start' => 774570
+               },
+                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - CPX skipped');
+
+
+ok($tmp =~ /variant CPX is of a non-supported type/, 'StructuralVariationFeature - skip CPX warning');
+
+open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 
 
 ## OTHER TESTS

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -483,6 +483,30 @@ ok($tmp =~ /VCF line.+looks incomplete/, 'StructuralVariationFeature del without
 
 open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 
+## test max SV length
+my $lvf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1, max_sv_size => 1000, warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(21 25587758 sv_dup T <DUP> . . SVLEN=10001;CIPOS=-3,2;CIEND=-4,5)]),
+  valid_chromosomes => [21]
+})->next();
+delete($lvf->{adaptor}); delete($lvf->{_line});
+
+is_deeply($lvf, bless( {
+  'outer_end' => 25597764,
+  'chr' => '21',
+  'inner_end' => 25597755,
+  'outer_start' => 25587756,
+  'end' => 25597759,
+  'vep_skip' => 1,
+  'seq_region_end' => 25597759,
+  'inner_start' => 25587761,
+  'strand' => 1,
+  'class_SO_term' => 'duplication',
+  'variation_name' => 'sv_dup',
+  'start' => 25587759,
+  'seq_region_start' => 25587759,
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - longer than specified maximum');
+
 
 
 ## OTHER TESTS

--- a/vep
+++ b/vep
@@ -100,7 +100,10 @@ GetOptions(
   'dont_skip',               # don't skip vars that fail validation
   'nearest=s',               # get nearest transcript, gene or symbol (for gene)
   'distance=s',              # set up/downstream distance
-  
+
+  'overlaps',                # report length and percent of a transcript or regulatory feature overlaped with a SV
+  'max_sv_size=i',             # modify the size of structural variant to be handled (limited by default to reduce memory requirements)
+
   # verbosity options
   'verbose|v',               # print out a bit more info while running
   'quiet|q',                 # print nothing to STDOUT (unless using -o stdout)
@@ -163,7 +166,7 @@ GetOptions(
   'show_ref_allele',         # indicate reference allele
   'no_escape',               # don't percent-escape HGVS strings
   'ambiguity',               # Add allele ambiguity code
-  
+
   # cache stuff
   'database',                # must specify this to use DB now
   'cache',                   # use cache


### PR DESCRIPTION
Complex SV cannot currently be annotated, so skip them. 
Long SV require large amounts of memory, so a default max size is set which can be overridden on the command line.
Docs to follow