### PR TITLE
fix condition for setting grch37 port

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -465,6 +465,12 @@ sub new {
   
   # set defaults
   # we need to do this first so paths are set for reading config etc
+
+  # Assign default port for GRCh37
+  if (defined($config->{'assembly'}) && lc($config->{'assembly'}) eq 'grch37' && defined($config->{'database'}) && !defined($config->{'port'})) {
+    $config->{'port'} = 3337;
+  }
+
   foreach my $key(keys %DEFAULTS) {
     $config->{$key} = $DEFAULTS{$key} unless exists($config->{$key});
   }

--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -114,7 +114,7 @@ sub init {
   # log start time
   $self->stats->start_time();
 
-  if(defined($self->param('assembly')) && lc($self->param('assembly')) eq 'grch37' && defined($self->param('database') && !defined($self->param('port')))) {
+  if(defined($self->param('assembly')) && lc($self->param('assembly')) eq 'grch37' && defined($self->param('database')) && !defined($self->param('port'))) {
     $self->param('port', 3337);
   }
 

--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -114,10 +114,6 @@ sub init {
   # log start time
   $self->stats->start_time();
 
-  if(defined($self->param('assembly')) && lc($self->param('assembly')) eq 'grch37' && defined($self->param('database')) && !defined($self->param('port'))) {
-    $self->param('port', 3337);
-  }
-
   if(defined($self->param('var_synonyms')) && !$self->param('check_existing')) {
     $self->status_msg("INFO: Colocated variants will be provided when using --var_synonyms\n");
     $self->param('check_existing', 1);


### PR DESCRIPTION
Providing a different port number for GRCh37 databases was ignored because of small bug in the condition statement.
This was reported here https://github.com/Ensembl/ensembl-vep/issues/958
It can be tested with our GRCh37 mirror server.