### PR TITLE
Fix QCDump failing for regions not available in otherfeatures

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
@@ -240,7 +240,14 @@ sub check_dirs {
 
   # check for dirs that don't appear in this list of slices
   delete($dirs_in_cache{$_->seq_region_name}) for @slices;
-  die("ERROR: Found ".(scalar keys %dirs_in_cache)." dirs in cache that have no corresponding slice\n") if scalar keys %dirs_in_cache;
+
+  my $n_dirs_in_cache = scalar keys %dirs_in_cache;
+  if ( $n_dirs_in_cache ) {
+    my @seqlevel_slices = @{$sa->fetch_all('seqlevel')};
+    delete($dirs_in_cache{$_->seq_region_name}) for @seqlevel_slices;
+    die("ERROR: Found ".(scalar keys %dirs_in_cache)." dirs in cache that have no corresponding slice\n") if scalar keys %dirs_in_cache;
+    warn("WARNING: Found $n_dirs_in_cache dirs in cache that have no corresponding features in database\n");
+  }
 
   # now filter out slices with no transcripts
   my $ta = $dba->get_TranscriptAdaptor();


### PR DESCRIPTION
Solves [ENSVAR-4737](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4737) problem for the MT region of _Macaca mulatta_.

After dumping the VEP cache, [QCDump.pm](https://github.com/Ensembl/ensembl-vep/blob/master/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm) checks if the cache directory names exist as sequence region names reported from the **otherfeatures** database. However, this fails if the directory cache exists only in the **core database** but not in **otherfeatures**. The quality control check should gracefully handle such cases.

This PR brings the following enhancement: in case of failing the check because the directory does not exist in **otherfeatures**, check all available sequence regions using **seqlevel** (that lists all sequence regions names) instead of **toplevel** (that excludes sequence regions for which there are no features).

If the directory does not exist in **seqlevel**, return an error. Otherwise, just return a warning stating that the directory was not found when comparing against **toplevel** 