### PR TITLE
 use SVTYPE to define type in preference to ALTs for CNVs 

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -457,7 +457,8 @@ sub create_StructuralVariationFeatures {
     $type = $info->{SVTYPE};
   }
 
-  my $so_term;
+  # set a default which we do not expect to see
+  my $so_term = 'sequence_variant';
 
   if(defined($type)) {
     # convert to SO term
@@ -466,7 +467,7 @@ sub create_StructuralVariationFeatures {
       DEL  => 'deletion',
       TDUP => 'tandem_duplication',
       DUP  => 'duplication',
-      CNV  =>'copy_number_variation'
+      CNV  => 'copy_number_variation'
     );
 
     $so_term = defined $terms{$type} ? $terms{$type} : $type;

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -440,7 +440,9 @@ sub create_StructuralVariationFeatures {
   # get type
   my $type;
 
-  if($alt =~ /\<|\[|\]|\>/) {
+  ## avoid deriving type from alt for CNVs more precisely described by SVTYPE
+  ## ALT: "<CN0>", "<CN0>,<CN2>,<CN3>" "<CN2>" => SVTYPE: DEL, CNV, DUP
+  if($alt =~ /\<|\[|\]|\>/ && $alt !~ /CN/) {
     $type = $alt;
     $type =~ s/\<|\>//g;
     $type =~ s/\:.+//g;
@@ -450,7 +452,6 @@ sub create_StructuralVariationFeatures {
       $self->warning_msg("WARNING: VCF line on line ".$self->line_number." looks incomplete, skipping:\n$line\n");
       return [];
     }
-
   }
   else {
     $type = $info->{SVTYPE};
@@ -464,7 +465,8 @@ sub create_StructuralVariationFeatures {
       INS  => 'insertion',
       DEL  => 'deletion',
       TDUP => 'tandem_duplication',
-      DUP  => 'duplication'
+      DUP  => 'duplication',
+      CNV  =>'copy_number_variation'
     );
 
     $so_term = defined $terms{$type} ? $terms{$type} : $type;

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -543,6 +543,54 @@ ok($tmp =~ /variant CPX is of a non-supported type/, 'StructuralVariationFeature
 open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 
 
+
+my $cnv_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(1 774569 gnomAD_v2_DEL_1_1 N <CN0> 1 PASS END=828435;SVTYPE=DUP;CHR2=1;SVLEN=53959)]),
+  valid_chromosomes => [1]
+})->next();
+delete($cnv_vf->{adaptor}); delete($cnv_vf->{_line});
+
+is_deeply($cnv_vf, bless( {
+                 'outer_end' => '828435',
+                 'chr' => '1',
+                 'inner_end' => '828435',
+                 'outer_start' => '774570',
+                 'end' => 828435,
+                 'seq_region_start' => 774570,
+                 'inner_start' => '774570',
+                 'strand' => 1,
+                 'seq_region_end' => 828435,
+                 'class_SO_term' => 'duplication',
+                 'variation_name' => 'gnomAD_v2_DEL_1_1',
+                 'start' => 774570
+               },
+                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - CNV with only duplication allele');
+
+my $cnv_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(1 774569 gnomAD_v2_DEL_1_1 N <CN0>,<CN2> 1 PASS END=828435;SVTYPE=CNV;CHR2=1;SVLEN=53959)]),
+  valid_chromosomes => [1]
+})->next();
+delete($cnv_vf->{adaptor}); delete($cnv_vf->{_line});
+
+is_deeply($cnv_vf, bless( {
+                 'outer_end' => '828435',
+                 'chr' => '1',
+                 'inner_end' => '828435',
+                 'outer_start' => '774570',
+                 'end' => 828435,
+                 'seq_region_start' => 774570,
+                 'inner_start' => '774570',
+                 'strand' => 1,
+                 'seq_region_end' => 828435,
+                 'class_SO_term' => 'copy_number_variation',
+                 'variation_name' => 'gnomAD_v2_DEL_1_1',
+                 'start' => 774570
+               },
+                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - CNV with multiple alleles');
+
+
 ## OTHER TESTS
 ##############
 


### PR DESCRIPTION
Previously the SO type was derived from the ALT allele - this doesn't work for CNVs with alleles "CN0", "CN0,CN2,CN3" and "CN2" - now use SVTYPE: DEL, CNV, DUP respectively first for CNVs