### PR TITLE
VEP JSON output - remove frequencies of non-matching co-located alleles

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -124,6 +124,13 @@ my @LIST_FIELDS = qw(
   var_synonyms
 );
 
+my @FREQ_FIELDS = qw(
+  AFR AMR ASN EAS SAS EUR
+  AA EA
+  ExAC ExAC_Adj ExAC_AFR ExAC_AMR ExAC_EAS ExAC_FIN ExAC_NFE ExAC_OTH ExAC_SAS
+  gnomAD gnomAD_AFR gnomAD_AMR gnomAD_ASJ gnomAD_EAS gnomAD_FIN gnomAD_NFE gnomAD_OTH gnomAD_SAS
+);
+
 
 =head2 new
 
@@ -409,6 +416,12 @@ sub add_colocated_variant_info_JSON {
   # remove empty
   foreach my $key(keys %$ex) {
     delete $ex->{$key} if !defined($ex->{$key}) || $ex->{$key} eq '' || ($key !~ /af/ && $ex->{$key} eq 0);
+  }
+
+  # Remove the frequencies from the co-located variant
+  # that are not part of frequency hash
+  foreach my $key (@FREQ_FIELDS) {
+    delete $ex->{$key};
   }
 
   # rename

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -400,12 +400,7 @@ sub add_colocated_variant_info_JSON {
   foreach my $frequency_hash (@$frequency_hashes) {
     my $allele = $frequency_hash->{Allele};
     # frequencies
-    foreach my $pop (grep {defined($frequency_hash->{"$_\_AF"})} qw(
-      AFR AMR ASN EAS SAS EUR
-      AA EA
-      ExAC ExAC_Adj ExAC_AFR ExAC_AMR ExAC_EAS ExAC_FIN ExAC_NFE ExAC_OTH ExAC_SAS
-      gnomAD gnomAD_AFR gnomAD_AMR gnomAD_ASJ gnomAD_EAS gnomAD_FIN gnomAD_NFE gnomAD_OTH gnomAD_SAS
-    )) {
+    foreach my $pop (grep {defined($frequency_hash->{"$_\_AF"})} @FREQ_FIELDS) {
       my $lc_pop = lc($pop);
       $frequencies->{$allele}->{$lc_pop} = $frequency_hash->{"$pop\_AF"}[0];
       delete $ex->{$pop};


### PR DESCRIPTION
This is related to  #938. For further details and examples see: ENSVAR-4006