### PR TITLE
Hotfix for FTP/HTTP links in `INSTALL.pl`

### DIFF
--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -1765,7 +1765,7 @@ sub plugins() {
 sub download_to_file {
   my ($url, $file) = @_;
 
-  $url =~ s/([a-z])\//$1\:21\// if $url =~ /ftp/ && $url !~ /\:21/;
+  $url =~ s/([a-z])\//$1\:21\// if $url =~ /^ftp/ && $url !~ /\:21/;
 
   if($CAN_USE_CURL) {
     my $response = `curl -s -o $file -w '%{http_code}' --location "$url" `;

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -1274,11 +1274,11 @@ sub cache() {
     if(is_url($URL_TO_USE)) {
       print " - downloading $URL_TO_USE/$file_path\n" unless $QUIET;
       if(!$TEST) {
-        download_to_file("$URL_TO_USE/$file_path", $target_file);
+        $ftp->get($file_name, $target_file) or download_to_file("$URL_TO_USE/$file_path", $target_file);
 
         my $checksums = "CHECKSUMS";
         my $checksums_target_file = "$CACHE_DIR/tmp/$checksums";
-        download_to_file("$URL_TO_USE/$checksums", $checksums_target_file);
+        $ftp->get($checksums, $checksums_target_file) or download_to_file("$URL_TO_USE/$checksums", $checksums_target_file);
         if (-e $checksums_target_file) {
           my $sum_download = `sum $target_file`;
           $sum_download =~ m/([0-9]+)(\s+)([0-9]+)/;
@@ -1478,7 +1478,7 @@ sub fasta() {
     if($ftp) {
       print " - downloading $file\n" unless $QUIET;
       if(!$TEST) {
-        download_to_file("$FASTA_URL/$species/$dna_path/$file", $ex);
+        $ftp->get($file, $ex) or download_to_file("$FASTA_URL/$species/$dna_path/$file", $ex);
       }
     }
     else {
@@ -1514,7 +1514,7 @@ sub fasta() {
         if(!$TEST) {
           $index_file =~ /$file(\..+)/;
           print " - downloading $index_file\n" unless $QUIET;
-          download_to_file("$FASTA_URL/$species/$dna_path/$index_file", $ex.$1);
+          $ftp->get($index_file, $ex.$1) or download_to_file("$FASTA_URL/$species/$dna_path/$index_file", $ex.$1);
           $got_indexes++;
         }
       }

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -1274,11 +1274,11 @@ sub cache() {
     if(is_url($URL_TO_USE)) {
       print " - downloading $URL_TO_USE/$file_path\n" unless $QUIET;
       if(!$TEST) {
-        $ftp->get($file_name, $target_file) or download_to_file("$URL_TO_USE/$file_path", $target_file);
+        download_to_file("$URL_TO_USE/$file_path", $target_file);
 
         my $checksums = "CHECKSUMS";
         my $checksums_target_file = "$CACHE_DIR/tmp/$checksums";
-        $ftp->get($checksums, $checksums_target_file) or download_to_file("$URL_TO_USE/$checksums", $checksums_target_file);
+        download_to_file("$URL_TO_USE/$checksums", $checksums_target_file);
         if (-e $checksums_target_file) {
           my $sum_download = `sum $target_file`;
           $sum_download =~ m/([0-9]+)(\s+)([0-9]+)/;
@@ -1478,7 +1478,7 @@ sub fasta() {
     if($ftp) {
       print " - downloading $file\n" unless $QUIET;
       if(!$TEST) {
-        $ftp->get($file, $ex) or download_to_file("$FASTA_URL/$species/$dna_path/$file", $ex);
+        download_to_file("$FASTA_URL/$species/$dna_path/$file", $ex);
       }
     }
     else {
@@ -1514,7 +1514,7 @@ sub fasta() {
         if(!$TEST) {
           $index_file =~ /$file(\..+)/;
           print " - downloading $index_file\n" unless $QUIET;
-          $ftp->get($index_file, $ex.$1) or download_to_file("$FASTA_URL/$species/$dna_path/$index_file", $ex.$1);
+          download_to_file("$FASTA_URL/$species/$dna_path/$index_file", $ex.$1);
           $got_indexes++;
         }
       }
@@ -1764,8 +1764,6 @@ sub plugins() {
 
 sub download_to_file {
   my ($url, $file) = @_;
-
-  $url =~ s/([a-z])\//$1\:21\// if $url =~ /^ftp/ && $url !~ /\:21/;
 
   if($CAN_USE_CURL) {
     my $response = `curl -s -o $file -w '%{http_code}' --location "$url" `;

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -404,7 +404,7 @@ sub update() {
 
 sub is_url {
   my $url = shift;
-  return $url =~ /^http/i;
+  return $url =~ /^(http|ftp)/i;
 }
 
 sub check_default_dir {


### PR DESCRIPTION
Fix #1302:
* Fix download of cache and FASTA files for fallback cases.
* Allow user-provided links with `ftp://` protocol to download cache and FASTA.