### PR TITLE
Sanity check for VEP cli options

### DIFF
--- a/vep
+++ b/vep
@@ -222,6 +222,7 @@ $config->{output_file}=@{$config->{output_file}}[0] if ($config->{output_file});
 &usage && exit(0) if (!$arg_count) || $config->{help};
 
 $config->{database} ||= 0;
+
 my $runner = Bio::EnsEMBL::VEP::Runner->new($config);
 
 if($config->{show_cache_info}) {

--- a/vep
+++ b/vep
@@ -114,7 +114,7 @@ GetOptions(
   
   # output options
   'everything|e',            # switch on EVERYTHING :-)
-  'output_file|o=s',         # output file name
+  'output_file|o=s@',         # output file name
   'compress_output=s',       # compress output with e.g. bgzip, gzip
   'no_headers',              # don't print headers
   'stats_file|sf=s',         # stats file name
@@ -217,10 +217,11 @@ GetOptions(
   'debug',                   # print out debug info
 ) or die "ERROR: Failed to parse command-line flags\n";
 
+die "ERROR: More than one output file command-line flag provided\n" unless (scalar @{$config->{output_file}} <= 1);
+$config->{output_file}=@{$config->{output_file}}[0] if ($config->{output_file});
 &usage && exit(0) if (!$arg_count) || $config->{help};
 
 $config->{database} ||= 0;
-
 my $runner = Bio::EnsEMBL::VEP::Runner->new($config);
 
 if($config->{show_cache_info}) {

--- a/vep
+++ b/vep
@@ -217,8 +217,8 @@ GetOptions(
   'debug',                   # print out debug info
 ) or die "ERROR: Failed to parse command-line flags\n";
 
-die "ERROR: More than one output file command-line flag provided\n" unless (scalar @{$config->{output_file}} <= 1);
-$config->{output_file}=@{$config->{output_file}}[0] if ($config->{output_file});
+warn("WARNING: More than one output file command-line flag provided. Using the last value provided\n") unless (scalar @{$config->{output_file}} <= 1);
+$config->{output_file}=@{$config->{output_file}}[-1] if ($config->{output_file});
 &usage && exit(0) if (!$arg_count) || $config->{help};
 
 $config->{database} ||= 0;


### PR DESCRIPTION
Ticket: [ENSVAR-1097](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-1097)
Related issue: [197](https://github.com/Ensembl/ensembl-vep/issues/197)

When VEP is run with multiple output_file (-o) options, this PR throws a warning and takes the latest option provided.
For example,
```
vep --force_overwrite -i input.vcf --database --assembly GRCh38 -o a.txt -o c.txt
```
```
WARNING: More than one output file command-line flag provided. Using the last value provided
```