### PR TITLE
Fix gzip error for compressed input file

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Utils.pm
+++ b/modules/Bio/EnsEMBL/VEP/Utils.pm
@@ -430,17 +430,14 @@ sub get_compressed_filehandle {
   my $fh;
   if($CAN_USE_PERLIO_GZIP && !$multi) {
     eval q{ open $fh, "<:gzip", $file; };
-    warning("Opening $file failed using PerlIO::gzip\nERROR: $@\nTrying other methods..\n") if $@;
     return $fh unless $@;
   }
   if($CAN_USE_GZIP) {
     eval q{ open $fh, "gzip -dc $file |"; };
-    warning("Opening $file failed using system gzip\nERROR: $!\nTrying other methods..\n") if $!;
     return $fh unless $!;
   }
   if($CAN_USE_IO_UNCOMPRESS) {
-    eval q{ $fh = IO::Uncompress::Gunzip->new($file, MultiStream => $multi) or die("ERROR: $GunzipError"); };
-    warning("Opening $file failed using IO::Uncompress::Gunzip\n", "ERROR: $@\n") if $@;
+    eval q{ $fh = IO::Uncompress::Gunzip->new($file, MultiStream => $multi); };
     return $fh unless $@;
   }
   

--- a/modules/Bio/EnsEMBL/VEP/Utils.pm
+++ b/modules/Bio/EnsEMBL/VEP/Utils.pm
@@ -429,16 +429,16 @@ sub get_compressed_filehandle {
 
   my $fh;
   if($CAN_USE_PERLIO_GZIP && !$multi) {
-    eval q{ open $fh, "<:gzip", $file; };
-    return $fh unless $@;
+    return $fh if eval q{ open $fh, "<:gzip", $file; };
+    warn "Could not open compressed or binary file using PerlIO::gzip - $!\n";
   }
   if($CAN_USE_GZIP) {
-    eval q{ open $fh, "gzip -dc $file |"; };
-    return $fh unless $!;
+    return $fh if eval q{ open $fh, "gzip -dc $file |"; };
+    warn "Could not open compressed or binary file using system gzip - $!\n";
   }
   if($CAN_USE_IO_UNCOMPRESS) {
-    eval q{ $fh = IO::Uncompress::Gunzip->new($file, MultiStream => $multi); };
-    return $fh unless $@;
+    return $fh if eval q{ $fh = IO::Uncompress::Gunzip->new($file, MultiStream => $multi); };
+    warn "Could not open compressed or binary file using IO::Uncompress::Gunzip - $!\n";
   }
   
   die("ERROR: Cannot read from compressed or binary file\n");


### PR DESCRIPTION
[ENSVAR-4595](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4595) 

If `gzip` fails we can try the next with `IO::Uncompress::Gunzip` instead of dying. It will add greater reliability without compromising performance.