### PR TITLE
Trim whitespace from input coordinates

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -333,6 +333,9 @@ sub create_VariationFeatures {
     }
   }
 
+  $start =~ s/^\s+|\s+$//g;
+  $end =~ s/^\s+|\s+$//g;
+
   # create VF object
   my $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
     start          => $start,

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -872,6 +872,19 @@ $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
 
 is($vf->{start}, 'foo', 'dont skip VF that fails validation with dont_skip');
 
+
+my $str = '25587759 ';
+$vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => $cfg,
+  file => $test_cfg->create_input_file([
+    [21, $str, '.', 'C', 'A' ,'.', '.', '.'],
+  ]),
+  valid_chromosomes => [21]
+})->next();
+is($vf->{start}, 25587759, 'Trim whitespace from input coordinates');
+
+
+
 # restore STDERR
 open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 


### PR DESCRIPTION
As reported in #759, the VCF parser is not matching colocated variants when there is unexpected whitespace found in the coordinate field. Trimming whitespace from here should fix the issue