### PR TITLE
Allow installer to convert cache if requested

### DIFF
--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -1296,7 +1296,7 @@ sub cache() {
       closedir CACHEDIR;
     }
     
-    if(($CONVERT) && !$TEST) {
+    if(((-e $bgzip && -e $tabix) || $CONVERT) && !$TEST) {
       unless($QUIET) {
         print " - converting cache, this may take some time but will allow VEP to look up variants and frequency data much faster\n";
         print " - use CTRL-C to cancel if you do not wish to convert this cache now (you may run convert_cache.pl later)\n";

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -1295,6 +1295,14 @@ sub cache() {
       move("$CACHE_DIR/tmp/$species/$_", "$CACHE_DIR/$species/$_") for readdir CACHEDIR;
       closedir CACHEDIR;
     }
+    
+    if(($CONVERT) && !$TEST) {
+      unless($QUIET) {
+        print " - converting cache, this may take some time but will allow VEP to look up variants and frequency data much faster\n";
+        print " - use CTRL-C to cancel if you do not wish to convert this cache now (you may run convert_cache.pl later)\n";
+      }
+      system("perl $dirname/convert_cache.pl --dir $CACHE_DIR --species $species --version $DATA_VERSION\_$assembly --bgzip $bgzip --tabix $tabix") == 0 or print STDERR "WARNING: Failed to run convert script\n";
+    }
   }
 }
 


### PR DESCRIPTION
As described in https://github.com/Ensembl/ensembl-vep/issues/610, the CONVERT flag no longer works after changing the installer to download the indexed cache files by default

Incase there are users who want to convert old cache files, I've restored this functionality for when the --CONVERT flag is used.