### PR TITLE
include mouse strains

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DumpVEP_conf.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DumpVEP_conf.pm
@@ -86,8 +86,7 @@ sub default_options {
  
     # include or exclude the following species from the dumps, run for a division or all the species on the server
     species => [],
-    # Excluding mouse strains
-    antispecies => ['mus_musculus_129s1svimj', 'mus_musculus_aj', 'mus_musculus_akrj', 'mus_musculus_balbcj', 'mus_musculus_c3hhej', 'mus_musculus_c57bl6nj', 'mus_musculus_casteij', 'mus_musculus_cbaj', 'mus_musculus_dba2j', 'mus_musculus_fvbnj', 'mus_musculus_lpj', 'mus_musculus_nodshiltj', 'mus_musculus_nzohlltj', 'mus_musculus_pwkphj', 'mus_musculus_wsbeij'],
+    antispecies => [],
     division    => [],
     run_all     => 0,
 


### PR DESCRIPTION
At the moment strains and breeds are not shown in the list of species on VEP tools. We already dump dog and pig breeds and we want to show the new sheep reference and the previous sheep reference which has a widely used variation database.
In order to make it easier for the web code to show all strains and breeds and not make exceptions for mouse we will also dump the mouse strains from release 102.