### PR TITLE
Prevent looking up of NM/XMs in core db

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
@@ -168,6 +168,7 @@ sub create_VariationFeatures {
   my @errors;
 
   foreach my $core_group(@core_groups) {
+    next if (($hgvs =~ /NM_/ || $hgvs =~ /XM_/) && $core_group eq 'core');
     my $sa  = $self->get_adaptor($core_group, 'Slice');
     my $ta  = $self->get_adaptor($core_group, 'Transcript');
 


### PR DESCRIPTION
Giving the input `NM_001258273.1:c.1A>T,` to variant recoder was returning odd results, including `NM_001258273.1:c.-632A>T`

Variant recoder was generating a $vf object using a transcript generated by calling $ta->fetch_all_by_external_name on the core db, which was not an exact match. The change skips the core database and looks directly in otherfeatures for transcripts that look like RefSeq transcripts.