### PR TITLE
Remove all adaptors from core dump

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Core.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Core.pm
@@ -117,8 +117,7 @@ sub get_dumpable_object {
     ])
   };
 
-  for (my $i = 0; $i < scalar(@{$obj->{$chr}}); $i++)
-  {
+  for (my $i = 0; $i < scalar(@{$obj->{$chr}}); $i++) {
     if(my $tr = $obj->{$chr}->[$i]) {
       delete $tr->{slice}->{adaptor};
       delete $tr->{slice}->{coord_system}->{adaptor};

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Core.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Core.pm
@@ -117,14 +117,17 @@ sub get_dumpable_object {
     ])
   };
 
-  if(my $tr = $obj->{$chr}->[0]) {
-    delete $tr->{slice}->{adaptor};
-    delete $tr->{slice}->{coord_system}->{adaptor};
+  for (my $i = 0; $i < scalar(@{$obj->{$chr}}); $i++)
+  {
+    if(my $tr = $obj->{$chr}->[$i]) {
+      delete $tr->{slice}->{adaptor};
+      delete $tr->{slice}->{coord_system}->{adaptor};
 
-    # clean introns, they may have a rev-strand slice attached
-    if(my ($intron) = @{$tr->{_variation_effect_feature_cache}->{introns}}) {
-      delete $intron->{slice}->{adaptor};
-      delete $intron->{slice}->{coord_system}->{adaptor};
+      # clean introns, they may have a rev-strand slice attached
+      if(my ($intron) = @{$tr->{_variation_effect_feature_cache}->{introns}}) {
+        delete $intron->{slice}->{adaptor};
+        delete $intron->{slice}->{coord_system}->{adaptor};
+      }
     }
   }
 


### PR DESCRIPTION
Designed to solve the issue:

_Can't store CODE items at Storable.pm line 303, at ensembl-vep/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper.pm line 167._

Some bacteria dumps (e.g. _chlamydia_trachomatis_gca_000590735_) have database adaptors attached to the transcript slices. Not sure why. This removes them all before dumping.

I've redumped human with this change. Output is the same, doesn't cause a slowdown.