### PR TITLE
Some re-factoring on nextflow vep

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -73,6 +73,7 @@ The following config files are used and can be modified depending on user requir
   --vep_config FILENAME   VEP config file. Default: nf_config/vep.ini
   --chros LIST_OF_CHROS   Comma-separated list of chromosomes to generate. i.e. 1,2,..., Default: 1,2,...X,Y,MT
   --cpus INT              Number of CPUs to use. Default 1.
+  --output_prefix         Output filename prefix. The generated output file will have name <output_prefix>.vcf.gz
 ```
 NB: File paths are expected to be absolute paths.
 

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -68,12 +68,12 @@ The following config files are used and can be modified depending on user requir
 #### Options
 
 ```bash
-  --vcf VCF               VCF that will be split. Currently supports sorted and bgzipped file
-  --outdir DIRNAME        Name of output dir. Default: outdir
-  --vep_config FILENAME   VEP config file. Default: nf_config/vep.ini
-  --chros LIST_OF_CHROS   Comma-separated list of chromosomes to generate. i.e. 1,2,..., Default: 1,2,...X,Y,MT
-  --cpus INT              Number of CPUs to use. Default 1.
-  --output_prefix         Output filename prefix. The generated output file will have name <output_prefix>.vcf.gz
+  --vcf VCF                         VCF that will be split. Currently supports sorted and bgzipped file
+  --outdir DIRNAME                  Name of output dir. Default: outdir
+  --vep_config FILENAME             VEP config file. Default: nf_config/vep.ini
+  --chros LIST_OF_CHROS             Comma-separated list of chromosomes to generate. i.e. 1,2,..., Default: 1,2,...X,Y,MT
+  --cpus INT                        Number of CPUs to use. Default 1.
+  --output_prefix FILENAME_PREFIX   Output filename prefix. The generated output file will have name <output_prefix>.vcf.gz
 ```
 NB: File paths are expected to be absolute paths.
 

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -72,6 +72,7 @@ The following config files are used and can be modified depending on user requir
   --outdir DIRNAME                  Name of output dir. Default: outdir
   --vep_config FILENAME             VEP config file. Default: nf_config/vep.ini
   --chros LIST_OF_CHROS             Comma-separated list of chromosomes to generate. i.e. 1,2,..., Default: 1,2,...X,Y,MT
+  --chros_file LIST_OF_CHROS_FILE   Path to file containing list of chromosomes
   --cpus INT                        Number of CPUs to use. Default 1.
   --output_prefix FILENAME_PREFIX   Output filename prefix. The generated output file will have name <output_prefix>.vcf.gz
 ```

--- a/nextflow/nf_config/nextflow.config
+++ b/nextflow/nf_config/nextflow.config
@@ -37,3 +37,4 @@ profiles {
 params.chros_default = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
 //params.chros_file = "$PWD/examples/clinvar-testset/chros.txt"
 params.vep_config = "$PWD/nf_config/vep.ini"
+params.output_prefix = ""

--- a/nextflow/nf_config/nextflow.config
+++ b/nextflow/nf_config/nextflow.config
@@ -34,6 +34,6 @@ profiles {
   }  
 }
 
-params.chros = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
+params.chros_default = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
 //params.chros_file = "$PWD/examples/clinvar-testset/chros.txt"
 params.vep_config = "$PWD/nf_config/vep.ini"

--- a/nextflow/nf_config/nextflow.config
+++ b/nextflow/nf_config/nextflow.config
@@ -34,7 +34,6 @@ profiles {
   }  
 }
 
-params.chros_default = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
 //params.chros_file = "$PWD/examples/clinvar-testset/chros.txt"
 params.vep_config = "$PWD/nf_config/vep.ini"
 params.output_prefix = ""

--- a/nextflow/nf_config/nextflow.config
+++ b/nextflow/nf_config/nextflow.config
@@ -34,6 +34,7 @@ profiles {
   }  
 }
 
+//params.chros = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
 //params.chros_file = "$PWD/examples/clinvar-testset/chros.txt"
 params.vep_config = "$PWD/nf_config/vep.ini"
 params.output_prefix = ""

