### PR TITLE
Get biotype from GFF's transcript_biotype attribute

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
@@ -210,7 +210,8 @@ sub _record_get_id {
   Arg 2      : hashref $gene_record_hash
   Example    : $biotype = $as->_record_get_biotype($tr_record, $gene_record);
   Description: Get sequence ontology (SO) biotype of this record. Attempts to
-               find it in the "biotype" or "transcript_type" attribute fields,
+               find it in the "biotype", "transcript_type" or
+               "transcript_biotype" attribute fields,
                and if that fails (as it will for RefSeq GFFs), make an
                educated guess looking at the record type and various other
                attributes.
@@ -227,7 +228,9 @@ sub _record_get_biotype {
   if(!exists($record->{_biotype})) {
 
     # Ensembl-y GFFs have biotype as an attribute
-    my $biotype = $record->{attributes}->{biotype} || $record->{attributes}->{transcript_type};
+    my $biotype = $record->{attributes}->{biotype} ||
+                  $record->{attributes}->{transcript_type} ||
+                  $record->{attributes}->{transcript_biotype};
 
     # others we need to (guess) work it out
     if(!$biotype) {


### PR DESCRIPTION
[ENSVAR-4310](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4310): for the new Ensembl GFF format, we may rename the current **biotype** attribute as **transcript_biotype**. This PR allows to support that potential change.

Also resolves #868 that asks to support this attribute in GFFs for consistency with GTF  file parsing. This way, parsing both GTF and GFF files will allow us to get transcript biotypes based on one of these attributes: **biotype**, **transcript_type** or **transcript_biotype**.

(Should I include a unit test for this change?)

## Testing

Input:
-  [Sample GFF input.zip](https://github.com/Ensembl/ensembl-vep/files/8532618/Sample.GFF.input.zip): two Tabix-indexed human annotations for chromosomes 21 and 22. One of the annotations has biotype attributes named as `biotype` and the other as `transcript_biotype`.
- [Sample VCF file](https://github.com/Ensembl/ensembl-vep/blob/master/examples/homo_sapiens_GRCh38.vcf)

Use argument `--biotype` in VEP to print the transcript biotype that can be compared with the annotation file:

```
perl $vep --i homo_sapiens_GRCh38.vcf \
          --o out.vep \
          --cache --dir_cache $cache \
          --offline \
          --biotype \
          --gff $gff
```