### PR TITLE
Remove column 'Existing_variation' from VEP default output

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -119,7 +119,7 @@ our @FLAG_FIELDS = (
   { flag => 'check_frequency', fields => ['FREQS'] },
 
   # misc variation stuff
-  { flag => 'check_existing',  fields => ['CLIN_SIG','SOMATIC','PHENO'] },
+  { flag => 'check_existing',  fields => ['CLIN_SIG','SOMATIC','PHENO', 'Existing_variation'] },
   { flag => 'pubmed',          fields => ['PUBMED'] },
   { flag => 'check_svs',       fields => ['SV'] },
   { flag => 'dont_skip',       fields => ['CHECK_REF'] },
@@ -256,7 +256,6 @@ our @DEFAULT_OUTPUT_COLS = qw(
   Protein_position
   Amino_acids
   Codons
-  Existing_variation
 );
 
 our %TS_TV = (

--- a/t/OutputFactory_Tab.t
+++ b/t/OutputFactory_Tab.t
@@ -59,7 +59,6 @@ is_deeply(
     Protein_position
     Amino_acids
     Codons
-    Existing_variation
     IMPACT
     DISTANCE
     STRAND
@@ -88,13 +87,12 @@ is_deeply(
     '## Protein_position : Relative position of amino acid in protein',
     '## Amino_acids : Reference and variant amino acids',
     '## Codons : Reference and variant codon sequence',
-    '## Existing_variation : Identifier(s) of co-located known variants',
     '## IMPACT : Subjective impact classification of consequence type',
     '## DISTANCE : Shortest distance from variant to transcript',
     '## STRAND : Strand of the feature (1/-1)',
     '## FLAGS : Transcript quality flags',
     '## custom_test : test.vcf.gz (overlap)',
-    "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tIMPACT\tDISTANCE\tSTRAND\tFLAGS\tcustom_test"
+    "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tIMPACT\tDISTANCE\tSTRAND\tFLAGS\tcustom_test"
   ],
   'headers'
 );
@@ -119,7 +117,7 @@ my $runner = get_annotated_buffer_runner({
 is(
   $runner->get_OutputFactory->headers->[-2].$runner->get_OutputFactory->headers->[-1],
   "## test : header".
-  "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tREF_ALLELE\tIMPACT\tDISTANCE\tSTRAND\tFLAGS\ttest",
+  "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tREF_ALLELE\tIMPACT\tDISTANCE\tSTRAND\tFLAGS\ttest",
   'headers - plugin'
 );
 
@@ -127,13 +125,13 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::Tab->new({
   config => $cfg,
   header_info => $test_cfg->{header_info}
 });
-is($of->output_hash_to_line({}), '-'.("\t\-" x 17), 'output_hash_to_line - empty');
+is($of->output_hash_to_line({}), '-'.("\t\-" x 16), 'output_hash_to_line - empty');
 
 is(
   $of->output_hash_to_line({
     Uploaded_variation => 0,
   }),
-  '0'.("\t\-" x 17),
+  '0'.("\t\-" x 16),
   'output_hash_to_line - test 0'
 );
 
@@ -159,7 +157,7 @@ is(
     Transcript
     3_prime_UTR_variant
     1122
-    - - - - -
+    - - - -
     C
     MODIFIER
     -
@@ -184,7 +182,6 @@ is(
     278
     V/I
     Gtt/Att
-    -
     C
     MODERATE
     -
@@ -224,7 +221,7 @@ SKIP: {
       Transcript
       3_prime_UTR_variant
       1122
-      - - - - -
+      - - - -
       MODIFIER
       -
       -1
@@ -249,10 +246,10 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::Tab->new({config => $ib->config});
 is(
   $lines[0],
   "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t".
-  "-\t-\t-\t-\trs142513484\tMODIFIER\t-\t-1\t-\tSNV\tMRPL39\tHGNC\tHGNC:14027\tprotein_coding\tYES\t-\t-\t5\t-\t".
+  "-\t-\t-\t-\tMODIFIER\t-\t-1\t-\tSNV\tMRPL39\tHGNC\tHGNC:14027\tprotein_coding\tYES\t-\t-\t5\t-\t".
   "CCDS33522.1\tENSP00000305682\tQ9NYK5\t-\tUPI00001AEAC0\t-\t-\t-\t-\t11/11\t-\t-\t-\tENST00000307301.11:c.*18G>A\t".
   "-\t-\t0.0010\t0.003\t0.0014\t0\t0\t0\t0.004998\t0\t0.0003478\t0.004643\t0.0003236\t0\t0\t0\t1.886e-05\t0\t0\t".
-  "0.004998\tAA\t-\t-\t-\t-\t-\t-\t-\t-\t-",
+  "0.004998\tAA\t-\t-\t-\trs142513484\t-\t-\t-\t-\t-\t-",
   'get_all_lines_by_InputBuffer - everything'
 );
 

--- a/t/OutputFactory_VEP_output.t
+++ b/t/OutputFactory_VEP_output.t
@@ -94,14 +94,13 @@ is_deeply(
     '## Protein_position : Relative position of amino acid in protein',
     '## Amino_acids : Reference and variant amino acids',
     '## Codons : Reference and variant codon sequence',
-    '## Existing_variation : Identifier(s) of co-located known variants',
     '## Extra column keys:',
     '## IMPACT : Subjective impact classification of consequence type',
     '## DISTANCE : Shortest distance from variant to transcript',
     '## STRAND : Strand of the feature (1/-1)',
     '## FLAGS : Transcript quality flags',
     '## custom_test : test.vcf.gz (overlap)',
-    "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tExtra"
+    "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExtra"
   ],
   'headers'
 );
@@ -114,18 +113,18 @@ my $runner = get_annotated_buffer_runner({
 is(
   $runner->get_OutputFactory->headers->[-2].$runner->get_OutputFactory->headers->[-1],
   "## test : header".
-  "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tExtra",
+  "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExtra",
   'headers - plugin'
 );
 
 
-is($of->output_hash_to_line({}), '-'.("\t\-" x 13), 'output_hash_to_line - empty');
+is($of->output_hash_to_line({}), '-'.("\t\-" x 12), 'output_hash_to_line - empty');
 
 is(
   $of->output_hash_to_line({
     Uploaded_variation => 0,
   }),
-  '0'.("\t\-" x 13),
+  '0'.("\t\-" x 12),
   'output_hash_to_line - test 0'
 );
 
@@ -134,7 +133,7 @@ is(
     Existing_variation => 'rs123',
     Foo => 'bar',
   }),
-  '-'.("\t\-" x 11)."\trs123\tFoo\=bar",
+  '-'.("\t\-" x 11)."\tExisting_variation\=rs123;Foo\=bar",
   'output_hash_to_line - test extra 1'
 );
 
@@ -144,7 +143,7 @@ is(
     Foo => 'bar',
     IMPACT => 'HIGH'
   }),
-  '-'.("\t\-" x 11)."\trs123\tIMPACT\=HIGH;Foo\=bar",
+  '-'.("\t\-" x 11)."\tIMPACT\=HIGH;Existing_variation\=rs123;Foo\=bar",
   'output_hash_to_line - test extra 2'
 );
 
@@ -170,7 +169,7 @@ is(
     Transcript
     3_prime_UTR_variant
     1122
-    - - - - -
+    - - - -
     REF_ALLELE=C;IMPACT=MODIFIER;STRAND=-1
   )),
   'get_all_lines_by_InputBuffer - check first'
@@ -191,7 +190,6 @@ is(
     278
     V/I
     Gtt/Att
-    -
     REF_ALLELE=C;IMPACT=MODERATE;STRAND=-1;FLAGS=cds_start_NF
   )),
   'get_all_lines_by_InputBuffer - check last'
@@ -215,7 +213,7 @@ is(
   'HGVSc=ENST00000307301.11:c.*18G>A;'.
   'AF=0.0010;AFR_AF=0.003;AMR_AF=0.0014;EAS_AF=0;EUR_AF=0;SAS_AF=0;AA_AF=0.004998;EA_AF=0;'.
   'gnomAD_AF=0.0003478;gnomAD_AFR_AF=0.004643;gnomAD_AMR_AF=0.0003236;gnomAD_ASJ_AF=0;'.
-  'gnomAD_EAS_AF=0;gnomAD_FIN_AF=0;gnomAD_NFE_AF=1.886e-05;gnomAD_OTH_AF=0;gnomAD_SAS_AF=0;MAX_AF=0.004998;MAX_AF_POPS=AA',
+  'gnomAD_EAS_AF=0;gnomAD_FIN_AF=0;gnomAD_NFE_AF=1.886e-05;gnomAD_OTH_AF=0;gnomAD_SAS_AF=0;MAX_AF=0.004998;MAX_AF_POPS=AA;Existing_variation=rs142513484',
   'get_all_lines_by_InputBuffer - everything'
 );
 
@@ -249,7 +247,7 @@ SKIP: {
       Transcript
       3_prime_UTR_variant
       1122
-      - - - - -
+      - - - -
       IMPACT=MODIFIER;STRAND=-1;test=test1;test_FILTER=PASS;test_FOO=BAR
     )),
     'get_all_lines_by_InputBuffer - custom'

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -244,7 +244,7 @@ is_deeply(
       Transcript
       3_prime_UTR_variant
       1122
-      - - - - -
+      - - - -
       IMPACT=MODIFIER;STRAND=-1
     )),
     join("\t", qw(
@@ -260,7 +260,6 @@ is_deeply(
       331
       A/T
       Gca/Aca
-      -
       IMPACT=MODERATE;STRAND=-1
     )),
     join("\t", qw(
@@ -271,7 +270,6 @@ is_deeply(
       ENST00000567517
       Transcript
       upstream_gene_variant
-      -
       -
       -
       -
@@ -296,7 +294,7 @@ is(
     Transcript
     3_prime_UTR_variant
     1122
-    - - - - -
+    - - - -
     IMPACT=MODIFIER;STRAND=-1
   )),
   'next_output_line'
@@ -432,14 +430,14 @@ ok($runner->run, 'run - ok');
 open IN, $test_cfg->{user_file}.'.out';
 my @tmp_lines = <IN>;
 close IN;
-is(scalar @tmp_lines, 40, 'run - count lines');
+is(scalar @tmp_lines, 39, 'run - count lines');
 
 is_deeply(
   [grep {!/^\#/} @tmp_lines],
   [
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1\n",
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1\n",
-    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\tIMPACT=MODERATE;STRAND=-1\n",
+    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1\n",
   ],
   'run - lines content'
 );


### PR DESCRIPTION
The column 'Existing_variation' is returned as default in VEP output however, it only returns data if --check_existing (or other option that switches on --check_existing) is used. 
As no data is returned by default, the column should be removed. 

Details in ENSVAR-4250