### PR TITLE
Filter vep - allow filtering multiple values

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/FilterSet.pm
+++ b/modules/Bio/EnsEMBL/VEP/FilterSet.pm
@@ -482,7 +482,9 @@ sub evaluate {
       $return = 0;
     }
     else {
-      if($input =~ /,/) {
+
+      # Filter multiple values
+      if(defined($input) && $input =~ /[0-9],/) {
         my $f = 0;
         my @input_splited = split /,/, $input;
         foreach my $value_i (@input_splited) {

--- a/modules/Bio/EnsEMBL/VEP/FilterSet.pm
+++ b/modules/Bio/EnsEMBL/VEP/FilterSet.pm
@@ -485,23 +485,16 @@ sub evaluate {
 
       # Filter multiple values
       if(defined($input) && $input =~ /[0-9](\,|\&)/) {
-        my $delimiter;
-        if($input =~ /\,/) {
-          $delimiter = ',';
-        }
-        else {
-          $delimiter = '&';
-        }
-
-        my $f = 0;
-        my @input_splited = split /$delimiter/, $input;
-        foreach my $value_i (@input_splited) {
+        my $delimiter = $1;
+        my $found = 0;
+        my @split_input = split /$delimiter/, $input;
+        foreach my $value_i (@split_input) {
           my $predicted = &$predicate($value_i, $value, $self);
           if($predicted) {
-            $f = 1;
+            $found = 1;
           }
         }
-        $result = $f;
+        $result = $found;
       }
       else {
         $result = &$predicate($input, $value, $self);

--- a/modules/Bio/EnsEMBL/VEP/FilterSet.pm
+++ b/modules/Bio/EnsEMBL/VEP/FilterSet.pm
@@ -461,6 +461,8 @@ sub evaluate {
   }
 
   else {
+    my $result;
+
     my $predicate_name = 'filter_'.$filter->{operator};
     my $predicate = \&$predicate_name;
 
@@ -480,7 +482,22 @@ sub evaluate {
       $return = 0;
     }
     else {
-      $return = &$predicate($input, $value, $self);
+      if($input =~ /,/) {
+        my $f = 0;
+        my @input_splited = split /,/, $input;
+        foreach my $value_i (@input_splited) {
+          my $predicted = &$predicate($value_i, $value, $self);
+          if($predicted) {
+            $f = 1;
+          }
+        }
+        $result = $f;
+      }
+      else {
+        $result = &$predicate($input, $value, $self);
+      }
+
+      $return = $result;
     }
   }
 

--- a/modules/Bio/EnsEMBL/VEP/FilterSet.pm
+++ b/modules/Bio/EnsEMBL/VEP/FilterSet.pm
@@ -484,9 +484,17 @@ sub evaluate {
     else {
 
       # Filter multiple values
-      if(defined($input) && $input =~ /[0-9],/) {
+      if(defined($input) && $input =~ /[0-9](\,|\&)/) {
+        my $delimiter;
+        if($input =~ /\,/) {
+          $delimiter = ',';
+        }
+        else {
+          $delimiter = '&';
+        }
+
         my $f = 0;
-        my @input_splited = split /,/, $input;
+        my @input_splited = split /$delimiter/, $input;
         foreach my $value_i (@input_splited) {
           my $predicted = &$predicate($value_i, $value, $self);
           if($predicted) {

--- a/t/FilterSet.t
+++ b/t/FilterSet.t
@@ -353,7 +353,8 @@ is($fs->evaluate({foo => 0.1}),   0, 'evaluate - gt - fail decimal');
 is($fs->evaluate({foo => 5.1}),   1, 'evaluate - gt - pass decimal');
 is($fs->evaluate({bar => 1}),     0, 'evaluate - gt - fail missing');
 is($fs->evaluate({foo => undef}), 0, 'evaluate - gt - fail undef');
-is($fs->evaluate({foo => 10&15}), 1, 'evaluate - gt - pass multiple values');
+is($fs->evaluate({foo => '10&15'}), 1, 'evaluate - gt - pass multiple values');
+is($fs->evaluate({foo => '1&4'}), 0, 'evaluate - gt - fail multiple values');
 
 # evaluate - gte
 $fs = Bio::EnsEMBL::VEP::FilterSet->new('foo gte 5');

--- a/t/FilterSet.t
+++ b/t/FilterSet.t
@@ -353,6 +353,7 @@ is($fs->evaluate({foo => 0.1}),   0, 'evaluate - gt - fail decimal');
 is($fs->evaluate({foo => 5.1}),   1, 'evaluate - gt - pass decimal');
 is($fs->evaluate({bar => 1}),     0, 'evaluate - gt - fail missing');
 is($fs->evaluate({foo => undef}), 0, 'evaluate - gt - fail undef');
+is($fs->evaluate({foo => 10&15}), 1, 'evaluate - gt - pass multiple values');
 
 # evaluate - gte
 $fs = Bio::EnsEMBL::VEP::FilterSet->new('foo gte 5');


### PR DESCRIPTION
Currently, filter_vep doesn't filter values '0.7&0.5' or '0.7,0.5'. 
This fix splits the values and checks them individually.  