### PR TITLE
Creating temp_dir before running pipeline should be mandatory

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
@@ -108,7 +108,9 @@ sub run {
     
     my $tmp_dir = $self->param('tmp_dir');
     
-    mkdir($tmp_dir) unless -e $tmp_dir;
+    unless(-e $tmp_dir){
+      mkdir($tmp_dir) or die "Cannot create temp_dir - $!";
+    }
    
     foreach my $chr(keys %{{map {$_->{chr} => 1} @{$self->param('regions')}}}) {
 


### PR DESCRIPTION
Die if temp_dir creation fails. In some cases, temp_dir creation may fail, for example, in case it needs to be created recursively. We currently made it mandatory pre-requisite to create temp_dir before running pipeline instead of handling it on the code -

https://www.ebi.ac.uk/seqdb/confluence/display/EV/VEP+dumps#VEPdumps-Pre-requisites

JIRA - https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4860 