### PR TITLE
use r2.1.1 for consistency

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DumpVEP_conf.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DumpVEP_conf.pm
@@ -162,7 +162,7 @@ sub default_options {
                 pops => ['', qw(afr amr asj eas fin nfe oth sas)],
                 name => 'gnomAD',
                 prefix => 'gnomAD',
-                version => 'v2.1.1',
+                version => 'r2.1.1',
               },
             ],
           },


### PR DESCRIPTION
We used r2.1 before and it is better to use r2.1.1 for consistency.