### PR TITLE
replace dash in var name

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -578,8 +578,8 @@ sub generate_chart_data {
   
   foreach my $chr(sort {($a !~ /^\d+$/ || $b !~ /^\d+/ || $a =~ /^\d\w/ || $b =~ /^\d\w/ ) ? $a cmp $b : $a <=> $b} keys %{$stats->{chr}}) {
     my $chr_id = $chr;
-    $chr_id =~ s/\./\_/g;
-    
+    $chr_id =~ s/\.|-/\_/g;
+
     push @charts, {
       id => 'chr_'.$chr_id,
       title => 'Distribution of variants on chromosome '.$chr,


### PR DESCRIPTION
A hyphen in a chromosome name which is used for creating the javascript variable name was breaking the html display. Hyphens are not allowed in javacscript names. My script for reproducing and testing can be found here PANDA/anja/vep_issue_974.
Issue was reported here #974 