### PR TITLE
Sort order of processing of frequency keys

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1116,8 +1116,8 @@ sub add_colocated_frequency_data {
 
   my $max_af = 0;
   my @max_af_pops;
-
-  foreach my $group(@keys) {
+  
+  foreach my $group(sort @keys) {
     foreach my $key(grep {$ex->{$_}} @{$FREQUENCY_KEYS{$group}}) {
 
       my %freq_data;


### PR DESCRIPTION
To prevent random ordering of fields in the case where there are multiple subpopulations with the same maximum frequency