### PR TITLE
Update ftp links to https

### DIFF
--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -213,9 +213,9 @@ $FTP_USER     ||= 'anonymous';
 ## Set the indexed cache url if it's been overwritten by the user
 $CACHE_URL_INDEXED = $CACHE_URL;
 
-$CACHE_URL  ||= "ftp://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/vep";
-$CACHE_URL_INDEXED  ||= "ftp://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/indexed_vep_cache";
-$FASTA_URL  ||= "ftp://ftp.ensembl.org/pub/release-$DATA_VERSION/fasta/";
+$CACHE_URL  ||= "https://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/vep";
+$CACHE_URL_INDEXED  ||= "https://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/indexed_vep_cache";
+$FASTA_URL  ||= "https://ftp.ensembl.org/pub/release-$DATA_VERSION/fasta/";
 $PLUGIN_URL ||= 'https://raw.githubusercontent.com/Ensembl/VEP_plugins';
 
 # using PREFER_BIN can save memory when extracting archives


### PR DESCRIPTION
This PR updates all ftp URLs from `http://` and `ftp://` protocol to https.
The affected hostnames have been tested to work with https.
Other affected repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/