### PR TITLE
hotfix: Remove default `homo_sapiens` from header test

### DIFF
--- a/t/OutputFactory_Tab.t
+++ b/t/OutputFactory_Tab.t
@@ -119,7 +119,7 @@ my $runner = get_annotated_buffer_runner({
 });
 is(
   $runner->get_OutputFactory->headers->[-2].$runner->get_OutputFactory->headers->[-1],
-  "## VEP command-line: vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --input_file [PATH]/test.vcf --no_stats --offline --plugin TestPlugin --quiet --show_ref_allele --species homo_sapiens --tab".
+  "## VEP command-line: vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --input_file [PATH]/test.vcf --no_stats --offline --plugin TestPlugin --quiet --show_ref_allele --tab".
   "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tREF_ALLELE\tIMPACT\tDISTANCE\tSTRAND\tFLAGS\ttest",
   'headers - plugin'
 );

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -54,7 +54,7 @@ is_deeply(
     '##VEP="v1" time="test"',
     '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|custom_test">',
     '##INFO=<ID=custom_test,Number=.,Type=String,Description="test.vcf.gz">',
-    "##VEP-command-line='vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --no_stats --offline --species homo_sapiens'",
+    "##VEP-command-line='vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --no_stats --offline'",
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
   ],
   'headers'

--- a/t/OutputFactory_VEP_output.t
+++ b/t/OutputFactory_VEP_output.t
@@ -114,7 +114,7 @@ my $runner = get_annotated_buffer_runner({
 });
 is(
   $runner->get_OutputFactory->headers->[-2].$runner->get_OutputFactory->headers->[-1],
-  "## VEP command-line: vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --input_file [PATH]/test.vcf --no_stats --offline --plugin TestPlugin --quiet --species homo_sapiens".
+  "## VEP command-line: vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --input_file [PATH]/test.vcf --no_stats --offline --plugin TestPlugin --quiet".
   "#Uploaded_variation\tLocation\tAllele\tGene\tFeature\tFeature_type\tConsequence\tcDNA_position\tCDS_position\tProtein_position\tAmino_acids\tCodons\tExisting_variation\tExtra",
   'headers - plugin'
 );


### PR DESCRIPTION
## Description

Tests are not passing due to `--species homo_sapiens` default was included on test.

## Test

1) Just wait for travis.