### PR TITLE
Improve INSTALL.pl

### DIFF
--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -138,12 +138,13 @@ GetOptions(
   'version|v=i', # Deprecated
   'cache_version|e=i',
   'assembly|y=s',
-  'bioperl!|b=s',
+  'bioperl|b=s',
   'cache_url|cacheurl|u=s',
   'dir_cache|cachedir|cache_dir|c=s',
   'fasta_url|fastaurl|f=s',
   'help|h',
   'no_update|n',
+  'no_bioperl',
   'species|s=s',
   'plugins|g=s',
   'dir_plugins|pluginsdir|plugins_dir|r=s',
@@ -237,8 +238,6 @@ $Archive::Extract::PREFER_BIN = $config->{prefer_bin} || 0;
 
 $config->{bioperl} = 1;
 $config->{quiet}   = 0 unless $config->{auto};
-
-warn Data::Dumper::Dumper $config;
 
 ##########################################################################
 ##########################################################################
@@ -433,7 +432,7 @@ sub check_default_dir {
 sub api() {
   setup_dirs();
   my $curdir = getcwd;
-  bioperl() if $config->{bioperl};
+  bioperl() unless $config->{no_bioperl};
 
   # htslib needs to find bioperl to pass tests
   $ENV{PERL5LIB} = $ENV{PERL5LIB} ? $ENV{PERL5LIB}.':'.$DEST_DIR : $DEST_DIR;

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -272,7 +272,7 @@ $Archive::Extract::PREFER_BIN = $PREFER_BIN == 0 ? 0 : 1;
 $QUIET = 0 unless $AUTO;
 
 # updates to ensembl-vep available?
-update() unless $NO_UPDATE;
+update() unless $NO_UPDATE or $AUTO;
 
 # auto?
 if($AUTO) {

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -134,19 +134,19 @@ our (@store_species, @indexes, @files, $ftp, $dirname);
 my $config = {};
 GetOptions(
   $config,
-  'destdir|dest_dir|dir_dest|d=s',
+  'dir_dest|destdir|dest_dir|d=s',
   'version|v=i', # Deprecated
   'cache_version|e=i',
   'assembly|y=s',
   'bioperl!|b=s',
-  'cacheurl|cache_url|u=s',
-  'cachedir|cache_dir|dir_cache|c=s',
-  'fastaurl|fasta_url|f=s',
+  'cache_url|cacheurl|u=s',
+  'dir_cache|cachedir|cache_dir|c=s',
+  'fasta_url|fastaurl|f=s',
   'help|h',
   'no_update|n',
   'species|s=s',
   'plugins|g=s',
-  'pluginsdir|plugins_dir|dir_plugins|r=s',
+  'dir_plugins|pluginsdir|plugins_dir|r=s',
   'plugins_url|pluginurl=s',
   'auto|a=s' => ($config->{auto} ||= 0),
   'quiet|q',
@@ -180,10 +180,10 @@ $config = read_config_from_environment($config);
 # Quick fix: this script should use $config instead of multiple global variables
 $API_VERSION  ||=  $config->{version};
 $DATA_VERSION ||=  $config->{cache_version};
-$CACHE_URL    ||=  $config->{cacheurl};
-$CACHE_DIR    ||=  $config->{cachedir};
-$FASTA_URL    ||=  $config->{fastaurl};
-$PLUGINS_DIR  ||=  $config->{pluginsdir};
+$CACHE_URL    ||=  $config->{cache_url};
+$CACHE_DIR    ||=  $config->{dir_cache};
+$FASTA_URL    ||=  $config->{fasta_url};
+$PLUGINS_DIR  ||=  $config->{dir_plugins};
 
 # load version data
 our $CURRENT_VERSION_DATA = get_version_data($RealBin.'/.version');
@@ -209,7 +209,7 @@ warn(
 
 my $default_dir_used = check_default_dir();
 
-$LIB_DIR            = $config->{destdir};
+$LIB_DIR            = $config->{dir_dest};
 $HTSLIB_DIR         = $LIB_DIR.'/htslib';
 $BIODBHTS_DIR       = $LIB_DIR.'/biodbhts';
 $REALPATH_DEST_DIR .= Cwd::realpath($DEST_DIR).'/Bio';

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -375,7 +375,7 @@ sub update() {
   unlink($repo_file);
 
   unless($default_branch) {
-    print "WARNING: Unable to carry out version check for '$module'\n" unless $QUIET;
+    warn "WARNING: Unable to carry out version check for '$module'\n" unless $QUIET;
     return;
   }
 
@@ -698,7 +698,7 @@ sub setup_dirs() {
 
     else {
       unless($default_dir_used || $AUTO) {
-        print "WARNING: You are using a non-default install directory.\nPressing \"y\" again will remove $DEST_DIR and its contents!!!\nAre you really, really sure (y/n)? ";
+        warn "WARNING: You are using a non-default install directory.\nPressing \"y\" again will remove $DEST_DIR and its contents!!!\nAre you really, really sure (y/n)? ";
         $ok = <>;
 
         if($ok !~ /^y/i) {
@@ -1075,7 +1075,7 @@ sub test() {
     eval q{use Set::IntervalTree};
     @test_files = grep {!/Haplo/} @test_files if $@;
 
-    print "Warning: Tests failed, VEP may not run correctly\n" unless runtests(@test_files);
+    warn "Warning: Tests failed, VEP may not run correctly\n" unless runtests(@test_files);
   }
   else {
     my $test_vep = `perl -I $DEST_DIR $dirname/vep --help 2>&1`;
@@ -1295,7 +1295,7 @@ sub cache() {
 
       my $ok;
 
-      print "\nWARNING: It looks like you already have the cache for $species $assembly (v$DATA_VERSION) installed.\n" unless $QUIET;
+      warn "\nWARNING: It looks like you already have the cache for $species $assembly (v$DATA_VERSION) installed.\n" unless $QUIET;
 
       if($AUTO) {
         print "\nDelete the folder $CACHE_DIR/$species/$DATA_VERSION\_$assembly and re-run INSTALL.pl if you want to re-install\n";
@@ -1370,7 +1370,7 @@ sub cache() {
         print " - converting cache, this may take some time but will allow VEP to look up variants and frequency data much faster\n";
         print " - use CTRL-C to cancel if you do not wish to convert this cache now (you may run convert_cache.pl later)\n";
       }
-      system("perl $dirname/convert_cache.pl --dir $CACHE_DIR --species $species --version $DATA_VERSION\_$assembly --bgzip $bgzip --tabix $tabix") == 0 or print STDERR "WARNING: Failed to run convert script\n";
+      system("perl $dirname/convert_cache.pl --dir $CACHE_DIR --species $species --version $DATA_VERSION\_$assembly --bgzip $bgzip --tabix $tabix") == 0 or warn "WARNING: Failed to run convert script\n";
     }
   }
 }
@@ -1390,7 +1390,7 @@ sub fasta() {
 
     # change URL to point to last e! version that had GRCh37 downloads
     elsif($FASTA_URL =~ /ftp/) {
-      print "\nWARNING: Changing FTP URL for GRCh37\n";
+      warn "\nWARNING: Changing FTP URL for GRCh37\n";
       $FASTA_URL =~ s/$DATA_VERSION/75/;
     }
   }
@@ -1741,15 +1741,17 @@ sub plugins() {
 
     my @not_found = grep {!$by_key{lc($_)}} @$PLUGINS;
     if(@not_found) {
-      printf(
-        "\nWARNING: The following plugins have not been found: %s\nAvailable plugins: %s\n",
+      warn(
+        "\nWARNING: The following plugins have not been found: ",
         join(",", @not_found),
-        join(",", sort map {$_->{key}} values %by_key)
+        "\nAvailable plugins: ",
+        join(",", sort map {$_->{key}} values %by_key),
+        "\n"
       );
     }
 
     if(!@selected_plugins) {
-      printf("\nERROR: No valid plugins given\n");
+      warn("\nWARNING: No valid plugins given\n");
       return;
     }
   }
@@ -1783,7 +1785,7 @@ sub plugins() {
 
     # warn if failed
     unless(-e $local_file) {
-      print " - WARNING: Failed to download/install ".$pl->{key}."\n";
+      warn " - WARNING: Failed to download/install ".$pl->{key}."\n";
       next;
     }
 


### PR DESCRIPTION
- [ENSVAR-1979](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-1979): Avoid checking VEP updates when using `--AUTO`
- [ENSVAR-5235](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5235): Print warnings using `warn()` instead of `print()`
- [ENSVAR-5234](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5234): Include `use warnings;` and reorder code
- [ENSVAR-5188](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5188): Improve config arguments and promote consistency with VEP arguments
    - Prefer lowercase arguments (uppercase still supported)
    - Added new alternative arguments that are more consistent with VEP (e.g., `--dir_cache` and `--dir_plugins` are now supported in `INSTALL.pl`)
    - Also added (alternative) arguments by adding an underscore to separate two words (e.g., `--cache_url` and `--fasta_url `)
    - Eventually, we will need to update documentation for INSTALL.pl (not critical as old usage is still compatible)