### PR TITLE
Bug99/transform to toplevel

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -53,7 +53,7 @@ use warnings;
 use base qw(Exporter);
 
 our $VEP_VERSION     = 99;
-our $VEP_SUB_VERSION = 1;
+our $VEP_SUB_VERSION = 2;
 
 our @EXPORT_OK = qw(
   @FLAG_FIELDS

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -545,8 +545,15 @@ sub validate_vf {
       $vf->{slice} ||= $self->get_slice($vf->{chr});
 
       if($vf->{slice}) {
-        my $transformed = $vf->transform('toplevel');
-
+        my $transformed;
+        eval {
+          $transformed = $vf->transform('toplevel');
+        };
+        if($@) {
+          my $msg = "Failed to transform vf chr=$vf->{chr}, start=$vf->{start}, end=$vf->{end} to toplevel: $@\n";
+          $self->warning_msg($msg);
+          return 0;
+        }
         # copy to VF
         if($transformed) {
           $vf->{$_} = $transformed->{$_} for keys %$transformed;

--- a/t/Parser.t
+++ b/t/Parser.t
@@ -352,7 +352,7 @@ SKIP: {
 
   $p = Bio::EnsEMBL::VEP::Parser->new({config => $cfg, file => $test_cfg->{test_vcf}});
 
-  # Since core has intrduced updates to the mapper code we cannot transform insertions from e.g.
+  # Since core has introduced updates to the mapper code we cannot transform insertions from e.g.
   # contig to toplevel
   my $vf =  get_vf({allele_string => '-/C', chr => 'AP000235.3', start => 100, end => 99}); 
   # after a fix this should run successfully again:


### PR DESCRIPTION
We have a bug report from VEP tools where VEP fails when it tries to annotate `GL000241.1  15996 . G GA  78.32` The reason is that VEP tries to transform the VF to the toplevel sequence and fails because the updated mapper code in the core API cannot transform insertions anymore. I will send a bug report to the core team. In the mean time we can only prevent VEP from dying and only return a warning if it comes across insertion that to need to be transformed to toplevel.

This PR should hopefully go live next week.

Depending on what core says I will need to create a similar PR against postreleasefix/100