### PR TITLE
Keep same chromosome ordering for the transcript tree

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/Transcript.pm
@@ -288,7 +288,7 @@ sub tree_file {
     open TR, ">$tmpfile" or throw("ERROR: Could not write to transcript coords file: $!");
 
     opendir DIR, $as_dir;
-    foreach my $c(grep {!/^\./ && -d $as_dir.'/'.$_} readdir DIR) {
+    foreach my $c(sort { $a cmp $b } grep {!/^\./ && -d $as_dir.'/'.$_} readdir DIR) {
       
       opendir CHR, $as_dir.'/'.$c;
 


### PR DESCRIPTION
The test was failing on the Docker build as the tree is now composed of 2 chromosomes (21 and 22) and for some reason, the tests on Docker built them in the order `22->21` whereas Travis built it in the order `21->22`.