### PR TITLE
Turn on shift_3prime when shift_genomic is switched on 

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -766,6 +766,13 @@ sub post_setup_checks {
     $self->status_msg("INFO: --shift_hgvs has been set to zero, setting shift_3prime to 0\n");
     $self->param('shift_3prime', 0);
   }
+  
+  if(defined($self->param('shift_genomic')) && $self->param('shift_genomic') eq 1 ) {
+    if(defined($self->param('shift_3prime')) && $self->param('shift_3prime') eq 0 ) {
+      $self->status_msg("INFO: --shift_genomic has been set to 1, setting shift_3prime to 1\n");
+    }
+    $self->param('shift_3prime', 1);
+  }
 
   return 1;
 }

--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -762,13 +762,13 @@ sub post_setup_checks {
     $self->param('stats_html', 1);
   }
   
-  if(defined($self->param('shift_hgvs')) && $self->param('shift_hgvs') eq 0) {
+  if(defined($self->param('shift_hgvs')) && $self->param('shift_hgvs') == 0) {
     $self->status_msg("INFO: --shift_hgvs has been set to zero, setting shift_3prime to 0\n");
     $self->param('shift_3prime', 0);
   }
   
-  if(defined($self->param('shift_genomic')) && $self->param('shift_genomic') eq 1 ) {
-    if(defined($self->param('shift_3prime')) && $self->param('shift_3prime') eq 0 ) {
+  if(defined($self->param('shift_genomic')) && $self->param('shift_genomic')) {
+    if(defined($self->param('shift_3prime')) && $self->param('shift_3prime') == 0 ) {
       $self->status_msg("INFO: --shift_genomic has been set to 1, setting shift_3prime to 1\n");
     }
     $self->param('shift_3prime', 1);

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -307,6 +307,10 @@ throws_ok {$runner->get_output_file_handle} qr/Output file .+ already exists/, '
 $runner = Bio::EnsEMBL::VEP::Runner->new({%$cfg_hash, output_file => 'stdout'});
 is($runner->get_output_file_handle, '*main::STDOUT', 'get_output_file_handle - stdout');
 
+$runner = Bio::EnsEMBL::VEP::Runner->new({%$cfg_hash, shift_genomic => 1});
+$runner->post_setup_checks;
+is($runner->param('shift_3prime'), 1, 'shift_genomic switches on shift_3prime');
+
 unlink($test_cfg->{user_file}.'.out');
 
 $runner = Bio::EnsEMBL::VEP::Runner->new({


### PR DESCRIPTION
Currently it requires both flags, which is unnecessary.

I'll submit a PR to postreleasefix/101 when this is approved