### PR TITLE
Automatically merge postreleasefix branch with release and master

### DIFF
--- a/.github/workflows/merge-branches.yml
+++ b/.github/workflows/merge-branches.yml
@@ -1,0 +1,32 @@
+name: Merge postreleasefix with release and master branches
+on:
+  push:
+    branches:
+      - 'postreleasefix/*'
+jobs:
+  sync-branch:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@master
+
+      - name: Set the release version
+        run: |
+          echo "release=$(echo ${GITHUB_REF} | grep -o [0-9]*$)" >> $GITHUB_ENV
+          
+      - name: "Merge postreleasefix/${{ env.release }} -> master"
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: "postreleasefix/${{ env.release }}"
+          target_branch: master
+          github_token: ${{ github.token }}
+          message: "Merge branch 'postreleasefix/${{ env.release }}'"
+
+      - name: "Merge postreleasefix/${{ env.release }} -> release/${{ env.release }}"
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: "postreleasefix/${{ env.release }}"
+          target_branch: "release/${{ env.release }}"
+          github_token: ${{ github.token }}
+          message: "Merge branch 'postreleasefix/${{ env.release }}'"

--- a/.github/workflows/merge-branches.yml
+++ b/.github/workflows/merge-branches.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   sync-branch:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.event.label.name == 'auto-merge'
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'auto-merge')
     steps:      
       - uses: actions/checkout@master
 

--- a/.github/workflows/merge-branches.yml
+++ b/.github/workflows/merge-branches.yml
@@ -1,11 +1,15 @@
 name: Merge postreleasefix with release and master branches
+
 on:
-  push:
+  pull_request:
+    types:
+      - closed # Run after closing PR
     branches:
       - 'postreleasefix/*'
 jobs:
   sync-branch:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.label.name == 'auto-merge'
     steps:      
       - uses: actions/checkout@master
 


### PR DESCRIPTION
After merging a PR targeting a branch named **postreleasefix/XX** and containing the label `auto-merge`, this GitHub Actions script will merge branch **posteleasefix/XX** with branch **release/XX** and **master** (the script takes 30 seconds to run).

## Conditions to trigger the action

* PR contains `auto-merge` label
* PR targeting a branch whose name starts with `postreleasefix/`
* The script is only triggered after the PR is merged

If these conditions are not met, the branches will not automatically merge when merging the PR. However, the changes will be automatically merged in later PRs that meet the previous conditions.

## Script steps

After merging a PR labelled `auto-merge` and targeting `postreleasefix/107`, this script will be triggered:
1. Get the release version based on the last digits of the branch: `107`
2. Merge `postreleasefix/107` to `master`
3. Merge `postreleasefix/107` to `release/107` (this step is not performed if there is an error in step 2).

## Merge conflicts

If the merge conflict occurs when trying to merge `master`, no branches will be merged. However, if a merge conflict only affects the `release/XX` branch, the changes in `postreleasefix/XX` will still be merged with `master`.

The action status will be updated accordingly in the **Actions** tab. In case of a merge conflict, we will need to manually merge the branches.

## Notes

* This PR can be merged to **postreleasefix/107** and it will immediately merge changes from **postreleasefix/107** to **release/107** and **master**. Otherwise, the PR can be merged to **master** to be used in future **postreleasefix** branches.
* In what other repos would this be useful to have?