### PR TITLE
feat: Include not annotated skipped --max_sv_size

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
@@ -171,6 +171,10 @@ sub get_all_regions_by_InputBuffer {
   my ($min, $max) = (1e10, 0);
 
   foreach my $vf(@{$buffer->buffer}) {
+
+    # skip long and unsupported types of SV; doing this here to avoid stopping looping
+    next if $vf->{vep_skip};
+
     my $chr = $vf->{chr} || $vf->slice->seq_region_name;
     throw("ERROR: Cannot get chromosome from VariationFeature") unless $chr;
 

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -209,8 +209,6 @@ sub next {
   if(my $parser = $self->parser) {
     while(@$buffer < $buffer_size && (my $vf = $parser->next)) {
 
-      # skip long and unsupported types of SV; doing this here to avoid stopping looping
-      next if $vf->{vep_skip};
 
       # exit the program if the maximum number of variants not ordered in the input file is reached
       if (!$self->param('no_check_variants_order') &&

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -222,7 +222,16 @@ sub get_all_output_hashes_by_InputBuffer {
 
   foreach my $vf(@{$buffer->buffer}) {
 
-    my $hash = {
+    my $hash;
+
+    # Include non-annotated line
+    if ($vf->{vep_skip}){
+      $hash->{input} = join($self->{delimiter}, @{$vf->{_line}}) if defined($vf->{_line});
+      push @return, $hash;
+      next;  
+    }
+
+    $hash = {
       id              => $vf->{variation_name},
       seq_region_name => $vf->{chr},
       start           => $vf->{start},

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -280,6 +280,12 @@ sub get_all_lines_by_InputBuffer {
 
   foreach my $vf(@{$buffer->buffer}) {
 
+    # Include non-annotated line
+    if ($vf->{vep_skip}){
+      push @return, join("\t", @{$vf->{_line}}) if $vf->{vep_skip};
+      next;  
+    }
+
     my $line;
     my $fieldname = $self->{vcf_info_field} || 'CSQ';
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
@@ -100,9 +100,6 @@ sub output_hash_to_line {
   my $self = shift;
   my $hash = shift;
 
-  print Data::Dumper::Dumper($self);
-  die "OK";
-
   # "core" fields
   my @line = map {defined($hash->{$_}) ? convert_arrayref($hash->{$_}) : '-'} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTPUT_COLS;
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
@@ -100,6 +100,9 @@ sub output_hash_to_line {
   my $self = shift;
   my $hash = shift;
 
+  print Data::Dumper::Dumper($self);
+  die "OK";
+
   # "core" fields
   my @line = map {defined($hash->{$_}) ? convert_arrayref($hash->{$_}) : '-'} @Bio::EnsEMBL::VEP::Constants::DEFAULT_OUTPUT_COLS;
 


### PR DESCRIPTION
## Description

An user reported that still wants variants skipped by `--max_sv_size` to be included in output VCF (https://github.com/Ensembl/ensembl-vep/issues/600). This PR still skips annotation but include VCF line without any annotation.

## Test

1) Use `--max_sv_size` flag with SV variants. It should keep warning and keep variants, i.e:

INPUT:
```sh
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
1       121035  gnomAD  N       <DEL>   .       .       END=1121130;SVTYPE=DEL
1       95244265        95244265        A       C       .       .       .
```

BEFORE:
```sh
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
1       95244265        95244265        A       C       .       .       CSQ=C|missense_variant|MODERATE|RWDD3|ENSG00000122481|Transcript|ENST00000263893|protein_coding|2/3||||160|140|47|E/A|gAg/gCg|||1||HGNC|HGNC:21393,.....
```

NOW:
```sh
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
1       121035  gnomAD  N       <DEL>   .       .       END=1121130;SVTYPE=DEL
1       95244265        95244265        A       C       .       .       CSQ=C|missense_variant|MODERATE|RWDD3|ENSG00000122481|Transcript|ENST00000263893|protein_coding|2/3||||160|140|47|E/A|gAg/gCg|||1||HGNC|HGNC:21393,.....
```