### PR TITLE
Fix config file parsing

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -761,7 +761,7 @@ sub read_config_from_file {
     # preserve spaces between quotes
     s/([\"\'].*)(\s)(.*[\"\'])/$1\_\_\_SPACE\_\_\_$3/g;
 
-    my @split = split /\s+|\=/;
+    my @split = split /\s+/;
     my $key = shift @split;
     $key =~ s/^\-//g;
 
@@ -772,7 +772,7 @@ sub read_config_from_file {
     s/[\"\']//g for @split;
 
     if(grep {$key eq $_} @ALLOW_MULTIPLE) {
-      push @{$config->{$key}}, join('', @split);
+      push @{$config->{$key}}, join(' ', @split);
     }
     else {
       $config->{$key} ||= $split[0];

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -772,7 +772,7 @@ sub read_config_from_file {
     s/[\"\']//g for @split;
 
     if(grep {$key eq $_} @ALLOW_MULTIPLE) {
-      push @{$config->{$key}}, @split;
+      push @{$config->{$key}}, join('', @split);
     }
     else {
       $config->{$key} ||= $split[0];

--- a/t/Config.t
+++ b/t/Config.t
@@ -59,10 +59,10 @@ is($tmp->{test1}, 'hello', 'read_config_from_file basic');
 is($tmp->{test2}, 'foo bar', 'quoted string with spaces');
 is($tmp->{test3}, 'foo', 'read_config_from_file flag not allowed multiple');
 is($tmp->{individual}, 'dave,barry', 'read_config_from_file flag list preserved comma-separated');
-is_deeply($tmp->{plugin}, [qw(foo bar too)], 'read_config_from_file flag allowed multiple');
+is_deeply($tmp->{plugin}, [qw(hello,foo=bar too)], 'read_config_from_file flag allowed multiple');
 
 $cfg->read_config_from_file($test_cfg->{test_ini_file}, $tmp);
-is_deeply($tmp->{plugin}, [qw(foo bar too foo bar too)], 'read_config_from_file flag multiples added not overwritten');
+is_deeply($tmp->{plugin}, [qw(hello,foo=bar too hello,foo=bar too)], 'read_config_from_file flag multiples added not overwritten');
 
 
 

--- a/t/testdata/vep.ini
+++ b/t/testdata/vep.ini
@@ -1,6 +1,6 @@
 test1	hello
 test2	"foo bar"
-test3	foo	bar
-plugin	foo	bar
+test3	foo bar
+plugin	hello,foo=bar
 plugin	too
 individual	dave,barry


### PR DESCRIPTION
**Issue**

When given config file to VEP it parses the parameters by whitespace and = , but in our doc says the key value pair are whitespace seprated - https://www.ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_config 

Moreover splitting by = has problem with plugins like IntAct and SpliceAI as they have = in their args - 
```
plugin IntAct,mutation_file=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e108/vep/plugin_data/mutations.tsv,mapping_file=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e107/vep/plugin_data/mutation_gc_map.txt.gz,pmid=1
plugin SpliceAI,snv=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e108/vep/plugin_data/spliceai_scores.masked.snv.hg38.vcf.gz,indel=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e107/vep/plugin_data/spliceai_scores.masked.indel.hg38.vcf.gz
```

It will split up the value part and thus corrupt the parameter.

**Solution**
Remove = as delimiter.

**Test Example**
config file
```
force_overwrite 1 
species homo_sapiens 
cache_version 108
assembly GRCh38
dir_cache /nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted 
cache 1
fasta /nfs/production/flicek/ensembl/variation/data/Homo_sapiens.GRCh38.dna.toplevel.fa.gz
dir_plugins /hps/software/users/ensembl/repositories/snhossain/VEP_plugins
plugin SpliceAI,snv=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e108/vep/plugin_data/spliceai_scores.masked.snv.hg38.vcf.gz,indel=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e107/vep/plugin_data/spliceai_scores.masked.indel.hg38.vcf.gz
plugin Conservation,mammals
plugin IntAct,mutation_file=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e108/vep/plugin_data/mutations.tsv,mapping_file=/nfs/production/flicek/ensembl/variation/enseweb-data_tools/grch38/e107/vep/plugin_data/mutation_gc_map.txt.gz,pmid=1
```

input 
```
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO                              
1	65568	.	A	C	.	.	.
2	265023	.	C	T	.	.	.
3	319780	.	GA	G	.	.	.
1	95244265	.	T	C	.	.	.
4	89828156	rs201106962	A	C	.	.	.
13	32316497	.	G	T	.	.	.
```