### PR TITLE
Bugfix101/vcf minimal rejoin

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -274,6 +274,8 @@ sub get_all_lines_by_InputBuffer {
   map {@{$self->reset_shifted_positions($_)}}
     @{$buffer->buffer};
 
+  $self->rejoin_variants_in_InputBuffer($buffer) if $buffer->rejoin_required;
+
   foreach my $vf(@{$buffer->buffer}) {
 
     my $line;

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -564,8 +564,21 @@ ok(
   "SV overlap percent and length available"
 );
 
+## rejoin on minimal
 
+$ib = get_runner({
+  input_file => $test_cfg->create_input_file([qw(21 25741665 . CAGAAGAAAG TAGAAGAAAG,C . . .)]),
+  minimal => 1,
+})->get_InputBuffer;
+$of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 
+is(scalar @{$ib->buffer}, 2, 'minimal - expanded count');
+is($ib->buffer->[0]->allele_string, 'C/T', 'minimal - expanded first allele string');
+
+$of->rejoin_variants_in_InputBuffer($ib);
+
+is(scalar @{$ib->buffer}, 1, 'minimal - rejoined count');
+is($ib->buffer->[0]->allele_string, 'CAGAAGAAAG/TAGAAGAAAG/C', 'minimal - rejoined allele string');
 
 ## test getting stuff from input
 ################################


### PR DESCRIPTION
Rejoin alleles after minimal was applied. This is done in all other output factories but was missing from the VCF output factory. This is a bug reported bu a user on release/100.
I will also create a PR for 102 and master and ideally for 100 too.