### PR TITLE
Check so_term if so_name is empty

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Regulation.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Regulation.pm
@@ -152,7 +152,12 @@ sub clean_regfeat {
     }
   }
 
-  $rf->{feature_type} = $rf->{feature_type}->{so_name} if $rf->{feature_type};
+  if ($rf->{feature_type}){
+    my $name_to_use = $rf->{feature_type}->{so_name};
+    $name_to_use  ||= $rf->{feature_type}->{so_term};
+
+    $rf->{feature_type} = $name_to_use;
+  }
 
   return $rf;
 }

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Regulation.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Regulation.pm
@@ -152,12 +152,7 @@ sub clean_regfeat {
     }
   }
 
-  if ($rf->{feature_type}){
-    my $name_to_use = $rf->{feature_type}->{so_name};
-    $name_to_use  ||= $rf->{feature_type}->{so_term};
-
-    $rf->{feature_type} = $name_to_use;
-  }
+  $rf->{feature_type} = $rf->feature_so_term if $rf->{feature_type}; 
 
   return $rf;
 }


### PR DESCRIPTION
The feature_type value for regulatory features was missing - caused by changes in the funcgen api for 100. 