### PR TITLE
Issue warnings to notify unsupported feature_types

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
@@ -236,6 +236,9 @@ sub _get_records_by_coords {
 
       push @records, $self->_record_to_hash();
     }
+    else {
+      $self->warning_msg("The feature_type ".$parser->get_type." is being skipped\n");
+    }
 
     $parser->next();
   }


### PR DESCRIPTION
[ENSVAR-5034](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5034)

This PR aims to warn users when unsupported feature_types are present in the GFF file.

### Testing
```
zcat t/testdata/custom/refseq.gff.gz \
| sed 's/\tgene\t/\tncRNA_gene\t/; s/NC_000021.9/21/' \
| bgzip > ../refseq2.gff.gz

tabix ../refseq2.gff.gz
```
```
vep --force_overwrite -i t/testdata/input/test.vcf --gff ../refseq2.gff.gz --fasta t/testdata/fasta/Homo_sapiens.GRCh38.toplevel.test.fa
```
#### Expected Output
```
WARNING: The feature_type region is being skipped
WARNING: The feature_type match is being skipped
WARNING: The feature_type ncRNA_gene is being skipped
WARNING: Parent entries with the following IDs were not found or skipped due to invalid types: gene49536, gene49532, gene49523, gene49518, gene49535, gene49516, gene49526, gene49528, gene49513, gene49519, gene49527, gene49521, gene49525, gene49534, gene49522, gene49537, gene49524, gene49514, gene49531
```