### PR TITLE
Fix Docker badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub](https://img.shields.io/github/license/Ensembl/ensembl-vep.svg)](https://github.com/Ensembl/ensembl-vep/blob/master/LICENSE)
 [![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl-vep/badge.svg?branch=master)](https://coveralls.io/github/Ensembl/ensembl-vep?branch=master)
-[![Docker Build Status](https://img.shields.io/docker/build/ensemblorg/ensembl-vep.svg)](https://hub.docker.com/r/ensemblorg/ensembl-vep)
+[![Docker Build Status](https://img.shields.io/docker/cloud/build/ensemblorg/ensembl-vep.svg)](https://hub.docker.com/r/ensemblorg/ensembl-vep)
 [![Docker Hub Pulls](https://img.shields.io/docker/pulls/ensemblorg/ensembl-vep.svg)](https://hub.docker.com/r/ensemblorg/ensembl-vep)
 
 * **VEP** (Variant Effect Predictor) predicts the functional effects of genomic variants.


### PR DESCRIPTION
Docker badge is currently showing:
![image](https://user-images.githubusercontent.com/3199157/155516578-57884519-afa4-4aac-91db-5b162de9409e.png)

Probably using a deprecated API. Other Docker build badges can be seen here: https://shields.io/category/build