### PR TITLE
fix: use of get_all_overlapping_Peaks method

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/RegFeat.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/RegFeat.pm
@@ -221,7 +221,7 @@ sub get_features_by_regions_uncached {
         my %cl =  
           map {$_->[0] => $_->[1]}
           map {$_->[0] =~ s/ /\_/g; $_}
-          map { [$_->get_PeakCalling->get_Epigenome->name, 1] } @{$mf->get_all_overlapping_Peaks};
+          map { [$_->name, 1] } @{$mf->get_all_Epigenomes_with_experimental_evidence};
         $mf->{cell_types} = \%cl;
       }
     }


### PR DESCRIPTION
JIRA: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5135)

## Description

While running last VEP Dump this bug was found:

```sh
Can't use an undefined value as an ARRAY reference at /hps/software/users/ensembl/repositories/enseven/ensembl-vep/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/RegFeat.pm line 224.
```

## Test

1) Just need to make sure that Vep Dump it's working with new function for RegFeat.pm