### PR TITLE
Remove old 37 transcripts from VEP (and cache files)

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
@@ -249,8 +249,8 @@ sub get_features_by_regions_uncached {
         # in human and mouse otherfeatures DB, there may be duplicate genes
         # skip those from analysis refseq_human_import and refseq_mouse_import
         next if $self->{core_type} eq 'otherfeatures' && $self->assembly !~ /GRCh37/i && $tr->analysis && $tr->analysis->logic_name =~ /^refseq_[a-z]+_import$/;
-
-        if($self->{core_type} eq 'otherfeatures' && defined($tr->display_xref)){
+	next if $self->{core_type} eq 'otherfeatures' && $self->assembly =~ /GRCh37/i && $tr->analysis && $tr->analysis->logic_name =~ /^refseq.+import$/;
+	if($self->{core_type} eq 'otherfeatures' && defined($tr->display_xref)){
 	         $tr->{stable_id} = $tr->display_xref->{display_id};
         }
         

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
@@ -249,6 +249,11 @@ sub get_features_by_regions_uncached {
         # in human and mouse otherfeatures DB, there may be duplicate genes
         # skip those from analysis refseq_human_import and refseq_mouse_import
         next if $self->{core_type} eq 'otherfeatures' && $self->assembly !~ /GRCh37/i && $tr->analysis && $tr->analysis->logic_name =~ /^refseq_[a-z]+_import$/;
+
+	## Due to the inclusion of the new RefSeq transcript set (mapped from 38) into the 37 otherfeatures database,
+	## older, lower quality transcripts have been removed from the cache files. To do this, we filter out all transcripts
+	## with the analysis logic_name 'refseq_import' or 'refseq_human_import'. 
+	## All new transcripts have the logic name 'refseq_import_grch38'
 	next if $self->{core_type} eq 'otherfeatures' && $self->assembly =~ /GRCh37/i && $tr->analysis && $tr->analysis->logic_name =~ /^refseq.+import$/;
 	if($self->{core_type} eq 'otherfeatures' && defined($tr->display_xref)){
 	         $tr->{stable_id} = $tr->display_xref->{display_id};

--- a/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
@@ -168,7 +168,6 @@ sub create_VariationFeatures {
   my @errors;
 
   foreach my $core_group(@core_groups) {
-    next if (($hgvs =~ /NM_/ || $hgvs =~ /XM_/) && $core_group eq 'core');
     my $sa  = $self->get_adaptor($core_group, 'Slice');
     my $ta  = $self->get_adaptor($core_group, 'Transcript');
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
@@ -168,6 +168,7 @@ sub create_VariationFeatures {
   my @errors;
 
   foreach my $core_group(@core_groups) {
+    next if (($hgvs =~ /NM_/ || $hgvs =~ /XM_/) && $core_group eq 'core');
     my $sa  = $self->get_adaptor($core_group, 'Slice');
     my $ta  = $self->get_adaptor($core_group, 'Transcript');
 


### PR DESCRIPTION
No test has been added as we don't have a 37 test database.

This should remove both refseq_import and refseq_human_import transcripts.