### PR TITLE
Updating .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ addons:
       - mysql-client-core-5.6
 
 before_install:
-  - export ENSEMBL_BRANCH=master
+  - export ENSEMBL_BRANCH=main
   - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
   - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
   - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-io.git
-  - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
-  - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
+  - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
+  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
 
   - export CWD=$PWD
   - export DEPS=$HOME/dependencies


### PR DESCRIPTION
ensembl-test, ensembl and ensembl-io no longer have a master branch. 
Updated .travis.yml to use main branch