### PR TITLE
feat: Integrate SVO plugin to VEP - add PC field

### DIFF
--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -260,9 +260,9 @@ $FTP_USER     ||= 'anonymous';
 ## Set the indexed cache url if it's been overwritten by the user
 $CACHE_URL_INDEXED = $CACHE_URL;
 
-$CACHE_URL  ||= "ftp://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/vep";
-$CACHE_URL_INDEXED  ||= "ftp://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/indexed_vep_cache";
-$FASTA_URL  ||= "ftp://ftp.ensembl.org/pub/release-$DATA_VERSION/fasta/";
+$CACHE_URL  ||= "https://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/vep";
+$CACHE_URL_INDEXED  ||= "https://ftp.ensembl.org/pub/release-$DATA_VERSION/variation/indexed_vep_cache";
+$FASTA_URL  ||= "https://ftp.ensembl.org/pub/release-$DATA_VERSION/fasta/";
 $PLUGIN_URL ||= 'https://raw.githubusercontent.com/Ensembl/VEP_plugins';
 
 # using PREFER_BIN can save memory when extracting archives

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -359,11 +359,11 @@ sub annotate_VariationFeature {
         }   
       }
     } else {
-      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep "/^PC$/", $self->{fields});
+      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep {$_ eq "PC"} @{$self->{fields}});
       push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
     }
   } else {
-    $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep "/^PC$/", $self->{fields});
+    $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep {$_ eq "PC"} @{$self->{fields}});
     push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
   }
   

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -361,6 +361,7 @@ sub annotate_VariationFeature {
     }
     else
     {
+      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if grep $_ eq "PC", $self->fields;
       push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
     }
   }

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -359,11 +359,11 @@ sub annotate_VariationFeature {
         }   
       }
     } else {
-      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if ($self->fields && grep $_ eq "PC", $self->fields);
+      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep $_ eq "PC", $self->fields);
       push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
     }
   } else {
-    $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if ($self->fields && grep $_ eq "PC", $self->fields);
+    $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep $_ eq "PC", $self->fields);
     push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
   }
   

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -359,11 +359,11 @@ sub annotate_VariationFeature {
         }   
       }
     } else {
-      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep $_ eq "PC", $self->fields);
+      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep "/^PC$/", $self->{fields});
       push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
     }
   } else {
-    $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep $_ eq "PC", $self->fields);
+    $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if (defined($self->{fields}) && grep "/^PC$/", $self->{fields});
     push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
   }
   
@@ -446,7 +446,7 @@ sub _record_overlaps_VF {
     my @overlap_start = sort { $a <=> $b } ($vs, $parser->get_start);
     my @overlap_end   = sort { $a <=> $b } ($ve, $parser->get_end);
 
-    my $overlap_percentage = 100 * (1+ $overlap_end[0]  - $overlap_start[1])/ $length;
+    my $overlap_percentage = sprintf("%.3f", 100 * (1+ $overlap_end[0]  - $overlap_start[1])/ $length);
     
     return overlap($parser->get_start, $parser->get_end, $vs, $ve), $overlap_percentage;
   }

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -345,25 +345,28 @@ sub annotate_VariationFeature {
   my $vf = shift;
 
   my ($overlap_percentage, $overlap_result) = $self->_record_overlaps_VF($vf);
+
   return if $overlap_percentage < 80;
-  if ($overlap_result && @{$self->_create_records($overlap_result)}[0]->{'name'} =~  /^COSV/) {
-    my ($matched_cosmic_record) = grep{$_->{'name'} eq @{$self->_create_records($overlap_result)}[0]->{'name'}} @{$vf->{_custom_annotations}->{$self->short_name}};
+
+  my $record = $self->_create_records($overlap_result);
+
+  if ($overlap_result && @{$record}[0]->{'name'} =~  /^COSV/) {
+    my ($matched_cosmic_record) = grep{$_->{'name'} eq @{$record}[0]->{'name'}} @{$vf->{_custom_annotations}->{$self->short_name}};
     if ($matched_cosmic_record){
-      foreach my $key (keys %{@{$self->_create_records($overlap_result)}[0]->{'fields'}}) {
+      foreach my $key (keys %{@{$record}[0]->{'fields'}}) {
         unless (exists $matched_cosmic_record->{'fields'}->{$key}) {
-          $matched_cosmic_record->{'fields'}{$key} = @{$self->_create_records($overlap_result)}[0]->{'fields'}->{$key};
+          $matched_cosmic_record->{'fields'}{$key} = @{$record}[0]->{'fields'}->{$key};
         }   
       }
     }
     else
     {
-      push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$self->_create_records($overlap_result)};
+      push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
     }
   }
   else {
     if ($overlap_result){
-      my $record = $self->_create_records($overlap_result);
-      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage;
+      $record->[0]->{"fields"}->{"PC"} = $overlap_percentage if grep $_ eq "PC", $self->fields;
       push @{$vf->{_custom_annotations}->{$self->short_name}}, @{$record};
     }
   }

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -167,8 +167,6 @@ sub new {
     return $class->new({%$hashref, config => $self->config});
   }
 
-  push $self->{fields}, "PC";
-
   return $self;
 }
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -2302,6 +2302,11 @@ sub get_custom_headers {
       if (grep { /^$sub_id$/ } @flatten_header){
         my $pos = $pos{$sub_id} / 2;
         $headers[$pos][1] .= ",$custom->{file}";
+      } elsif ($field eq "PC") {
+        push @headers, [
+          $sub_id,
+          sprintf("Percentage of input variant covered by reference variant from %s", $custom->{file})
+        ];
       } else {
         push @headers, [
           $sub_id,


### PR DESCRIPTION
Jira: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5028)

## Description

[StructuralVariationOverlap](https://github.com/Ensembl/VEP_plugins/blob/release/107/StructuralVariantOverlap.pm) plugin retrieves information from overlapping structural variants. Output should have percentage (PC) + allele frequency (AF) if exists. Using vep `--custom`, we can already retrieve AF information easily, but percentage will not be calculated. This PR is meant to add PC information by default into SV custom overlap usage.

## Test

1) Use `--custom` with and without `PC` as a field. For example:
```sh
vep ... --custom gnomad_chr22.vcf.gz,prefix,vcf,overlap,0,PC,info_columns
vep ... --custom gnomad_chr22.vcf.gz,prefix,vcf,overlap,0,info_columns
```