### PR TITLE
OutputFactory json - do not convert gene symbol to integer

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -116,6 +116,7 @@ my %NUMBERIFY_EXEMPT = (
   'gene_id' => 1,
   'gene_symbol' => 1,
   'transcript_id' => 1,
+  'SYMBOL' => 1
 );
 
 my @LIST_FIELDS = qw(


### PR DESCRIPTION
The SpliceAI json output:
```
"spliceai": {
 "DP_DL":7,
 "DS_AL":0,
 "DP_AG":19,
 "DS_DL":0,
 "SYMBOL":"NANS",
 "DS_AG":0.01,
 "DP_AL":1,
 "DP_DG":-4,
 "DS_DG":0
}
```
The OutputFactory/JSON tries to numberify the SYMBOL string. For gene "NANS" on REST, the string is converted to `-nan`
Ticket: ENSVAR-4087