### PR TITLE
GA4GH VRS Allele object to variant recoder

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -396,8 +396,7 @@ our %INCOMPATIBLE = (
   tab         => [qw(vcf json)],
   individual  => [qw(minimal)],
   check_ref   => [qw(lookup_ref)],
-  check_svs   => [qw(offline)],
-  ga4gh_vrs   => [qw(vcf tab txt)]
+  check_svs   => [qw(offline)]
 );
 
 # deprecated/replaced flags

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -381,6 +381,7 @@ our %REQUIRES = (
   phyloP    => [qw(ucsc_assembly)],
   phastCons => [qw(ucsc_assembly)],
   custom_multi_allelic => [qw(custom)],
+  ga4gh_vrs => [qw(json)]
 );
 
 # incompatible options
@@ -396,6 +397,7 @@ our %INCOMPATIBLE = (
   individual  => [qw(minimal)],
   check_ref   => [qw(lookup_ref)],
   check_svs   => [qw(offline)],
+  ga4gh_vrs   => [qw(vcf tab txt)]
 );
 
 # deprecated/replaced flags

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -76,6 +76,7 @@ our @FLAG_FIELDS = (
   { flag => 'variant_class',   fields => ['VARIANT_CLASS']},
   { flag => 'minimal',         fields => ['MINIMISED']},
   { flag => 'spdi',            fields => ['SPDI']},
+  { flag => 'ga4gh_vrs',       fields =>  ['GA4GH_VRS']},
 
   # gene-related
   { flag => 'symbol',          fields => ['SYMBOL','SYMBOL_SOURCE','HGNC_ID'] },
@@ -172,6 +173,7 @@ our %FIELD_DESCRIPTIONS = (
   'HGVSp'              => 'HGVS protein sequence name',
   'HGVSg'              => 'HGVS genomic sequence name',
   'SPDI'               => 'Genomic SPDI notation',
+  'GA4GH_VRS'          => 'GA4GH VRS object',
   'SIFT'               => 'SIFT prediction and/or score',
   'PolyPhen'           => 'PolyPhen prediction and/or score',
   'EXON'               => 'Exon number(s) / total',

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -76,7 +76,6 @@ our @FLAG_FIELDS = (
   { flag => 'variant_class',   fields => ['VARIANT_CLASS']},
   { flag => 'minimal',         fields => ['MINIMISED']},
   { flag => 'spdi',            fields => ['SPDI']},
-  { flag => 'ga4gh_vrs',       fields =>  ['GA4GH_VRS']},
 
   # gene-related
   { flag => 'symbol',          fields => ['SYMBOL','SYMBOL_SOURCE','HGNC_ID'] },
@@ -173,7 +172,6 @@ our %FIELD_DESCRIPTIONS = (
   'HGVSp'              => 'HGVS protein sequence name',
   'HGVSg'              => 'HGVS genomic sequence name',
   'SPDI'               => 'Genomic SPDI notation',
-  'GA4GH_VRS'          => 'GA4GH VRS object',
   'SIFT'               => 'SIFT prediction and/or score',
   'PolyPhen'           => 'PolyPhen prediction and/or score',
   'EXON'               => 'Exon number(s) / total',

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -202,6 +202,7 @@ sub new {
     hgvsg_use_accession
     spdi
     sift
+    ga4gh_vrs
     polyphen
     polyphen_analysis
 
@@ -1283,6 +1284,17 @@ sub VariationFeatureOverlapAllele_to_output_hash {
       
     if(my $spdi = $vf->{_spdi_genomic}->{$hash->{Allele}}){
       $hash->{SPDI} = $spdi;  
+    }
+  }
+
+  # ga4gh_vrs
+  if ($self->{ga4gh_vrs}) {
+    $vf->{_ga4gh_spdi_genomic} = $vf->spdi_genomic();
+
+    if (my $ga4gh_spdi = $vf->{_ga4gh_spdi_genomic}->{$hash->{Allele}}) {
+      if ($ga4gh_spdi =~ /^NC/) {
+        $hash->{GA4GH_SPDI} = $ga4gh_spdi;
+      }
     }
   }
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -84,6 +84,7 @@ use base qw(Bio::EnsEMBL::VEP::OutputFactory);
 
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Variation::Utils::Constants;
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(ga4gh_vrs_from_spdi);
 
 use Bio::EnsEMBL::VEP::Utils qw(numberify);
 
@@ -361,7 +362,12 @@ sub add_VariationFeatureOverlapAllele_info {
       $vfoa_hash->{$rename{$key}} = $vfoa_hash->{$key};
       delete $vfoa_hash->{$key};
     }
-
+    if (defined($vfoa_hash->{ga4gh_spdi})) {
+      my $ga4gh_vrs = ga4gh_vrs_from_spdi($vfoa_hash->{ga4gh_spdi});
+      if ($ga4gh_vrs) {
+          $vfoa_hash->{ga4gh_vrs} = $ga4gh_vrs;
+      }
+    }
     push @{$hash->{$ftype.'_consequences'}}, $vfoa_hash;
   }
 

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -227,6 +227,7 @@ is_deeply($runner->get_OutputFactory, bless( {
   'vcf_string' => undef,
   'clin_sig_allele' => 1,
   'var_synonyms' => undef,
+  'ga4gh_vrs' => undef,
 }, 'Bio::EnsEMBL::VEP::OutputFactory::VEP_output' ), 'get_OutputFactory');
 
 

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -1161,7 +1161,7 @@ SKIP: {
   my $can_use_db = $db_cfg && scalar keys %$db_cfg && !$@;
 
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
-  skip 'No local database configured', 5 unless $can_use_db;
+  skip 'No local database configured', 6 unless $can_use_db;
 
   my $multi = Bio::EnsEMBL::Test::MultiTestDB->new('homo_vepiens') if $can_use_db;
   
@@ -1192,6 +1192,64 @@ SKIP: {
   is($info->{db_host}, $db_cfg->{host}, 'get_output_header_info - db_host');
   ok($info->{db_name} =~ /homo_vepiens_core.+/, 'get_output_header_info - db_name');
   ok($info->{db_version}, 'get_output_header_info - db_version');
+
+  # GA4GH VRS Allele object
+  $runner = Bio::EnsEMBL::VEP::Runner->new({
+    %$cfg_hash,
+    fasta => $test_cfg->{fasta},
+    input_data => '21 10524654 . C A',
+    %$db_cfg,
+    database => 1,
+    ga4gh_vrs => 1,
+    json => 1,
+    offline => 0,
+    species => 'human_vep',
+  });
+
+  $runner->init();
+  is_deeply(
+     $runner->run_rest(),
+     [{
+         "allele_string" => "C/A",
+         "assembly_name" => "GRCh38",
+         "end" => 10524654,
+         "id" => ".",
+         "input" =>  "21 10524654 . C A",
+         "intergenic_consequences" => [
+             {
+                 "consequence_terms" => [
+                     "intergenic_variant"
+                 ],
+                 "ga4gh_spdi" => "NC_000021.9:10524653:C:A",
+                 "ga4gh_vrs" =>  {
+                     "location" => {
+                         "interval"  => {
+                             "end" =>  10524654,
+                             "start" => 10524653,
+                             "type" => "SimpleInterval"
+                         },
+                         "sequence_id" => "refseq:NC_000021.9",
+                         "type" => "SequenceLocation"
+                     },
+                     "state" => {
+                         "sequence" => "A",
+                         "type" => "SequenceState"
+                     },
+                     "type" =>  "Allele"
+                 },
+                 "impact" =>  "MODIFIER",
+                 "variant_allele" => "A"
+             }
+         ],
+         "most_severe_consequence" => "intergenic_variant",
+         "seq_region_name" =>  "21",
+         "start" =>  10524654,
+         "strand" => 1
+     }],
+     'GA4GH VRS Allele',
+  );
 };
+
+
 
 done_testing();

--- a/t/VariantRecoder.t
+++ b/t/VariantRecoder.t
@@ -46,7 +46,7 @@ SKIP: {
   my $can_use_db = $db_cfg && scalar keys %$db_cfg && !$@;
 
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
-  skip 'No local database configured', 22 unless $can_use_db;
+  skip 'No local database configured', 24 unless $can_use_db;
 
   my $multi = Bio::EnsEMBL::Test::MultiTestDB->new('homo_vepiens') if $can_use_db;
   
@@ -374,6 +374,79 @@ SKIP: {
     'recode - output MANE Select and fields'
   );
 
-  };
+  my $vr_ga4gh_vrs = Bio::EnsEMBL::VEP::VariantRecoder->new(
+                      {%$cfg_hash, %$db_cfg, offline => 0,
+                       database => 1, species => 'homo_vepiens',
+                       ga4gh_vrs => 1, fields => 'spdi'});
+  is_deeply(
+    $vr_ga4gh_vrs->recode('rs142513484'),
+    [
+     {
+      'T' => {
+        'input' => 'rs142513484',
+        'spdi' => [
+           'NC_000021.9:25585732:C:T'
+        ],
+        'ga4gh_vrs' => [
+           {
+             'location' => {
+                 'sequence_id' => 'refseq:NC_000021.9',
+                 'type' => 'SequenceLocation',
+                 'interval' => {
+                     'type' => 'SimpleInterval',
+                     'end' => 25585733,
+                     'start' => 25585732
+                 }
+             },
+             'type' => 'Allele',
+             'state' => {
+                'sequence' => 'T',
+                'type' => 'SequenceState'
+             }
+           }
+        ]
+      }
+     }
+   ],
+   'recode - SNV ID input - output GA4GH VRS Allele, SPDI'
+   );
+
+   my $vrs_input_2 = 'NC_000021.9:25585732:C:T';
+   is_deeply(
+     $vr_ga4gh_vrs->recode($vrs_input_2),
+     [
+      {
+       'T' => {
+         'input' => 'NC_000021.9:25585732:C:T',
+         'spdi' => [
+            'NC_000021.9:25585732:C:T'
+         ],
+         'ga4gh_vrs' => [
+            {
+              'location' => {
+                  'sequence_id' => 'refseq:NC_000021.9',
+                  'type' => 'SequenceLocation',
+                  'interval' => {
+                      'type' => 'SimpleInterval',
+                      'end' => 25585733,
+                      'start' => 25585732
+                  }
+              },
+              'type' => 'Allele',
+              'state' => {
+                 'sequence' => 'T',
+                 'type' => 'SequenceState'
+              }
+            }
+         ]
+       }
+      }
+    ],
+    'recode - SNV SPDI input - output GA4GH VRS Allele, SPDI'
+    );
+
+};
+
+
 
 done_testing();

--- a/variant_recoder
+++ b/variant_recoder
@@ -83,6 +83,7 @@ GetOptions(
   'vcf_string',              # returns the vcf format in a string
   'var_synonyms',            # returns the variation synonyms
   'mane_select',             # returns MANE Select transcripts in HGVS format (e.g. hgvsg, hgvsc, hgvsp)
+  'ga4gh_vrs',               # returns the GA4GH VRS allele object
 
   # these flags are for use with RefSeq caches
   'bam=s',                   # bam file used to modify transcripts

--- a/vep
+++ b/vep
@@ -141,6 +141,7 @@ GetOptions(
   'gene_phenotype',          # indicate if genes are phenotype-associated
   'mirna',                   # identify miRNA structural elements overlapped by variant
   'spdi',                    # add genomic SPDI
+  'ga4gh_vrs',               # add GA4GH_VRS
   'hgvs',                    # add HGVS names to extra column
   'hgvsg',                   # add HGVS g. also
   'hgvsg_use_accession',     # force HGVSg to return on chromosome accession instead of input chr name


### PR DESCRIPTION
Adds option to output GA4GH VRS Allele object in Variant Recoder and VEP
For further info see: 
ENSVAR-4092 Variant Recoder
ENSVAR-4186 VEP

Requires https://github.com/Ensembl/ensembl-variation/pull/739
