### PR TITLE
refactor: Include SV SO terms

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -481,7 +481,9 @@ sub create_StructuralVariationFeatures {
       DEL  => 'deletion',
       TDUP => 'tandem_duplication',
       DUP  => 'duplication',
-      CNV  => 'copy_number_variation'
+      CNV  => 'copy_number_variation',
+      INV  => 'inversion',
+      BND  => 'breakpoint'
     );
 
     $so_term = defined $terms{$type} ? $terms{$type} : $type;


### PR DESCRIPTION
## Description

When SV are annotated by VEP, `Allele` column usually get a SO term class (insertion, deletion, duplication, etc) in VCF case.
This PR is meant to include missing SO term classes.

INV => inversion (http://www.sequenceontology.org/browser/current_release/term/SO:1000036)
BND => breakpoint (http://www.sequenceontology.org/browser/current_release/term/SO:0000699 - synonym)

## Test

1) Check if `Allele` column have a SO term in INV and breakpoint cases, ie.

```sh
INPUT:
2	127050429	INV_exon	N	<INV>	.	.	END=127050512
2	127050429	BND_exon	N	<BND>	.	.	END=127050512;CHR2=chr3;END2=127050512

BEFORE:
2       127050429       INV_exon        N       <INV>   .       .       END=127050512;CSQ=INV|...
2       127050429       BND_exon        N       <BND>   .       .       END=127050512;CHR2=chr3;END2=127050512;CSQ=BND|...

OUTPUT:
2       127050429       INV_exon        N       <INV>   .       .       END=127050512;CSQ=inversion|...
2       127050429       BND_exon        N       <BND>   .       .       END=127050512;CHR2=chr3;END2=127050512;CSQ=breakpoint|...
```