### PR TITLE
Use a default distance to check if the variant is still in the same r…

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -53,7 +53,7 @@ use warnings;
 use base qw(Exporter);
 
 our $VEP_VERSION     = 97;
-our $VEP_SUB_VERSION = 0;
+our $VEP_SUB_VERSION = 1;
 
 our @EXPORT_OK = qw(
   @FLAG_FIELDS
@@ -313,5 +313,6 @@ our %COLOUR_KEYS = (
 );
 
 our $MAX_NOT_ORDERED_VARIANTS = 100;
+our $MAX_NOT_ORDERED_VARIANTS_DISTANCE = 100;
 
 1;

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -123,8 +123,10 @@ sub new {
     # Could also implement a way to change it from the Runner object by fetching 
     # a "$self->param('max_not_ordered_variants')" - for future developments
     $self->{max_not_ordered_variants} = $hashref->{max_not_ordered_variants} if $hashref->{max_not_ordered_variants};
+    $self->{max_not_ordered_variants_distance} = $hashref->{max_not_ordered_variants_distance} if $hashref->{max_not_ordered_variants_distance};
   }
   $self->{max_not_ordered_variants} = $Bio::EnsEMBL::VEP::Constants::MAX_NOT_ORDERED_VARIANTS if (!$self->{max_not_ordered_variants});
+  $self->{max_not_ordered_variants_distance} = $Bio::EnsEMBL::VEP::Constants::MAX_NOT_ORDERED_VARIANTS_DISTANCE if (!$self->{max_not_ordered_variants_distance});
 
   return $self;
 }
@@ -232,8 +234,15 @@ sub next {
       else {
         push @$buffer, $vf;
         $prev_chr = $vf->{chr};
-        if ($prev_start > $vf->{start} && !$self->param('no_check_variants_order')) {
-          $self->{count_not_ordered_variants} ++;
+        if (!$self->param('no_check_variants_order')) {
+          # Use a default distance to check if the variant is still in the same region
+          # even if it's not ordered with the previous variant location: we use the VF start and not the VCF start
+          # (they can be different when the variant is a deletion for instance and/or when the alleles can be minimised)
+          my $prev_start_with_range = $prev_start - $self->{max_not_ordered_variants_distance};
+             $prev_start_with_range = 1 if ($prev_start_with_range < 0);
+          if ($prev_start_with_range > $vf->{start}) {
+            $self->{count_not_ordered_variants} ++;
+          }
         }
         $prev_start = $vf->{start};
       }

--- a/t/Haplo_Runner.t
+++ b/t/Haplo_Runner.t
@@ -136,6 +136,7 @@ SKIP: {
     'buffer_size' => $runner->param('buffer_size'),
     'minimal' => undef,
     'max_not_ordered_variants' => 100,
+    'max_not_ordered_variants_distance' => 100,
     'transcript_tree' => $runner->get_TranscriptTree,
   }, 'Bio::EnsEMBL::Haplo::VEP::InputBuffer' ), 'get_InputBuffer');
 

--- a/t/InputBuffer.t
+++ b/t/InputBuffer.t
@@ -355,7 +355,8 @@ is_deeply($ib, bless( {
   'pre_buffer' => [],
   'temp' => {},
   'minimal' => undef,
-  'max_not_ordered_variants' => 100
+  'max_not_ordered_variants' => 100,
+  'max_not_ordered_variants_distance' => 100
 }, 'Bio::EnsEMBL::VEP::InputBuffer' ), 'finished buffer empty after reset_buffer');
 
 
@@ -479,20 +480,20 @@ is_deeply(
 
 # Check non ordered variants
 my $max_non_ordered_variants = 5;
+my $max_not_ordered_variants_distance = 5;
 $cfg = Bio::EnsEMBL::VEP::Config->new({%{$test_cfg->base_testing_cfg}, buffer_size => 100});
 $p = Bio::EnsEMBL::VEP::Parser::VCF->new({config => $cfg, file => $test_cfg->{not_ord_vcf}, valid_chromosomes => [1,21,22]});
-$ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg, parser => $p, max_not_ordered_variants => $max_non_ordered_variants});
+$ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg, parser => $p, max_not_ordered_variants => $max_non_ordered_variants, max_not_ordered_variants_distance => $max_not_ordered_variants_distance});
 
 $ib->next();
 $ib->next();
 dies_ok {$ib->next()} "die - Exiting the program as the maximun number of unsorted variants as been reached ($max_non_ordered_variants).";
 
 
-
 # Skip check for non ordered variants
 $cfg = Bio::EnsEMBL::VEP::Config->new({%{$test_cfg->base_testing_cfg}, buffer_size => 100, no_check_variants_order => 1});
 $p = Bio::EnsEMBL::VEP::Parser::VCF->new({config => $cfg, file => $test_cfg->{not_ord_vcf}, valid_chromosomes => [1,21,22]});
-$ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg, parser => $p});
+$ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg, parser => $p, max_not_ordered_variants => $max_non_ordered_variants, max_not_ordered_variants_distance => $max_not_ordered_variants_distance});
 
 $ib->next();
 $ib->next();
@@ -500,6 +501,20 @@ eval {
   $ib->next();
 };
 ok(!$@, "Skip the count for non ordered variants with the flag 'no_check_variants_order'");
+
+
+# Check for non ordered variants with larger position difference (default settings)
+$max_not_ordered_variants_distance = 100;
+$cfg = Bio::EnsEMBL::VEP::Config->new({%{$test_cfg->base_testing_cfg}, buffer_size => 100});
+$p = Bio::EnsEMBL::VEP::Parser::VCF->new({config => $cfg, file => $test_cfg->{not_ord_vcf}, valid_chromosomes => [1,21,22]});
+$ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg, parser => $p, max_not_ordered_variants => $max_non_ordered_variants, max_not_ordered_variants_distance => $max_not_ordered_variants_distance});
+
+$ib->next();
+$ib->next();
+eval {
+  $ib->next();
+};
+ok(!$@, "Pass non ordered variants with location differences larger ($max_not_ordered_variants_distance"."nt)");
 
 # done
 done_testing();

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -128,7 +128,8 @@ is_deeply($runner->get_InputBuffer, bless({
   }, 'Bio::EnsEMBL::VEP::Parser::VEP_input' ),
   'buffer_size' => $runner->param('buffer_size'),
   'minimal' => undef,
-  'max_not_ordered_variants' => 100
+  'max_not_ordered_variants' => 100,
+  'max_not_ordered_variants_distance' => 100
 }, 'Bio::EnsEMBL::VEP::InputBuffer' ), 'get_InputBuffer');
 
 my $info = $runner->get_output_header_info;


### PR DESCRIPTION
…egion even if it's not ordered with the previous variant location: we use the VF start and not the VCF start (they can be different when the variant is a deletion for instance and/or when the alleles can be minimised)