### PR TITLE
Set breakend end position to be the start position

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -412,6 +412,7 @@ sub create_StructuralVariationFeatures {
     $self->warning_msg("WARNING: variant " . $info->{SVTYPE}. " is of a non-supported type, skipping:\n$line\n");
     $skip = 1;
   }
+
   ## check against size upperlimit to avoid memory problems
   my $len = $end - $start;
   if( $len > $self->{max_sv_size} ){
@@ -428,6 +429,13 @@ sub create_StructuralVariationFeatures {
   elsif(defined($info->{SVLEN})) {
     $end = $start + abs($info->{SVLEN}) - 1;
   }
+
+  if($info->{SVTYPE} && $info->{SVTYPE} =~/BND/ ){
+    ## break ends are not currently annotated as fusions between different regions/chromosomes
+    ## each end is annotated separately
+    $end = $start;
+  }
+
 
   # check for imprecise breakpoints
   my ($min_start, $max_start, $min_end, $max_end) = (

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -591,6 +591,24 @@ is_deeply($cnv_vf, bless( {
                 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - CNV with multiple alleles');
 
 
+## Currently regard fusions across different chromosomes as single breakpoint
+my $bnd_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A	.	PASS	SVTYPE=BND;CHR2=1;END=37938377   )]),
+  valid_chromosomes => [1,2]
+})->next();
+ok($bnd_vf->end() == 68914093, 'StructuralVariationFeature - cross-chromosome BND');
+
+my $bnd2_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(2    68914092        BND00001121     A       ]2:68920000]A	.	PASS   SVTYPE=BND;CHR2=2;END=68920000   )]),
+  valid_chromosomes => [1,2]
+})->next();
+ok($bnd2_vf->end() == 68920000, 'StructuralVariationFeature - within-chromosome BND');
+
+
+
+
 ## OTHER TESTS
 ##############
 


### PR DESCRIPTION
We don't currently handle break ends as fusions. The second break point is treated as if it is the end of a contiguous feature, which is very missleading when different chromosomes are involved. 

This does not provide full BND support, but does set the SV end to be the same as start when different chromosomes are involved, so only the features at the 'ref' break are reported.  

As discussed in: https://github.com/Ensembl/VEP_plugins/pull/232

Also sets class to BND.