### PR TITLE
Add plugins to VEP Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -150,7 +150,7 @@ RUN ensembl-vep/travisci/build_c.sh && \
     /usr/sbin/update-locale LANG=$LANG_VAR && \
     # Copy htslib executables. It also requires the packages 'zlib1g-dev', 'libbz2-dev' and 'liblzma-dev'
     cp $HTSLIB_DIR/bgzip $HTSLIB_DIR/tabix $HTSLIB_DIR/htsfile /usr/local/bin/ && \
-    # Delete cache from cpanm
+    # Remove CPAN cache
     rm -rf /root/.cpanm
 
 ENV LC_ALL $LANG_VAR
@@ -160,19 +160,46 @@ ENV LANG $LANG_VAR
 USER vep
 ENV PERL5LIB $PERL5LIB_TMP
 
-# Final steps
-WORKDIR $OPT_SRC/ensembl-vep
+# Setup Docker environment for when users run VEP and INSTALL.pl in Docker image:
+#   - skip VEP updates in INSTALL.pl
+ENV VEP_NO_UPDATE 1
+#   - avoid Faidx/HTSLIB installation in INSTALL.pl
+ENV VEP_NO_HTSLIB 1
+#   - skip plugin installation in INSTALL.pl
+ENV VEP_NO_PLUGINS 1
+#   - set plugins directory for VEP and INSTALL.pl
+ENV VEP_DIR_PLUGINS /plugins
+ENV VEP_PLUGINSDIR $VEP_DIR_PLUGINS
+WORKDIR $VEP_DIR_PLUGINS
+
 # Update bash profile
+WORKDIR $OPT_SRC/ensembl-vep
 RUN echo >> $OPT/.profile && \
     echo PATH=$PATH:\$PATH >> $OPT/.profile && \
     echo export PATH >> $OPT/.profile && \
-    # Run INSTALL.pl and remove the ensemb-vep tests and travis
-    ./INSTALL.pl -a a -l -n && rm -rf t travisci .travis.yml
+    # Install Ensembl API and plugins
+    ./INSTALL.pl --auto ap --plugins all --pluginsdir $VEP_DIR_PLUGINS --no_update --no_htslib && \
+    # Remove the ensemb-vep tests and travis
+    rm -rf t travisci .travis.yml
 
-# Avoid update checks for VEP and Ensembl API when running INSTALL.pl
-ENV VEP_NO_UPDATE=1
+# Install dependencies for VEP plugins:
+USER root
+ENV PLUGIN_DEPS "https://raw.githubusercontent.com/Ensembl/VEP_plugins/$BRANCH/config"
+#   - Ubuntu packages
+RUN curl -O "$PLUGIN_DEPS/ubuntu-packages.txt" && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    $(sed s/\#.*//g ubuntu-packages.txt) && \
+    rm -rf /var/lib/apt/lists/* ubuntu-packages.txt
+#   - Perl modules
+RUN curl -O "$PLUGIN_DEPS/cpanfile" && \
+    cpanm --installdeps --with-recommends . && \
+    rm -rf /root/.cpanm cpanfile
+#   - Python packages
+RUN curl -O "$PLUGIN_DEPS/requirements.txt" && \
+    python -m pip install --no-cache-dir -r requirements.txt && \
+    rm requirements.txt
 
-# Set working directory as symlink to $OPT/.vep
+# Set working directory as symlink to $OPT/.vep (containing VEP cache and data)
 USER root
 RUN ln -s $OPT/.vep /data
 USER vep


### PR DESCRIPTION
[ENSVAR-4574](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4574): Adding VEP plugins to docker image

* Plugins are installed to `/plugins`
* Dependencies are installed based on files from VEP_plugins repo: https://github.com/Ensembl/VEP_plugins/pull/553

### Set up

To test this PR, first change the line starting with `ENV PLUGIN_DEPS` to my repo:
```
ENV PLUGIN_DEPS "https://raw.githubusercontent.com/nuno-agostinho/VEP_plugins/improve/vep-docker/config"
```

After using this Dockerfile to build a Docker image (e.g., named `vep-plugins`), you can run a plugin like this:
```
docker run -v $HOME/vep_data:/data vep-plugins vep \
    --i input.vcf \
    --database \
    --plugin Blosum62
```

You can try using `--database` to avoid installing cache. If needed, you can install the cache in a folder such as `$HOME/vep_data` by using `docker run -ti -v $HOME/vep_data:/data vep-plugins vep INSTALL.pl`.

### Testing

Test multiple plugins, including:
- Carol (Perl module `Math::CDF`)
- Draw (Perl module `GD`)
- LocalID (sqlite3)
- PON_P2 (Python dependencies) -- should we include the `pon_p2.py` script in the Docker image?
- FATHMM (Python MySQL) -- should we include the `fathmm.py` script in the Docker image?
- More 2 or 3 other plugins

Ask me for help if needed, thanks!!