### PR TITLE
Discard references to 107 in release 106

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -52,7 +52,7 @@ use warnings;
 
 use base qw(Exporter);
 
-our $VEP_VERSION     = 107;
+our $VEP_VERSION     = 106;
 our $VEP_SUB_VERSION = 0;
 
 our @EXPORT_OK = qw(

--- a/t/test-genome-DBs/homo_vepiens/core/table.sql
+++ b/t/test-genome-DBs/homo_vepiens/core/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=939 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=937 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -776,7 +776,6 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
-  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/t/test-genome-DBs/homo_vepiens/funcgen/table.sql
+++ b/t/test-genome-DBs/homo_vepiens/funcgen/table.sql
@@ -381,7 +381,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=781 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=777 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/t/test-genome-DBs/homo_vepiens/otherfeatures/table.sql
+++ b/t/test-genome-DBs/homo_vepiens/otherfeatures/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=883 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=881 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -776,7 +776,6 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
-  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/t/test-genome-DBs/homo_vepiens/variation/table.sql
+++ b/t/test-genome-DBs/homo_vepiens/variation/table.sql
@@ -186,7 +186,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=163 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=161 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -549,7 +549,7 @@ CREATE TABLE `transcript_variation` (
   `feature_stable_id` varchar(128) DEFAULT NULL,
   `allele_string` text,
   `somatic` tinyint(1) NOT NULL DEFAULT '0',
-  `consequence_types` set('splice_acceptor_variant','splice_donor_variant','stop_lost','coding_sequence_variant','missense_variant','stop_gained','synonymous_variant','frameshift_variant','non_coding_transcript_variant','non_coding_transcript_exon_variant','mature_miRNA_variant','NMD_transcript_variant','5_prime_UTR_variant','3_prime_UTR_variant','incomplete_terminal_codon_variant','intron_variant','splice_region_variant','downstream_gene_variant','upstream_gene_variant','start_lost','stop_retained_variant','inframe_insertion','inframe_deletion','transcript_ablation','transcript_fusion','transcript_amplification','transcript_translocation','TFBS_ablation','TFBS_fusion','TFBS_amplification','TFBS_translocation','regulatory_region_ablation','regulatory_region_fusion','regulatory_region_amplification','regulatory_region_translocation','feature_elongation','feature_truncation','protein_altering_variant','start_retained_variant','splice_donor_5th_base_variant','splice_donor_region_variant','splice_polypyrimidine_tract_variant') DEFAULT NULL,
+  `consequence_types` set('splice_acceptor_variant','splice_donor_variant','stop_lost','coding_sequence_variant','missense_variant','stop_gained','synonymous_variant','frameshift_variant','non_coding_transcript_variant','non_coding_transcript_exon_variant','mature_miRNA_variant','NMD_transcript_variant','5_prime_UTR_variant','3_prime_UTR_variant','incomplete_terminal_codon_variant','intron_variant','splice_region_variant','downstream_gene_variant','upstream_gene_variant','start_lost','stop_retained_variant','inframe_insertion','inframe_deletion','transcript_ablation','transcript_fusion','transcript_amplification','transcript_translocation','feature_elongation','feature_truncation','protein_altering_variant','start_retained_variant') DEFAULT NULL,
   `cds_start` int(11) unsigned DEFAULT NULL,
   `cds_end` int(11) unsigned DEFAULT NULL,
   `cdna_start` int(11) unsigned DEFAULT NULL,
@@ -626,7 +626,7 @@ CREATE TABLE `variation_feature` (
   `map_weight` int(11) NOT NULL,
   `flags` set('genotyped') DEFAULT NULL,
   `source_id` int(10) unsigned NOT NULL,
-  `consequence_types` set('intergenic_variant','splice_acceptor_variant','splice_donor_variant','stop_lost','coding_sequence_variant','missense_variant','stop_gained','synonymous_variant','frameshift_variant','non_coding_transcript_variant','non_coding_transcript_exon_variant','mature_miRNA_variant','NMD_transcript_variant','5_prime_UTR_variant','3_prime_UTR_variant','incomplete_terminal_codon_variant','intron_variant','splice_region_variant','downstream_gene_variant','upstream_gene_variant','start_lost','stop_retained_variant','inframe_insertion','inframe_deletion','transcript_ablation','transcript_fusion','transcript_amplification','transcript_translocation','TFBS_ablation','TFBS_fusion','TFBS_amplification','TFBS_translocation','regulatory_region_ablation','regulatory_region_fusion','regulatory_region_amplification','regulatory_region_translocation','feature_elongation','feature_truncation','regulatory_region_variant','TF_binding_site_variant','protein_altering_variant','start_retained_variant','splice_donor_5th_base_variant','splice_donor_region_variant','splice_polypyrimidine_tract_variant') NOT NULL DEFAULT 'intergenic_variant',
+  `consequence_types` set('intergenic_variant','splice_acceptor_variant','splice_donor_variant','stop_lost','coding_sequence_variant','missense_variant','stop_gained','synonymous_variant','frameshift_variant','non_coding_transcript_variant','non_coding_transcript_exon_variant','mature_miRNA_variant','NMD_transcript_variant','5_prime_UTR_variant','3_prime_UTR_variant','incomplete_terminal_codon_variant','intron_variant','splice_region_variant','downstream_gene_variant','upstream_gene_variant','start_lost','stop_retained_variant','inframe_insertion','inframe_deletion','transcript_ablation','transcript_fusion','transcript_amplification','transcript_translocation','TFBS_ablation','TFBS_fusion','TFBS_amplification','TFBS_translocation','regulatory_region_ablation','regulatory_region_fusion','regulatory_region_amplification','regulatory_region_translocation','feature_elongation','feature_truncation','regulatory_region_variant','TF_binding_site_variant','protein_altering_variant','start_retained_variant') NOT NULL DEFAULT 'intergenic_variant',
   `variation_set_id` set('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','28','29','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','59','60','61','62','63','64') NOT NULL DEFAULT '',
   `class_attrib_id` int(10) unsigned DEFAULT '0',
   `somatic` tinyint(1) NOT NULL DEFAULT '0',

--- a/t/test-genome-DBs/homo_vepiens_coreonly/core/table.sql
+++ b/t/test-genome-DBs/homo_vepiens_coreonly/core/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=939 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=937 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -776,7 +776,6 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
-  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/t/test-genome-DBs/multi/ontology/table.sql
+++ b/t/test-genome-DBs/multi/ontology/table.sql
@@ -139,7 +139,7 @@ CREATE TABLE `meta` (
   `species_id` int(1) unsigned DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `key_value_idx` (`meta_key`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=55 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=54 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `ontology` (
   `ontology_id` int(10) unsigned NOT NULL AUTO_INCREMENT,

--- a/t/test-genome-DBs/mus_muscuvep/core/meta.txt
+++ b/t/test-genome-DBs/mus_muscuvep/core/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	core
-2	\N	schema_version	107
+2	\N	schema_version	106
 3	\N	patch	patch_65_66_a.sql|schema_version
 4	\N	patch	patch_65_66_b.sql|fix_external_db_id
 5	\N	patch	patch_65_66_c.sql|reorder_unmapped_obj_index
@@ -198,5 +198,3 @@
 1876	\N	patch	patch_103_104_a.sql|schema_version
 1877	\N	patch	patch_104_105_a.sql|schema_version
 1878	\N	patch	patch_105_106_a.sql|schema_version
-1879	\N	patch	patch_106_107_a.sql|schema_version
-1880	\N	patch	patch_106_107_b.sql|Added index for seq_region_mapping

--- a/t/test-genome-DBs/mus_muscuvep/core/table.sql
+++ b/t/test-genome-DBs/mus_muscuvep/core/table.sql
@@ -490,7 +490,7 @@ CREATE TABLE `meta` (
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1881 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1879 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,
@@ -776,7 +776,6 @@ CREATE TABLE `seq_region_mapping` (
   `external_seq_region_id` int(10) unsigned NOT NULL,
   `internal_seq_region_id` int(10) unsigned NOT NULL,
   `mapping_set_id` int(10) unsigned NOT NULL,
-  UNIQUE KEY `seq_region_mapping_uindex` (`external_seq_region_id`,`internal_seq_region_id`,`mapping_set_id`),
   KEY `mapping_set_idx` (`mapping_set_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
Based on issue #1153

Running `prove -v t/*.t` returns no errors after these changes.