### PR TITLE
Bugfix103/dont skip

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
@@ -208,8 +208,11 @@ sub _get_records_by_coords {
   my ($self, $c, $s, $e, $no_rescan) = @_;
 
   my $parser = $self->parser();
-  $parser->seek($c, $s - 1, $e + 1);
-  $parser->next();
+  if ($parser->seek($c, $s - 1, $e + 1)) {
+    $parser->next();
+  } else {
+    return;
+  }
 
   my $include = $self->include_feature_types;
 

--- a/t/AnnotationSource_File_GFF.t
+++ b/t/AnnotationSource_File_GFF.t
@@ -19,7 +19,6 @@ use Test::More;
 use Test::Exception;
 use FindBin qw($Bin);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap);
-use Data::Dumper;
 use lib $Bin;
 use VEPTestingConfig;
 my $test_cfg = VEPTestingConfig->new();
@@ -406,7 +405,8 @@ SKIP: {
   $ib->finish_annotation();
 
   is($ib->buffer->[0]->display_consequence, 'missense_variant', 'annotate_InputBuffer - display_consequence');
-  # dont_skip test
+  # dont_skip test Check that variants that are on seq_regions which are not part of the GFF file are still
+  # included in the output if --dont_skip is used
   my $in = qq{21\t25585733\trs142513484\tC\tT\t.\t.\t.
   SEQ_21\t25587758\trs116645811\tG\tA\t.\t.\t.};
 

--- a/t/AnnotationSource_File_GFF.t
+++ b/t/AnnotationSource_File_GFF.t
@@ -32,7 +32,7 @@ SKIP: {
   no warnings 'once';
 
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
-  skip 'Bio::DB::HTS::Tabix module not available', 44 unless $Bio::EnsEMBL::VEP::AnnotationSource::File::CAN_USE_TABIX_PM;
+  skip 'Bio::DB::HTS::Tabix module not available', 51 unless $Bio::EnsEMBL::VEP::AnnotationSource::File::CAN_USE_TABIX_PM;
 
   ## BASIC TESTS
   ##############
@@ -426,6 +426,7 @@ SKIP: {
   close IN;
   unlink($test_cfg->{user_file}.'.out');
   unlink($test_cfg->{user_file}.'.out_warnings.txt');
+  is(scalar (grep {/SEQ_21/} @tmp_lines), 1, 'dont_skip variants which are not in GFF file');
 }
 
 done_testing();

--- a/t/AnnotationSource_File_GFF.t
+++ b/t/AnnotationSource_File_GFF.t
@@ -32,7 +32,7 @@ SKIP: {
   no warnings 'once';
 
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
-  skip 'Bio::DB::HTS::Tabix module not available', 51 unless $Bio::EnsEMBL::VEP::AnnotationSource::File::CAN_USE_TABIX_PM;
+  skip 'Bio::DB::HTS::Tabix module not available', 52 unless $Bio::EnsEMBL::VEP::AnnotationSource::File::CAN_USE_TABIX_PM;
 
   ## BASIC TESTS
   ##############
@@ -406,7 +406,7 @@ SKIP: {
   $ib->finish_annotation();
 
   is($ib->buffer->[0]->display_consequence, 'missense_variant', 'annotate_InputBuffer - display_consequence');
-
+  # dont_skip test
   my $in = qq{21\t25585733\trs142513484\tC\tT\t.\t.\t.
   SEQ_21\t25587758\trs116645811\tG\tA\t.\t.\t.};
 

--- a/t/AnnotationSource_File_GFF.t
+++ b/t/AnnotationSource_File_GFF.t
@@ -19,7 +19,7 @@ use Test::More;
 use Test::Exception;
 use FindBin qw($Bin);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap);
-
+use Data::Dumper;
 use lib $Bin;
 use VEPTestingConfig;
 my $test_cfg = VEPTestingConfig->new();
@@ -406,6 +406,26 @@ SKIP: {
   $ib->finish_annotation();
 
   is($ib->buffer->[0]->display_consequence, 'missense_variant', 'annotate_InputBuffer - display_consequence');
+
+  my $in = qq{21\t25585733\trs142513484\tC\tT\t.\t.\t.
+  SEQ_21\t25587758\trs116645811\tG\tA\t.\t.\t.};
+
+  $runner = Bio::EnsEMBL::VEP::Runner->new({
+    %{$test_cfg->base_testing_cfg},
+    input_data => $in,
+    output_file => $test_cfg->{user_file}.'.out',
+    gff => $test_cfg->{custom_gff},
+    no_stats => 1,
+    dont_skip => 1,
+    quiet => 1,
+  });
+
+  $runner->run;
+  open IN, $test_cfg->{user_file}.'.out';
+  my @tmp_lines = <IN>;
+  close IN;
+  unlink($test_cfg->{user_file}.'.out');
+  unlink($test_cfg->{user_file}.'.out_warnings.txt');
 }
 
 done_testing();


### PR DESCRIPTION
Even with the dont_skip option variants that don't overlap transcripts in the GFF file where not included in the output. $parser->next() is using exit 1 in the [ensembl-io](https://github.com/Ensembl/ensembl-io/blob/release/101/modules/Bio/EnsEMBL/IO/TabixParser.pm#L109) when the iterator is not defined which I think is the problem here. The issue was reported here https://github.com/Ensembl/ensembl-vep/issues/875. I add some test files to PANDA/anja/vep_issue_875/