### PR TITLE
Remove tmp files from VEP tests

### DIFF
--- a/t/BaseVEP.t
+++ b/t/BaseVEP.t
@@ -317,8 +317,10 @@ SKIP: {
   1;
 };
 
+# Remove created index file
+my $fasta_index = $test_cfg->{fasta_dir} . '/Homo_sapiens.GRCh38.toplevel.test.fa.fai';
+unlink $fasta_index if (-e $fasta_index);
 
 ## DONE
 #######
 done_testing();
-

--- a/t/VEPTestingConfig.pm
+++ b/t/VEPTestingConfig.pm
@@ -252,4 +252,9 @@ sub DESTROY {
   if (-e $self->{cache_dir}.'/transcript_coords.txt') {
     unlink($self->{cache_dir} . '/transcript_coords.txt');
   }
+
+  # Remove warnings file
+  if (-e $Bin . '/variant_effect_output.txt_warnings.txt') {
+    unlink($Bin . '/variant_effect_output.txt_warnings.txt');
+  }
 }

--- a/t/VEPTestingConfig.pm
+++ b/t/VEPTestingConfig.pm
@@ -45,7 +45,7 @@ our %DEFAULTS = (
   sereal_dir     => $Bin.'/testdata/cache/sereal/homo_sapiens/84_GRCh38',
   exac_root_dir  => $Bin.'/testdata/cache/exac/',
 
-  fasta          => $Bin.'/testdata/cache/homo_sapiens/84_GRCh38/test.fa',
+  fasta          => $Bin.'/testdata/cache/homo_sapiens/84_GRCh38/test.fa.gz',
   fasta_dir      => $Bin.'/testdata/fasta',
 
   test_ini_file  => $Bin.'/testdata/vep.ini',
@@ -228,5 +228,28 @@ sub DESTROY {
 
   for my $file_key(qw(user_file user_registry_file)) {
     unlink($self->{$file_key}) if $self->{$file_key};
+  }
+
+  # Remove fasta index files
+  for my $index (qw(fai gzi)) {
+    my $index_file = join('.', $self->{'fasta'}, $index);
+    if (-e $index_file) {
+      unlink($index_file);
+    }
+  }
+
+  # Remove unpacked fasta file and index
+  my $unpacked_fasta = $self->{cache_dir} . '/test.fa';
+  if (-e $unpacked_fasta) {
+    unlink $unpacked_fasta;
+  }
+  my $unpacked_fasta_index = $unpacked_fasta . '.fai';
+  if (-e $unpacked_fasta_index) {
+    unlink $unpacked_fasta_index;
+  }
+  
+  # Remove transcript coords file
+  if (-e $self->{cache_dir}.'/transcript_coords.txt') {
+    unlink($self->{cache_dir} . '/transcript_coords.txt');
   }
 }


### PR DESCRIPTION
Removes files created during the run of VEP tests
See ENSVAR-2137

The FASTA file changed from test.fa to test.fa.gz as that is file in repository.
It is unpacked to test.fa as part of running the tests.