--- a/nextflow/nf_modules/merge_chros_VCF.nf
+++ b/nextflow/nf_modules/merge_chros_VCF.nf
@@ -9,6 +9,9 @@ nextflow.enable.dsl=2
 // defaults
 prefix = "out"
 mergedVCF = "merged-file"
+if ( params.output_prefix != "" ){
+  mergedVCF = params.output_prefix
+}
 params.outdir = ""
 params.cpus = 1
 

--- a/nextflow/nf_modules/read_chros_VCF.nf
+++ b/nextflow/nf_modules/read_chros_VCF.nf
@@ -32,6 +32,6 @@ process readChrVCF {
 
   shell:
   """
-  bcftools view -h ${vcf} | zgrep '##contig=<ID' |cut -d',' -f1| cut -d'=' -f3| cut -d'>' -f1 > scaffolds.txt 
+  tabix ${vcf} -l > scaffolds.txt 
   """
 }

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -16,6 +16,8 @@ params.vep_config=""
 params.chros=""
 params.chros_file=""
 
+chros_default = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
+
 // module imports
 include { splitVCF } from '../nf_modules/split_into_chros.nf' 
 include { mergeVCF } from '../nf_modules/merge_chros_VCF.nf'  
@@ -103,8 +105,7 @@ workflow {
   
   if( chr.equals("") ){
     log.info 'Taking default chromosome values'
-    chr_str = params.chros_default.toString()
-    chr = Channel.of(chr_str.split(','))
+    chr = Channel.of(chros_default.split(','))
   }
   
   splitVCF(chr, params.vcf, vcf_index)

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -59,13 +59,18 @@ if(check_bgzipped.exitValue()){
 }
 
 def sout = new StringBuilder(), serr = new StringBuilder()
-check_parsing = "$params.singularity_dir/vep.sif tabix -p vcf -f $params.vcf".execute()
-check_parsing.consumeProcessOutput(sout, serr)
-check_parsing.waitFor()
-if( serr ){
-  exit 1, "The specified VCF file has issues in parsing: $serr"
-}
+
 vcf_index = "${params.vcf}.tbi"
+
+if( !file(vcf_index).exists() ) {
+log.info 'I got here somehowe.....'
+  check_parsing = "$params.singularity_dir/vep.sif tabix -p vcf -f $params.vcf".execute()
+  check_parsing.consumeProcessOutput(sout, serr)
+  check_parsing.waitFor()
+  if( serr ){
+    exit 1, "The specified VCF file has issues in parsing: $serr"
+  }
+}
 
 if ( params.vep_config ){
   vepFile = file(params.vep_config)

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -85,6 +85,7 @@ else
 log.info 'Starting workflow.....'
 
 workflow {
+  chr = ""
   if (params.chros){
     log.info 'Reading chromosome names from list'
     chr_str = params.chros.toString()
@@ -99,7 +100,14 @@ workflow {
     readChrVCF(params.vcf, vcf_index)
     chr = readChrVCF.out.splitText().map{it -> it.trim()}
   }
-  splitVCF(chr , params.vcf, vcf_index)
+  
+  if( chr.equals("") ){
+    log.info 'Taking default chromosome values'
+    chr_str = params.chros_default.toString()
+    chr = Channel.of(chr_str.split(','))
+  }
+  
+  splitVCF(chr, params.vcf, vcf_index)
   chrosVEP(splitVCF.out, params.vep_config)
   mergeVCF(chrosVEP.out.vcfFile.collect(), chrosVEP.out.indexFile.collect())
 }  

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -16,8 +16,6 @@ params.vep_config=""
 params.chros=""
 params.chros_file=""
 
-chros_default = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
-
 // module imports
 include { splitVCF } from '../nf_modules/split_into_chros.nf' 
 include { mergeVCF } from '../nf_modules/merge_chros_VCF.nf'  
@@ -87,7 +85,6 @@ else
 log.info 'Starting workflow.....'
 
 workflow {
-  chr = ""
   if (params.chros){
     log.info 'Reading chromosome names from list'
     chr_str = params.chros.toString()
@@ -101,11 +98,6 @@ workflow {
     log.info 'Computing chromosome names from input'
     readChrVCF(params.vcf, vcf_index)
     chr = readChrVCF.out.splitText().map{it -> it.trim()}
-  }
-  
-  if( chr.equals("") ){
-    log.info 'Taking default chromosome values'
-    chr = Channel.of(chros_default.split(','))
   }
   
   splitVCF(chr, params.vcf, vcf_index)

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -38,6 +38,7 @@ if (params.help) {
   log.info '  --chros LIST_OF_CHROS	Comma-separated list of chromosomes to generate. i.e. 1,2,... Default: 1,2,...,X,Y,MT'
   log.info '  --chros_file LIST_OF_CHROS_FILE Path to file containing list of chromosomes' 
   log.info '  --cpus INT	        Number of CPUs to use. Default 1.'
+  log.info '  --output_prefix FILENAME_PREFIX   Output filename prefix. The generated output file will have name <output_prefix>.vcf.gz'
   exit 1
 }
 
@@ -81,6 +82,7 @@ else
 log.info 'Starting workflow.....'
 
 workflow {
+log.info params.chros
   if (params.chros){
     log.info 'Reading chromosome names from list'
     chr_str = params.chros.toString()

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -60,16 +60,13 @@ if(check_bgzipped.exitValue()){
 
 def sout = new StringBuilder(), serr = new StringBuilder()
 
-vcf_index = "${params.vcf}.tbi"
-
-if( !file(vcf_index).exists() ) {
-  check_parsing = "$params.singularity_dir/vep.sif tabix -p vcf -f $params.vcf".execute()
-  check_parsing.consumeProcessOutput(sout, serr)
-  check_parsing.waitFor()
-  if( serr ){
-    exit 1, "The specified VCF file has issues in parsing: $serr"
-  }
+check_parsing = "$params.singularity_dir/vep.sif tabix -p vcf -f $params.vcf".execute()
+check_parsing.consumeProcessOutput(sout, serr)
+check_parsing.waitFor()
+if( serr ){
+  exit 1, "The specified VCF file has issues in parsing: $serr"
 }
+vcf_index = "${params.vcf}.tbi"
 
 if ( params.vep_config ){
   vepFile = file(params.vep_config)

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -59,7 +59,6 @@ if(check_bgzipped.exitValue()){
 }
 
 def sout = new StringBuilder(), serr = new StringBuilder()
-
 check_parsing = "$params.singularity_dir/vep.sif tabix -p vcf -f $params.vcf".execute()
 check_parsing.consumeProcessOutput(sout, serr)
 check_parsing.waitFor()
@@ -96,7 +95,6 @@ workflow {
     readChrVCF(params.vcf, vcf_index)
     chr = readChrVCF.out.splitText().map{it -> it.trim()}
   }
-  
   splitVCF(chr, params.vcf, vcf_index)
   chrosVEP(splitVCF.out, params.vep_config)
   mergeVCF(chrosVEP.out.vcfFile.collect(), chrosVEP.out.indexFile.collect())

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -63,7 +63,6 @@ def sout = new StringBuilder(), serr = new StringBuilder()
 vcf_index = "${params.vcf}.tbi"
 
 if( !file(vcf_index).exists() ) {
-log.info 'I got here somehowe.....'
   check_parsing = "$params.singularity_dir/vep.sif tabix -p vcf -f $params.vcf".execute()
   check_parsing.consumeProcessOutput(sout, serr)
   check_parsing.waitFor()


### PR DESCRIPTION
- New option `--output_prefix` to overwrite output file name
- Do not try to create index file if already present
- It has been always taking chromosomes from the `params.chros` - by default comment out the `param.chros` in config (reverted).
- The tabix index file is mandatorily generated, it is better to use `tabix` instead of `bcftools` to read chromosomes from the file because that will remove dependency from the header. So even if there is no proper header in the input vcf we will get the chromosomes.