### PR TITLE
feat: Add SO terms based on CN alterations

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -467,9 +467,9 @@ sub create_StructuralVariationFeatures {
       $skip = 1;
     }
   } elsif ($alt =~ /\<CN/i) {
+    $type = "CNV";
     $type = "DEL" if $alt =~ /\<CN=?0\>/;
     $type = "DUP" if $alt =~ /\<CN=?2\>/;
-    $type = "CNV" if $alt =~ /\<CN=?[0-9]\>,\<CN=?[1-9]\>/;
   }
 
   # set a default which we do not expect to see

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -469,8 +469,7 @@ sub create_StructuralVariationFeatures {
   } elsif ($alt =~ /\<CN/i) {
     $type = "DEL" if $alt =~ /\<CN=?0\>/;
     $type = "DUP" if $alt =~ /\<CN=?2\>/;
-    $type = "CNV" if $alt =~ /\<CN=?0\>,\<CN=?2\>/;
-    $type = "CNV" if $alt =~ /\<CN=[1-9]\>,\<CN=[1-9]\>/;
+    $type = "CNV" if $alt =~ /\<CN=?[0-9]\>,\<CN=?[1-9]\>/;
   }
 
   # set a default which we do not expect to see


### PR DESCRIPTION
Jira: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5031)

## Description

Some structural variants does not have SVTYPE included on INFO field + follow specific pattern to determine if is a deletion, duplication or copy number variation. This PR includes does specific patterns and relate than to their SO terms.

## Technical description

1) Besides <CN=0> (DEL) or <CN=2> (DUP) or <CN=0>,<CN=2> (CNV) patterns, we might have lots of patterns for CNV as:
<CN=0>,<CN=1>,<CN=2>,<CN=3>,....,<CN=n>, as n = number of amount of copy numbers in that variant.
2) Sometimes <CN=0>, might be represented as <CN0>, as well as, other \<CN\>'s.

## Tests

1) Run a VCF with all those cases and check if does it work, i.e:
```sh
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
1       713044  CNV     C       <CN=0>,<CN=2>   .       .       END=755966
1       713044  CNV2    C       <CN0>,<CN2>     .       .       END=755966
1       713044  CNV2    C       <CN0>,<CN2>,<CN3>,<CN4> .       .       END=755966
1       713044  DUP     C       <CN=2>  .       .       END=755966
1       713044  DUP2    C       <CN2>   .       .       END=755966
1       713044  DEL     C       <CN=0>  .       .       END=755966
1       713044  DEL2    C       <CN0>   .       .       END=755966
```