### PR TITLE
catch unexpected extra command-line parameters at run time

### DIFF
--- a/vep
+++ b/vep
@@ -217,6 +217,8 @@ GetOptions(
   'debug',                   # print out debug info
 ) or die "ERROR: Failed to parse command-line flags\n";
 
+die("ERROR: Unexpected extra command-line parameter(s): " . join(", ", @ARGV)) if scalar @ARGV;
+
 warn("WARNING: More than one output file command-line flag provided. Using the last value provided: '@{$config->{output_file}}[-1]' \n") unless (scalar @{$config->{output_file}} <= 1);
 $config->{output_file}=@{$config->{output_file}}[-1] if ($config->{output_file});
 &usage && exit(0) if (!$arg_count) || $config->{help};


### PR DESCRIPTION
GetOptions doesn't seem to care about anything left hanging in `@ARGV`, so if a user inadvertently adds an additional parameter (e.g. adding a value to a param that doesn't ask for one like `--cache`) this will get left in `@ARGV`.

In most cases this will be harmless, but if using the LOFTEE plugin the [score3.pl](https://github.com/konradjk/loftee/blob/master/maxEntScan/score3.pl) script tries to open `$ARGV[0]` and dies with a difficult to trace error message.

I don't see any test file for `vep` itself; the following command will cause the die to trigger:

```vep --cache 99```