### PR TITLE
Include missing values in JSON output

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -240,7 +240,6 @@ sub get_all_output_hashes_by_InputBuffer {
 
     # get other data from super methods
     my $extra_hash = $self->VariationFeature_to_output_hash($vf);
-
     $hash->{lc($_)} = $extra_hash->{$_} for grep {!$SKIP_KEYS{$_}} keys %$extra_hash;
 
     $self->add_VariationFeatureOverlapAllele_info($vf, $hash);

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -240,6 +240,7 @@ sub get_all_output_hashes_by_InputBuffer {
 
     # get other data from super methods
     my $extra_hash = $self->VariationFeature_to_output_hash($vf);
+
     $hash->{lc($_)} = $extra_hash->{$_} for grep {!$SKIP_KEYS{$_}} keys %$extra_hash;
 
     $self->add_VariationFeatureOverlapAllele_info($vf, $hash);
@@ -305,7 +306,7 @@ sub add_VariationFeatureOverlapAllele_info {
       my $tmp = $vfoa_hash->{$key};
       delete $vfoa_hash->{$key};
 
-      next if !defined($tmp) || ($key ne 'Allele' && $tmp eq '-');
+      next if !defined($tmp) || (($key ne 'Allele' && lc($key) ne 'used_ref' && lc($key) ne 'given_ref') && $tmp eq '-');
 
       # convert YES to 1
       $tmp = 1 if $tmp eq 'YES';

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
@@ -80,6 +80,8 @@ use base qw(Bio::EnsEMBL::VEP::OutputFactory::BaseTab);
 use Bio::EnsEMBL::VEP::Utils qw(convert_arrayref);
 use Bio::EnsEMBL::VEP::Constants;
 
+use Data::Dumper;
+
 my %OUTPUT_COLS_HASH = map {$_ => 1} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTPUT_COLS;
 
 
@@ -99,6 +101,8 @@ my %OUTPUT_COLS_HASH = map {$_ => 1} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTP
 sub output_hash_to_line {
   my $self = shift;
   my $hash = shift;
+
+  # print Dumper($hash);
 
   # "core" fields
   my @line = map {defined($hash->{$_}) ? convert_arrayref($hash->{$_}) : '-'} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTPUT_COLS;

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
@@ -80,8 +80,6 @@ use base qw(Bio::EnsEMBL::VEP::OutputFactory::BaseTab);
 use Bio::EnsEMBL::VEP::Utils qw(convert_arrayref);
 use Bio::EnsEMBL::VEP::Constants;
 
-use Data::Dumper;
-
 my %OUTPUT_COLS_HASH = map {$_ => 1} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTPUT_COLS;
 
 
@@ -101,8 +99,6 @@ my %OUTPUT_COLS_HASH = map {$_ => 1} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTP
 sub output_hash_to_line {
   my $self = shift;
   my $hash = shift;
-
-  # print Dumper($hash);
 
   # "core" fields
   my @line = map {defined($hash->{$_}) ? convert_arrayref($hash->{$_}) : '-'} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTPUT_COLS;

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -510,7 +510,42 @@ SKIP: {
     'minimal - get_all_lines_by_InputBuffer'
   );
 
+  # test refseq keys: used_ref and given_ref
+  $ib = get_annotated_buffer({
+    input_file => $test_cfg->create_input_file([qw(21 25891785 . G GA . . .)]),
+    refseq => 1,
+    fasta => $test_cfg->{fasta},
+  });
+  $of = Bio::EnsEMBL::VEP::OutputFactory::JSON->new({config => $ib->config});
+  @lines = @{$of->get_all_lines_by_InputBuffer($ib)};
 
+  is_deeply(
+    $json->decode($lines[0])->{'transcript_consequences'}[0],
+    {
+      'given_ref' => '-',
+      'variant_allele' => 'A',
+      'cdna_end' => 2348,
+      'codons' => 'atc/atTc',
+      'used_ref' => '-',
+      'protein_end' => 716,
+      'amino_acids' => 'I/IX',
+      'strand' => -1,
+      'cdna_start' => 2347,
+      'transcript_id' => 'NM_000484.3',
+      'gene_id' => '351',
+      'cds_start' => 2147,
+      'protein_start' => 716,
+      'refseq_match' => [
+        'rseq_mrna_match'
+       ],
+      'cds_end' => 2148,
+      'consequence_terms' => [
+        'frameshift_variant'
+      ],
+      'impact' => 'HIGH'
+    },
+    'get_all_lines_by_InputBuffer - refseq used_ref'
+  );
 
   # test custom
   use_ok('Bio::EnsEMBL::VEP::AnnotationSource::File');

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -34,7 +34,7 @@ SKIP: {
   no warnings 'once';
 
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
-  skip 'JSON module not available', 19 unless $Bio::EnsEMBL::VEP::OutputFactory::CAN_USE_JSON;
+  skip 'JSON module not available', 23 unless $Bio::EnsEMBL::VEP::OutputFactory::CAN_USE_JSON;
 
   ## BASIC TESTS
   ##############


### PR DESCRIPTION
'used_ref' and 'given_ref' are missing from JSON output when the value is '-'
More details: ENSVAR-4492