### PR TITLE
Fix `--mirna` returning miRNA structures for all ncRNAs

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1487,7 +1487,9 @@ sub BaseTranscriptVariationAllele_to_output_hash {
   }
 
   # miRNA structure
-  if($self->{mirna} && (my ($mirna_attrib) = grep {$_->code eq 'ncRNA'} @attribs)) {
+  if($self->{mirna} && $tr->biotype eq 'miRNA' &&
+     (my ($mirna_attrib) = grep {$_->code eq 'ncRNA'} @attribs)) {
+
     my ($start, $end, $struct) = split /\s+|\:/, $mirna_attrib->value;
 
     my ($cdna_start, $cdna_end) = ($tv->cdna_start, $tv->cdna_end);
@@ -1497,7 +1499,6 @@ sub BaseTranscriptVariationAllele_to_output_hash {
       $start && $end && $cdna_start && $cdna_end &&
       overlap($start, $end, $cdna_start, $cdna_end)
     ) {
-
       # account for insertions
       ($cdna_start, $cdna_end) = ($cdna_end, $cdna_start) if $cdna_start > $cdna_end;
     


### PR DESCRIPTION
Fixes #1278:  when running `--mirna`, it is currently displaying miRNA structures for any ncRNA, even if they are not miRNA.

Test these variants using `vep --id [rsID] --mirna --cache [cache_dir]`:
* rs569478349 that falls within a miRNA (`ENST00000577608`) and should return `miRNA=miRNA_stem`
* rs150964208 that falls within a ncRNA (that is not miRNA, `ENST00000384439`) and shouldn't return any miRNA structure (it was returning `miRNA=miRNA_loop` before)