### PR TITLE
Reset shifted positions correctly for VCF and JSON output

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -53,7 +53,7 @@ use warnings;
 use base qw(Exporter);
 
 our $VEP_VERSION     = 100;
-our $VEP_SUB_VERSION = 0;
+our $VEP_SUB_VERSION = 1;
 
 our @EXPORT_OK = qw(
   @FLAG_FIELDS

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -202,6 +202,9 @@ sub get_all_output_hashes_by_InputBuffer {
   my $self = shift;
   my $buffer = shift;
 
+  map {@{$self->reset_shifted_positions($_)}}
+    @{$buffer->buffer};
+
   $self->rejoin_variants_in_InputBuffer($buffer) if $buffer->rejoin_required;
 
   my @return;

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -271,6 +271,9 @@ sub get_all_lines_by_InputBuffer {
 
   my @return;
 
+  map {@{$self->reset_shifted_positions($_)}}
+    @{$buffer->buffer};
+
   foreach my $vf(@{$buffer->buffer}) {
 
     my $line;

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -408,7 +408,7 @@ SKIP: {
     {map {$_->{variant_allele} => $_} @{$json->decode($of->get_all_lines_by_InputBuffer($ib)->[0])->{transcript_consequences}}},
     {
       '-' => {
-        'cds_start' => 68,
+        'cds_start' => 67,
         'gene_id' => 'ENSG00000154727',
         'variant_allele' => '-',
         'cdna_end' => 603,
@@ -422,7 +422,7 @@ SKIP: {
         'protein_end' => 26,
         'strand' => 1,
         'amino_acids' => 'KKKG/S',
-        'cdna_start' => 595,
+        'cdna_start' => 594,
         'transcript_id' => 'ENST00000354828',
         'impact' => 'MODERATE',
         'allele_num' => 2,
@@ -431,14 +431,14 @@ SKIP: {
         'cds_start' => 67,
         'gene_id' => 'ENSG00000154727',
         'variant_allele' => 'T',
-        'cdna_end' => 594,
+        'cdna_end' => 603,
         'protein_start' => 23,
         'codons' => 'Cca/Tca',
-        'cds_end' => 67,
+        'cds_end' => 76,
         'consequence_terms' => [
           'missense_variant'
         ],
-        'protein_end' => 23,
+        'protein_end' => 26,
         'strand' => 1,
         'amino_acids' => 'P/S',
         'cdna_start' => 594,


### PR DESCRIPTION
Reset_shifted_positions method was only called in the primary OutputFactory.pm - needs to be called within JSON & VCF output factories too