### PR TITLE
Keep zero values in VCF - 97

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -53,7 +53,7 @@ use warnings;
 use base qw(Exporter);
 
 our $VEP_VERSION     = 97;
-our $VEP_SUB_VERSION = 3;
+our $VEP_SUB_VERSION = 4;
 
 our @EXPORT_OK = qw(
   @FLAG_FIELDS

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -369,6 +369,11 @@ sub output_hash_to_vcf_info_chunk {
 
       push @chunk, $data;
     }
+    # keep 0 values
+    elsif (defined $hash->{$col}
+           && ($hash->{$col} == 0)) {
+      push @chunk, $hash->{$col};
+    }
     else {
       push @chunk, '';
     }

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -244,6 +244,22 @@ is(
   'output_hash_to_vcf_info_chunk - whitespace converted'
 );
 
+$of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({fields => 'Allele,SIFT'})
+});
+
+is(
+  $of->output_hash_to_vcf_info_chunk({Allele => 'A', SIFT => '0'}),
+  'A|0',
+  "output_hash_to_vcf_info_chunk - '0' kept"
+);
+
+is(
+  $of->output_hash_to_vcf_info_chunk({Allele => 'A', SIFT => 0}),
+  'A|0',
+  "output_hash_to_vcf_info_chunk - 0 kept"
+);
+
 
 ## get_all_lines_by_InputBuffer
 ###############################


### PR DESCRIPTION
This is the same as #604 on branch release/97. 

Fix for when --sift s option is used, 0 SIFT values are not in VCF output.