### PR TITLE
Fix missing ref_allele when using fields -e102

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1249,7 +1249,8 @@ sub VariationFeatureOverlapAllele_to_output_hash {
   $hash->{ALLELE_NUM} = $vfoa->allele_number if $self->{allele_number};
 
   # reference allele
-  $hash->{REF_ALLELE} = $vf->ref_allele_string if $self->{show_ref_allele};
+  my $in_fields = defined($self->{_config}->{_params}->{fields}) ? grep(/REF_ALLELE/, @{$self->{_config}->{_params}->{fields}}) : 0 ;
+  $hash->{REF_ALLELE} = $vf->ref_allele_string if $self->{show_ref_allele} || $in_fields;
 
   # picked?
   $hash->{PICK} = 1 if defined($vfoa->{PICK});

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1250,7 +1250,6 @@ sub VariationFeatureOverlapAllele_to_output_hash {
 
   # reference allele
   my $in_fields = 0;
-  $DB::single=1;
   if ($self->{output_format} eq 'tab' || $self->{output_format} eq 'vcf'){
     $in_fields = defined($self->{_config}->{_params}->{fields}) ? grep(/REF_ALLELE/, @{$self->{_config}->{_params}->{fields}}) : 0 ;
   }

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1375,7 +1375,8 @@ sub BaseTranscriptVariationAllele_to_output_hash {
   }
 
   # gene symbol
-  if($self->{symbol}) {
+  my $in_fields = defined($self->{_config}->{_params}->{fields}) ? grep(/SYMBOL/, @{$self->{_config}->{_params}->{fields}}) : 0 ;
+  if($self->{symbol} || $in_fields) {
     my $symbol  = $tr->{_gene_symbol} || $tr->{_gene_hgnc};
     my $source  = $tr->{_gene_symbol_source};
     my $hgnc_id = $tr->{_gene_hgnc_id} if defined($tr->{_gene_hgnc_id});

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1249,7 +1249,11 @@ sub VariationFeatureOverlapAllele_to_output_hash {
   $hash->{ALLELE_NUM} = $vfoa->allele_number if $self->{allele_number};
 
   # reference allele
-  my $in_fields = defined($self->{_config}->{_params}->{fields}) ? grep(/REF_ALLELE/, @{$self->{_config}->{_params}->{fields}}) : 0 ;
+  my $in_fields = 0;
+  $DB::single=1;
+  if ($self->{output_format} eq 'tab' || $self->{output_format} eq 'vcf'){
+    $in_fields = defined($self->{_config}->{_params}->{fields}) ? grep(/REF_ALLELE/, @{$self->{_config}->{_params}->{fields}}) : 0 ;
+  }
   $hash->{REF_ALLELE} = $vf->ref_allele_string if $self->{show_ref_allele} || $in_fields;
 
   # picked?
@@ -1375,7 +1379,10 @@ sub BaseTranscriptVariationAllele_to_output_hash {
   }
 
   # gene symbol
-  my $in_fields = defined($self->{_config}->{_params}->{fields}) ? grep(/SYMBOL/, @{$self->{_config}->{_params}->{fields}}) : 0 ;
+  my $in_fields = 0;
+  if ($self->{output_format} eq 'tab' || $self->{output_format} eq 'vcf'){
+    $in_fields = defined($self->{_config}->{_params}->{fields}) ? grep(/SYMBOL/, @{$self->{_config}->{_params}->{fields}}) : 0 ;
+  }
   if($self->{symbol} || $in_fields) {
     my $symbol  = $tr->{_gene_symbol} || $tr->{_gene_hgnc};
     my $source  = $tr->{_gene_symbol_source};

--- a/t/OutputFactory_Tab.t
+++ b/t/OutputFactory_Tab.t
@@ -272,11 +272,12 @@ is(
   'get_all_lines_by_InputBuffer - configure fields'
 );
 
-#show REF_ALLELE via fields
+#show REF_ALLELE,SYMBOL via fields
 $ib = get_annotated_buffer({
   input_file => $test_cfg->{test_vcf},
   dir => $test_cfg->{cache_root_dir},
-  fields => 'REF_ALLELE,SYMBOL'
+  fields => 'REF_ALLELE,SYMBOL',
+  output_format =>'tab'
 });
 $of = Bio::EnsEMBL::VEP::OutputFactory::Tab->new({config => $ib->config});
 @lines = @{$of->get_all_lines_by_InputBuffer($ib)};

--- a/t/OutputFactory_Tab.t
+++ b/t/OutputFactory_Tab.t
@@ -276,15 +276,15 @@ is(
 $ib = get_annotated_buffer({
   input_file => $test_cfg->{test_vcf},
   dir => $test_cfg->{cache_root_dir},
-  fields => 'REF_ALLELE'
+  fields => 'REF_ALLELE,SYMBOL'
 });
 $of = Bio::EnsEMBL::VEP::OutputFactory::Tab->new({config => $ib->config});
 @lines = @{$of->get_all_lines_by_InputBuffer($ib)};
 
 is(
   $lines[0],
-  "C",
-  'get_all_lines_by_InputBuffer - REF_ALLELE configure fields'
+  "C\tMRPL39",
+  'get_all_lines_by_InputBuffer - REF_ALLELE,SYMBOL configure fields'
 );
 
 done_testing();

--- a/t/OutputFactory_Tab.t
+++ b/t/OutputFactory_Tab.t
@@ -272,6 +272,21 @@ is(
   'get_all_lines_by_InputBuffer - configure fields'
 );
 
+#show REF_ALLELE via fields
+$ib = get_annotated_buffer({
+  input_file => $test_cfg->{test_vcf},
+  dir => $test_cfg->{cache_root_dir},
+  fields => 'REF_ALLELE'
+});
+$of = Bio::EnsEMBL::VEP::OutputFactory::Tab->new({config => $ib->config});
+@lines = @{$of->get_all_lines_by_InputBuffer($ib)};
+
+is(
+  $lines[0],
+  "C",
+  'get_all_lines_by_InputBuffer - REF_ALLELE configure fields'
+);
+
 done_testing();
 
 sub get_annotated_buffer {


### PR DESCRIPTION
User reported issue `--fields REF_ALLELE` does not work, column ends up having `-`.
Same issue for `SYMBOL` fixed too.

jira ticket: ENSVAR-3575