### PR TITLE
Bugfix102/minimal intergenic

### DIFF
--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -1801,6 +1801,13 @@ $of->rejoin_variants_in_InputBuffer($ib);
 
 is(scalar @{$ib->buffer}, 2, 'minimal - intergenic - rejoined count');
 
+foreach my $vf (@{$ib->buffer}) {
+  my $vfoas = $of->get_all_VariationFeatureOverlapAlleles($vf);
+  foreach my $vfoa (@{$vfoas}) {
+    is(ref($vfoa->base_variation_feature_overlap), 'Bio::EnsEMBL::Variation::IntergenicVariation', 'base_variation_feature_overlap is set after rejoin');
+  }
+}
+
 is_deeply(
   [map {$_->display_consequence} @{$ib->buffer}],
   ['intergenic_variant', 'intergenic_variant'],


### PR DESCRIPTION
Rejoining intergenic variant alleles after minimising them caused an error for variants with more than one alt allele. The bug is reported in this issue #806
After rejoining the intergenic variant alleles the base_variation_feature_overlap object was missing for the allele that was merged into the original. Adding the base_variation_feature_overlap from the original is fixing the problem.