### PR TITLE
Include protein_coding_gene in the GFF inclusion list

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
@@ -85,6 +85,7 @@ my %INCLUDE_FEATURE_TYPES = map {$_ => 1} qw(
   NMD_transcript_variant
   processed_pseudogene
   processed_transcript
+  protein_coding_gene
   pseudogene
   pseudogenic_transcript
   RNA


### PR DESCRIPTION
[ENSVAR-5020](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5020)

### Testing

```
zcat t/testdata/custom/refseq.gff.gz \
| sed 's/\tgene\t/\tprotein_coding_gene\t/; s/NC_000021.9/21/' \
| bgzip > ../refseq2.gff.gz

tabix ../refseq2.gff.gz
```

##### Previous output
```
vep --force_overwrite -i t/testdata/input/test.vcf --gff ../refseq2.gff.gz --fasta t/testdata/fasta/Homo_sapiens.GRCh38.toplevel.test.fa 

WARNING: Parent entries with the following IDs were not found or skipped due to invalid types: gene49534, gene49532, gene49521, gene49527, gene49525, gene49522, gene49524, gene49518, gene49523, gene49537, gene49535, gene49531, gene49516, gene49536, gene49519, gene49514, gene49528, gene49513, gene49526
```

##### Current output

No warnings and VEP assigns consequences other than intergenic

