### PR TITLE
refactor: bad --species homo_sapiens usage

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/CacheDir.pm
+++ b/modules/Bio/EnsEMBL/VEP/CacheDir.pm
@@ -302,6 +302,8 @@ sub dir {
 
     # complete dir with species name and db_version
     my $species_dir_name = $self->species();
+    throw("Should not use ${species_dir_name} as --species.\nTry using flags --refseq or --merged with --species homo_sapiens\n") if
+    ${species_dir_name} eq "homo_sapiens_refseq" || ${species_dir_name} eq "homo_sapiens_merged";
     $species_dir_name .= '_'.$_ for grep { $self->param($_) } qw(refseq merged);
 
     # add species dir name

--- a/t/CacheDir.t
+++ b/t/CacheDir.t
@@ -105,6 +105,13 @@ throws_ok {
   })->dir()
 } qr/Cache directory .+ not found/, 'new with invalid species';
 
+throws_ok { 
+  Bio::EnsEMBL::VEP::CacheDir->new({
+    root_dir => $cfg_hash->{dir},
+    config => Bio::EnsEMBL::VEP::Config->new({%$cfg_hash, species => 'homo_sapiens_refseq'})
+  })->dir()
+} qr/Should not use .+ as --species.\nTry using flags --refseq or --merged with --species homo_sapiens\n/, 'Not allow homo_sapiens_refseq / homo_sapiens_merged';
+
 throws_ok {
   Bio::EnsEMBL::VEP::CacheDir->new({
     root_dir => $cfg_hash->{dir},


### PR DESCRIPTION
Jira: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4861)

## Description

An user (https://github.com/Ensembl/ensembl-vep/issues/1180) was successfully able to  run `vep --species homo_sapiens_refseq` without getting any error. This behavior created a bad annotated VCF as a result.
This PR was created to not allow users using specifically `--species homo_sapiens_merged` or `--species homo_sapiens_refseq`.

## Test

1) Try using vep with and without `--species homo_sapiens_refseq` and see if it errors pop out.