### PR TITLE
Support `ga4gh-vrs` flag in all formats except VCF

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -380,8 +380,7 @@ our %REQUIRES = (
   original  => [qw(filters)],
   phyloP    => [qw(ucsc_assembly)],
   phastCons => [qw(ucsc_assembly)],
-  custom_multi_allelic => [qw(custom)],
-  ga4gh_vrs => [qw(json)]
+  custom_multi_allelic => [qw(custom)]
 );
 
 # incompatible options
@@ -397,7 +396,8 @@ our %INCOMPATIBLE = (
   tab         => [qw(vcf json)],
   individual  => [qw(minimal)],
   check_ref   => [qw(lookup_ref)],
-  check_svs   => [qw(offline)]
+  check_svs   => [qw(offline)],
+  ga4gh_vrs   => [qw(vcf)]
 );
 
 # deprecated/replaced flags

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -76,6 +76,7 @@ our @FLAG_FIELDS = (
   { flag => 'variant_class',   fields => ['VARIANT_CLASS']},
   { flag => 'minimal',         fields => ['MINIMISED']},
   { flag => 'spdi',            fields => ['SPDI']},
+  { flag => 'ga4gh_vrs',       fields => ['GA4GH_VRS']},
 
   # gene-related
   { flag => 'symbol',          fields => ['SYMBOL','SYMBOL_SOURCE','HGNC_ID'] },
@@ -172,6 +173,7 @@ our %FIELD_DESCRIPTIONS = (
   'HGVSp'              => 'HGVS protein sequence name',
   'HGVSg'              => 'HGVS genomic sequence name',
   'SPDI'               => 'Genomic SPDI notation',
+  'GA4GH_VRS'          => 'GA4GH Variation Representation Specification',
   'SIFT'               => 'SIFT prediction and/or score',
   'PolyPhen'           => 'PolyPhen prediction and/or score',
   'EXON'               => 'Exon number(s) / total',

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1287,7 +1287,9 @@ sub VariationFeatureOverlapAllele_to_output_hash {
         if ($ga4gh_vrs) {
           throw("ERROR: Cannot use --ga4gh_vrs without JSON module installed\n") unless $CAN_USE_JSON;
           my $json = JSON->new;
-          $hash->{GA4GH_VRS} = $json->encode($ga4gh_vrs);
+          # avoid encoding JSON twice in case of returning JSON output format
+          $ga4gh_vrs = $json->encode($ga4gh_vrs) if $self->{output_format} ne 'json';
+          $hash->{GA4GH_VRS} = $ga4gh_vrs;
         }
       }
     }

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1280,7 +1280,7 @@ sub VariationFeatureOverlapAllele_to_output_hash {
     $vf->{_spdi_genomic} = $vf->spdi_genomic(); 
 
     if (my $spdi = $vf->{_spdi_genomic}->{$hash->{Allele}}) {
-      $hash->{SPDI} = $spdi;
+      $hash->{SPDI} = $spdi if $self->{spdi};
 
       if ($self->{ga4gh_vrs} && $spdi =~ /^NC/) {
         my $ga4gh_vrs = ga4gh_vrs_from_spdi($spdi);

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -74,6 +74,7 @@ use Bio::EnsEMBL::Utils::Scalar qw(assert_ref);
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 use Bio::EnsEMBL::Variation::Utils::Constants;
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(ga4gh_vrs_from_spdi);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap);
 use Bio::EnsEMBL::VEP::Utils qw(format_coords merge_arrays get_flatten);
 use Bio::EnsEMBL::VEP::Constants;
@@ -1274,22 +1275,20 @@ sub VariationFeatureOverlapAllele_to_output_hash {
       $hash->{HGVSg} = $hgvsg; 
     }
   }
-  # spdi
-  if($self->{spdi}) { 
+  # spdi + ga4gh_vrs
+  if($self->{spdi} || $self->{ga4gh_vrs}) {
     $vf->{_spdi_genomic} = $vf->spdi_genomic(); 
-      
-    if(my $spdi = $vf->{_spdi_genomic}->{$hash->{Allele}}){
-      $hash->{SPDI} = $spdi;  
-    }
-  }
 
-  # ga4gh_vrs
-  if ($self->{ga4gh_vrs}) {
-    $vf->{_ga4gh_spdi_genomic} = $vf->spdi_genomic();
+    if (my $spdi = $vf->{_spdi_genomic}->{$hash->{Allele}}) {
+      $hash->{SPDI} = $spdi;
 
-    if (my $ga4gh_spdi = $vf->{_ga4gh_spdi_genomic}->{$hash->{Allele}}) {
-      if ($ga4gh_spdi =~ /^NC/) {
-        $hash->{GA4GH_SPDI} = $ga4gh_spdi;
+      if ($self->{ga4gh_vrs} && $spdi =~ /^NC/) {
+        my $ga4gh_vrs = ga4gh_vrs_from_spdi($spdi);
+        if ($ga4gh_vrs) {
+          throw("ERROR: Cannot use --ga4gh_vrs without JSON module installed\n") unless $CAN_USE_JSON;
+          my $json = JSON->new;
+          $hash->{GA4GH_VRS} = $json->encode($ga4gh_vrs);
+        }
       }
     }
   }

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -84,7 +84,6 @@ use base qw(Bio::EnsEMBL::VEP::OutputFactory);
 
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Variation::Utils::Constants;
-use Bio::EnsEMBL::Variation::Utils::Sequence qw(ga4gh_vrs_from_spdi);
 
 use Bio::EnsEMBL::VEP::Utils qw(numberify);
 
@@ -362,12 +361,6 @@ sub add_VariationFeatureOverlapAllele_info {
     foreach my $key(grep {defined($vfoa_hash->{$_})} keys %rename) {
       $vfoa_hash->{$rename{$key}} = $vfoa_hash->{$key};
       delete $vfoa_hash->{$key};
-    }
-    if (defined($vfoa_hash->{ga4gh_spdi})) {
-      my $ga4gh_vrs = ga4gh_vrs_from_spdi($vfoa_hash->{ga4gh_spdi});
-      if ($ga4gh_vrs) {
-          $vfoa_hash->{ga4gh_vrs} = $ga4gh_vrs;
-      }
     }
     push @{$hash->{$ftype.'_consequences'}}, $vfoa_hash;
   }

--- a/modules/Bio/EnsEMBL/VEP/VariantRecoder.pm
+++ b/modules/Bio/EnsEMBL/VEP/VariantRecoder.pm
@@ -470,17 +470,14 @@ sub _get_all_results {
       add_to_output($mane_by_allele{$allele}, \%key_mane, $results->{$line_id}->{$allele} ||= {input => $line_id});
     }
 
-    # Adding GA4GH VRS allele objects
-    # The genomic refseq SPDI are stored in 'ga4gh_spdi'
-    # The find_in_ref calls make the ga4gh_spdi unique
+    # Adding GA4GH VRS allele objects based on SPDI
     if ($ga4gh_vrs) {
       for my $allele (keys %{$results->{$line_id}}) {
-        next if (! exists $results->{$line_id}->{$allele}->{'ga4gh_spdi'});
-        my @ga4gh_spdis = @{$results->{$line_id}->{$allele}->{'ga4gh_spdi'}};
-        for my $ga4gh_spdi (@ga4gh_spdis) {
-          push @{$results->{$line_id}->{$allele}->{'ga4gh_vrs'}}, ga4gh_vrs_from_spdi($ga4gh_spdi);
+        next if (! exists $results->{$line_id}->{$allele}->{'spdi'});
+        my @spdis = @{$results->{$line_id}->{$allele}->{'spdi'}};
+        for my $spdi (@spdis) {
+          push @{$results->{$line_id}->{$allele}->{'ga4gh_vrs'}}, ga4gh_vrs_from_spdi($spdi);
         }
-        delete($results->{$line_id}->{$allele}->{'ga4gh_spdi'});
       }
     }
 

--- a/modules/Bio/EnsEMBL/VEP/VariantRecoder.pm
+++ b/modules/Bio/EnsEMBL/VEP/VariantRecoder.pm
@@ -296,7 +296,7 @@ sub _get_all_results {
 
   my $ga4gh_vrs = 0;
   if ($want_keys{'ga4gh_vrs'}) {
-    $want_keys{'ga4gh_spdi'} = 1;
+    $want_keys{'spdi'} = 1;
     $ga4gh_vrs = 1;
   }
 

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -1220,7 +1220,6 @@ SKIP: {
                  "consequence_terms" => [
                      "intergenic_variant"
                  ],
-                 "ga4gh_spdi" => "NC_000021.9:10524653:C:A",
                  "ga4gh_vrs" =>  {
                      "location" => {
                          "interval"  => {


### PR DESCRIPTION
[ENSVAR-5274](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5274): The [GA4GH Variation Representation Specification](https://vrs.ga4gh.org/) is a standard written in JSON. Previously, this flag was only compatible with JSON, but we need to support more output formats in order to enable support for `--ga4gh-vrs` in VEP and VR: https://github.com/Ensembl/ensembl-rest/pull/570

Unfortunately, the VCF format replaces the commas from this representation to `&`, so I made the flags `--vcf` and `--ga4gh-vrs` as incompatible.

## Testing

- Run VEP with and without `--ga4gh_vrs` and check the following output formats:
  - **JSON:** prints the `ga4gh_vrs` as normal JSON
  - **VCF:** raises error message stating that VCF output is incompatible with `--ga4gh-vrs` flag
  - **Other formats:** prints the `ga4gh_vrs` as a JSON-compliant string
- Run VR with and without `--ga4gh_vrs`