### PR TITLE
Improve VEP Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,6 +150,7 @@ RUN ensembl-vep/travisci/build_c.sh && \
     /usr/sbin/update-locale LANG=$LANG_VAR && \
     # Copy htslib executables. It also requires the packages 'zlib1g-dev', 'libbz2-dev' and 'liblzma-dev'
     cp $HTSLIB_DIR/bgzip $HTSLIB_DIR/tabix $HTSLIB_DIR/htsfile /usr/local/bin/ && \
+    # Delete cache from cpanm
     rm -rf /root/.cpanm
 
 ENV LC_ALL $LANG_VAR

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,3 +171,9 @@ RUN echo >> $OPT/.profile && \
 
 # Avoid update checks for VEP and Ensembl API when running INSTALL.pl
 ENV VEP_NO_UPDATE=1
+
+# Set working directory as symlink to $OPT/.vep
+USER root
+RUN ln -s $OPT/.vep /data
+USER vep
+WORKDIR /data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -149,7 +149,8 @@ RUN ensembl-vep/travisci/build_c.sh && \
     echo "$LANG_VAR UTF-8" >> /etc/locale.gen && locale-gen en_US.utf8 && \
     /usr/sbin/update-locale LANG=$LANG_VAR && \
     # Copy htslib executables. It also requires the packages 'zlib1g-dev', 'libbz2-dev' and 'liblzma-dev'
-    cp $HTSLIB_DIR/bgzip $HTSLIB_DIR/tabix $HTSLIB_DIR/htsfile /usr/local/bin/
+    cp $HTSLIB_DIR/bgzip $HTSLIB_DIR/tabix $HTSLIB_DIR/htsfile /usr/local/bin/ && \
+    rm -rf /root/.cpanm
 
 ENV LC_ALL $LANG_VAR
 ENV LANG $LANG_VAR

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -168,3 +168,6 @@ RUN echo >> $OPT/.profile && \
     echo export PATH >> $OPT/.profile && \
     # Run INSTALL.pl and remove the ensemb-vep tests and travis
     ./INSTALL.pl -a a -l -n && rm -rf t travisci .travis.yml
+
+# Avoid update checks for VEP and Ensembl API when running INSTALL.pl
+ENV VEP_NO_UPDATE=1


### PR DESCRIPTION
* [ENSVAR-4082](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4082) and #981
  * Remove `.cpanm` cache for root (not required to run VEP)
  * Reduces image size from 787MB to 665MB
* [ENSVAR-5183](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5183)
  * Automatically skip update checks for VEP and Ensembl API when running `INSTALL.pl`
* [ENSVAR-5184](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5184)
  * Change default working directory to `/data`

### Testing

1. Build a Docker image with the Dockerfile from this PR, e.g., `docker build -t vep .` (replace `ENV BRANCH main` with `ENV BRANCH release/109` in the Dockerfile, otherwise you won't be able to test skipping of update checks when running `INSTALL.pl`)
2. Run `docker run -ti vep` and check if `pwd` is `/data`
3. When running simply the command `INSTALL.pl`, script should automatically skip the first question about updating VEP and Ensembl API
4. Pull latest VEP Docker image from Docker Hub
5. Check if image size is reduced using `docker images`
6. You can try running VEP in both images and comparing their output, it should be the same for the same command