### PR TITLE
Support if allele_string is indel in VEP default input

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -136,6 +136,7 @@ our @FLAG_FIELDS = (
 # field descriptions for output headers
 our %FIELD_DESCRIPTIONS = (
   'Uploaded_variation' => 'Identifier of uploaded variant',
+  'Original_allele'    => 'The variant allele uploaded',
   'ID'                 => 'Identifier of uploaded variant',
   'Location'           => 'Location of variant in standard coordinate format (chr:start or chr:start-end)',
   'Allele'             => 'The variant allele used to calculate the consequence',

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -865,9 +865,11 @@ sub pick_VariationFeatureOverlapAllele_per_gene {
 sub VariationFeature_to_output_hash {
   my $self = shift;
   my $vf = shift;
+  my $uploaded_allele_string = $vf->{original_allele_string} || $vf->{allele_string};
 
   my $hash = {
     Uploaded_variation  => $vf->variation_name ne '.' ? $vf->variation_name : ($vf->{original_chr} || $vf->{chr}).'_'.$vf->{start}.'_'.($vf->{allele_string} || $vf->{class_SO_term}),
+    Original_allele     => $uploaded_allele_string,
     Location            => ($vf->{chr} || $vf->seq_region_name).':'.format_coords($vf->{start}, $vf->{end}),
   };
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -868,7 +868,7 @@ sub VariationFeature_to_output_hash {
 
   my $hash = {
     Uploaded_variation  => $vf->variation_name ne '.' ? $vf->variation_name : ($vf->{original_chr} || $vf->{chr}).'_'.$vf->{start}.'_'.($vf->{allele_string} || $vf->{class_SO_term}),
-    Original_allele     => $vf->{original_allele_string} || $vf->{allele_string};,
+    Original_allele     => ($vf->{original_allele_string} || $vf->{allele_string}),
     Location            => ($vf->{chr} || $vf->seq_region_name).':'.format_coords($vf->{start}, $vf->{end}),
   };
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -865,11 +865,10 @@ sub pick_VariationFeatureOverlapAllele_per_gene {
 sub VariationFeature_to_output_hash {
   my $self = shift;
   my $vf = shift;
-  my $uploaded_allele_string = $vf->{original_allele_string} || $vf->{allele_string};
 
   my $hash = {
     Uploaded_variation  => $vf->variation_name ne '.' ? $vf->variation_name : ($vf->{original_chr} || $vf->{chr}).'_'.$vf->{start}.'_'.($vf->{allele_string} || $vf->{class_SO_term}),
-    Original_allele     => $uploaded_allele_string,
+    Original_allele     => $vf->{original_allele_string} || $vf->{allele_string};,
     Location            => ($vf->{chr} || $vf->seq_region_name).':'.format_coords($vf->{start}, $vf->{end}),
   };
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -97,6 +97,7 @@ use Bio::EnsEMBL::VEP::Constants;
 
 my @VCF_COLS = qw(
   Allele
+  Original_allele
   Consequence
   IMPACT
   SYMBOL

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -97,7 +97,6 @@ use Bio::EnsEMBL::VEP::Constants;
 
 my @VCF_COLS = qw(
   Allele
-  Original_allele
   Consequence
   IMPACT
   SYMBOL
@@ -116,6 +115,7 @@ my @VCF_COLS = qw(
   Codons
   Existing_variation
   MINIMISED
+  Original_allele
 );
 
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -114,6 +114,7 @@ my @VCF_COLS = qw(
   Amino_acids
   Codons
   Existing_variation
+  MINIMISED
 );
 
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -159,8 +159,8 @@ sub create_VariationFeatures {
 
   # normal vf
   else {
-    my $is_indel = 0;
-    $is_indel = 1 unless $allele_string =~ /[ATGC]{n}\/[ATGC]{n}/ or $allele_string =~ /-/;
+    my $is_in_del = 0;
+    $is_in_del = 1 unless $allele_string =~ /[ATGC]{n}\/[ATGC]{n}/ or $allele_string =~ /-/;
 
     $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
       start          => $start,
@@ -173,7 +173,7 @@ sub create_VariationFeatures {
       chr            => $chr,
     });
 
-    if ($is_indel) {
+    if ($is_in_del) {
       $vf = ${Bio::EnsEMBL::VEP::Parser->minimise_alleles([$vf])}[0];
     }
   }

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -162,7 +162,7 @@ sub create_VariationFeatures {
     my $is_indel = 0;
     # Checks if the allele string is insertion or/and deletion
     my ($ref_allele_string,$alt_allele_string) = split(/\//, $allele_string);
-    $is_indel = 1 if length($ref_allele_string)!= length($alt_allele_string) or $allele_string =~ /-/;
+    $is_indel = 1 unless length($ref_allele_string) == length($alt_allele_string) or $allele_string =~ /-/;
 
     $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
       start          => $start,

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -159,6 +159,22 @@ sub create_VariationFeatures {
 
   # normal vf
   else {
+    my @allele_arr =  split(/\//,$allele_string);
+    my $ref = $allele_arr[0];
+    my $alt_allele = $allele_arr[1];
+    my $is_indel = 0;
+    $is_indel = 1 if $alt_allele =~ /^[DI]/ or length($alt_allele) != length($ref);
+
+    if($is_indel) {
+    # insertion or deletion
+      if(substr($ref, 0, 1) eq substr($alt_allele, 0, 1)) {
+        # chop off first base
+        $ref = substr($ref, 1) || '-';
+        $alt_allele = substr($alt_allele, 1) || '-';
+        $allele_string = "${ref}/${alt_allele}";
+        $start++;
+      }
+    }
     $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
       start          => $start,
       end            => $end,

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -162,7 +162,7 @@ sub create_VariationFeatures {
     my $is_indel = 0;
     # Checks if the allele string is insertion or/and deletion
     my ($ref_allele_string,$alt_allele_string) = split(/\//, $allele_string);
-    $is_indel = 1 unless length($ref_allele_string)!= length($alt_allele_string) or $allele_string =~ /-/;
+    $is_indel = 1 if length($ref_allele_string)!= length($alt_allele_string) or $allele_string =~ /-/;
 
     $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
       start          => $start,

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -162,20 +162,6 @@ sub create_VariationFeatures {
     my $is_indel = 0;
     $is_indel = 1 unless $allele_string =~ /[ATGC]{n}\/[ATGC]{n}/ or $allele_string =~ /-/;
 
-    if($is_indel) {
-    # insertion or deletion
-      my @allele_arr =  split(/\//,$allele_string);
-      my $ref = $allele_arr[0];
-      my $alt_allele = $allele_arr[1];
-      
-      while(substr($ref, 0, 1) eq substr($alt_allele, 0, 1)) {
-        # chop off first base
-        $ref = substr($ref, 1) || '-';
-        $alt_allele = substr($alt_allele, 1) || '-';
-        $allele_string = "${ref}/${alt_allele}";
-        $start++;
-      }
-    }
     $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
       start          => $start,
       end            => $end,
@@ -186,8 +172,11 @@ sub create_VariationFeatures {
       variation_name => $var_name,
       chr            => $chr,
     });
-  }
 
+    if ($is_indel) {
+      $vf = ${Bio::EnsEMBL::VEP::Parser->minimise_alleles([$vf])}[0];
+    }
+  }
   $vf->{_line} = $parser->{record};
 
   return $self->post_process_vfs([$vf]);

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -159,15 +159,16 @@ sub create_VariationFeatures {
 
   # normal vf
   else {
-    my @allele_arr =  split(/\//,$allele_string);
-    my $ref = $allele_arr[0];
-    my $alt_allele = $allele_arr[1];
     my $is_indel = 0;
-    $is_indel = 1 if $alt_allele =~ /^[DI]/ or length($alt_allele) != length($ref);
+    $is_indel = 1 unless $allele_string =~ /[ATGC]{n}\/[ATGC]{n}/ or $allele_string =~ /-/;
 
     if($is_indel) {
     # insertion or deletion
-      if(substr($ref, 0, 1) eq substr($alt_allele, 0, 1)) {
+      my @allele_arr =  split(/\//,$allele_string);
+      my $ref = $allele_arr[0];
+      my $alt_allele = $allele_arr[1];
+      
+      while(substr($ref, 0, 1) eq substr($alt_allele, 0, 1)) {
         # chop off first base
         $ref = substr($ref, 1) || '-';
         $alt_allele = substr($alt_allele, 1) || '-';

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -159,8 +159,10 @@ sub create_VariationFeatures {
 
   # normal vf
   else {
-    my $is_in_del = 0;
-    $is_in_del = 1 unless $allele_string =~ /[ATGC]{n}\/[ATGC]{n}/ or $allele_string =~ /-/;
+    my $is_indel = 0;
+    # Checks if the allele string is insertion or/and deletion
+    my ($ref_allele_string,$alt_allele_string) = split(/\//, $allele_string);
+    $is_indel = 1 unless length($ref_allele_string)!= length($alt_allele_string) or $allele_string =~ /-/;
 
     $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
       start          => $start,
@@ -173,7 +175,7 @@ sub create_VariationFeatures {
       chr            => $chr,
     });
 
-    if ($is_in_del) {
+    if ($is_indel) {
       $vf = ${Bio::EnsEMBL::VEP::Parser->minimise_alleles([$vf])}[0];
     }
   }

--- a/t/AnnotationSource_File_VCF.t
+++ b/t/AnnotationSource_File_VCF.t
@@ -294,7 +294,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'GC', fields => {'GOO' => 'YAR','FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR','FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - insertion 1'
@@ -303,7 +303,7 @@ SKIP: {
     $ib->buffer->[1]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'AGC', fields => {'GOO' => 'YAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR', 'FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - insertion 2'
@@ -312,7 +312,7 @@ SKIP: {
     $ib->buffer->[2]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'CG', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 1'
@@ -321,7 +321,7 @@ SKIP: {
     $ib->buffer->[3]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'CGT', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 2'
@@ -330,7 +330,7 @@ SKIP: {
     $ib->buffer->[4]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'GGCG', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 3'

--- a/t/AnnotationSource_File_VCF.t
+++ b/t/AnnotationSource_File_VCF.t
@@ -312,7 +312,7 @@ SKIP: {
     $ib->buffer->[2]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'CG', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 1'
@@ -321,7 +321,7 @@ SKIP: {
     $ib->buffer->[3]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'CGT', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 2'
@@ -330,7 +330,7 @@ SKIP: {
     $ib->buffer->[4]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'GGCG', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 3'

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -192,6 +192,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'rs142513484',
+    'Original_allele' => 'C/T',
     'Location' => '21:25585733'
   },
   'VariationFeature_to_output_hash'
@@ -202,6 +203,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'rs142513484',
+    'Original_allele' => 'C/T',
     'Location' => '21:25585733',
     'VARIANT_CLASS' => 'SNV',
   },
@@ -214,6 +216,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'rs142513484',
+    'Original_allele' => 'C/T',
     'Location' => '21:25585733',
     'SV' => ['sv1', 'sv2'],
   },
@@ -237,6 +240,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'indtest',
+    'Original_allele' => 'A/G',
     'Location' => '21:25607429',
     'IND' => 'dave',
     'ZYG' => 'HET',
@@ -255,6 +259,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'indtest',
+    'Original_allele' => 'A/G',
     'Location' => '21:25607429',
     'IND' => 'dave',
     'ZYG' => 'HET',
@@ -270,6 +275,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'indtest',
+    'Original_allele' => 'A/G',
     'Location' => '21:25607429',
     'IND' => 'dave',
     'ZYG' => 'HET',
@@ -284,6 +290,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'indtest',
+    'Original_allele' => 'A/G',
     'Location' => '21:25607429',
     'AMBIGUITY' => 'R',
     'IND' => 'dave',

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -1324,6 +1324,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'sv_dup',
+    'Original_allele' => undef,
     'Location' => '21:25606615-25606616'
   },
   'SV - VariationFeature_to_output_hash'
@@ -1705,6 +1706,7 @@ is_deeply(
       'MINIMISED' => 1,
       'Feature_type' => 'Transcript',
       'Uploaded_variation' => '21_25741665_CAGAAGAAAG/TAGAAGAAAG/C',
+      'Original_allele' => 'CAGAAGAAAG/TAGAAGAAAG/C',
       'Allele' => '-',
       'CDS_position' => '68-76',
       'Gene' => 'ENSG00000154727',
@@ -1725,6 +1727,7 @@ is_deeply(
       'MINIMISED' => 1,
       'Feature_type' => 'Transcript',
       'Uploaded_variation' => '21_25741665_CAGAAGAAAG/TAGAAGAAAG/C',
+      'Original_allele' => 'CAGAAGAAAG/TAGAAGAAAG/C',
       'Allele' => 'T',
       'CDS_position' => 67,
       'Gene' => 'ENSG00000154727',

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -234,6 +234,7 @@ SKIP: {
       'end' => 25585733,
       'seq_region_name' => '21',
       'strand' => 1,
+      'original_allele' => 'C/T',
       'transcript_consequences' => [
         {
           'gene_id' => 'ENSG00000154719',
@@ -434,6 +435,7 @@ SKIP: {
       ],
       'strand' => 1,
       'id' => 'rs142513484',
+      'original_allele' => 'C/T',
       'allele_string' => 'C/T',
       'most_severe_consequence' => 'missense_variant',
       'start' => 25585733,

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -52,7 +52,7 @@ is_deeply(
   [
     '##fileformat=VCFv4.1',
     '##VEP="v1" time="test"',
-    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|custom_test">',
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|custom_test">',
     '##INFO=<ID=custom_test,Number=.,Type=String,Description="test.vcf.gz">',
     "##VEP-command-line='vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --no_stats --offline'",
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
@@ -64,7 +64,7 @@ my $headers = get_runner({plugin => ['TestPlugin'], quiet => 1, input_file => $t
 is_deeply(
   [$headers->[-4], $headers->[-3], $headers->[-1]],
   [
-    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|test">',
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|test">',
     '##test=header',
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG00096"
   ],
@@ -74,7 +74,7 @@ is_deeply(
 $headers = get_runner({refseq => 1, fasta => $test_cfg->{fasta}, quiet => 1, input_file => $test_cfg->{test_vcf}, vcf => 1})->get_OutputFactory->headers;
 is(
   $headers->[-3],
-  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|REFSEQ_MATCH|REFSEQ_OFFSET|GIVEN_REF|USED_REF|BAM_EDIT">',
+  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|REFSEQ_MATCH|REFSEQ_OFFSET|GIVEN_REF|USED_REF|BAM_EDIT">',
   'headers - BAM_EDIT'
 );
 
@@ -99,6 +99,7 @@ is_deeply(
     'Amino_acids',
     'Codons',
     'Existing_variation',
+    'MINIMISED',
     'DISTANCE',
     'STRAND',
     'FLAGS',
@@ -131,6 +132,7 @@ is_deeply(
     'Amino_acids',
     'Codons',
     'Existing_variation',
+    'MINIMISED',
     'DISTANCE',
     'STRAND',
     'FLAGS',
@@ -163,6 +165,7 @@ is_deeply(
     'Amino_acids',
     'Codons',
     'Existing_variation',
+    'MINIMISED',
     'DISTANCE',
     'STRAND',
     'FLAGS',
@@ -194,55 +197,55 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $cfg});
 
 is(
   $of->output_hash_to_vcf_info_chunk({}),
-  ('|' x 20),
+  ('|' x 21),
   'output_hash_to_vcf_info_chunk - empty'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => 'A'}),
-  'A'.('|' x 20),
+  'A'.('|' x 21),
   'output_hash_to_vcf_info_chunk'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => 'A'}, -1),
-  'T'.('|' x 20),
+  'T'.('|' x 21),
   'output_hash_to_vcf_info_chunk - allele revcomped'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Consequence => '-'}),
-  ('|' x 20),
+  ('|' x 21),
   'output_hash_to_vcf_info_chunk - "-" erased'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => '-'}),
-  '-'.('|' x 20),
+  '-'.('|' x 21),
   'output_hash_to_vcf_info_chunk - "-" intact for Allele'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => ';'}),
-  '%3B'.('|' x 20),
+  '%3B'.('|' x 21),
   'output_hash_to_vcf_info_chunk - ";" uri encoded'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => '|'}),
-  '&'.('|' x 20),
+  '&'.('|' x 21),
   'output_hash_to_vcf_info_chunk - "|" converted'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => ','}),
-  '&'.('|' x 20),
+  '&'.('|' x 21),
   'output_hash_to_vcf_info_chunk - "," converted'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => 'A  G'}),
-  'A_G'.('|' x 20),
+  'A_G'.('|' x 21),
   'output_hash_to_vcf_info_chunk - whitespace converted'
 );
 
@@ -285,7 +288,7 @@ is(scalar @lines, scalar @{$ib->buffer}, 'get_all_lines_by_InputBuffer - count')
 is(
   $lines[0],
   "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|'.
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|'.
   "\tGT\t0|0",
   'get_all_lines_by_InputBuffer - check first'
 );
@@ -293,16 +296,16 @@ is(
 is(
   $lines[-1],
   "21\t25982445\trs141331202\tC\tT\t.\t.\t".
-  'CSQ=T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000346798||||||1157|1123|375|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000348990||||||1045|898|300|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000354192||||||857|730|244|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000357903||||||1233|1066|356|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000358918||||||1170|1123|375|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000359726||||||985|793|265|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000415997||||||326|328|110|V/I|Gtt/Att|||-1|cds_start_NF&cds_end_NF,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000439274||||||989|955|319|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000440126||||||1317|1051|351|V/I|Gtt/Att|||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000448850||||||830|832|278|V/I|Gtt/Att|||-1|cds_start_NF'.
+  'CSQ=T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000346798||||||1157|1123|375|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000348990||||||1045|898|300|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000354192||||||857|730|244|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000357903||||||1233|1066|356|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000358918||||||1170|1123|375|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000359726||||||985|793|265|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000415997||||||326|328|110|V/I|Gtt/Att||||-1|cds_start_NF&cds_end_NF,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000439274||||||989|955|319|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000440126||||||1317|1051|351|V/I|Gtt/Att||||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000448850||||||830|832|278|V/I|Gtt/Att||||-1|cds_start_NF'.
   "\tGT\t0|0",
   'get_all_lines_by_InputBuffer - check last'
 );
@@ -320,7 +323,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is(
   $lines[0],
   "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   'get_all_lines_by_InputBuffer - incomplete VCF entry filled out'
 );
 
@@ -330,7 +333,7 @@ $ib->buffer->[0]->get_all_TranscriptVariations->[0]->transcript->{stable_id} = '
 is(
   $lines[0],
   "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00&00_03&07%3B301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00&00_03&07%3B301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   'get_all_lines_by_InputBuffer - invalid character conversion'
 );
 
@@ -349,14 +352,14 @@ is(
   $lines[0],
 '21	25585733	rs142513484	C	T	.	.	CSQ=T|3_prime_UTR_variant'.
 '|MODIFIER|MRPL39|ENSG00000154719|Transcript|ENST00000307301|protein_coding|11/11||ENST00000307301.11:c.*18G>A||1122|'.
-'||||rs142513484||-1||SNV|HGNC|HGNC:14027|YES|||5||CCDS33522.1|ENSP00000305682|Q9NYK5||UPI00001AEAC0|'.
+'||||rs142513484|||-1||SNV|HGNC|HGNC:14027|YES|||5||CCDS33522.1|ENSP00000305682|Q9NYK5||UPI00001AEAC0|'.
 '|||||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643|0.0003236|0|0|0|1.886e-05|0|0||||||||||||0.004643|gnomADe_AFR||'.
 '|||||||,T|missense_variant|MODERATE|MRPL39|ENSG00000154719|Transcript|ENST00000352957|protein_coding|10/10|'.
-'|ENST00000352957.8:c.991G>A|ENSP00000284967.6:p.Ala331Thr|1033|991|331|A/T|Gca/Aca|rs142513484||-1||SNV|HGNC'.
+'|ENST00000352957.8:c.991G>A|ENSP00000284967.6:p.Ala331Thr|1033|991|331|A/T|Gca/Aca|rs142513484|||-1||SNV|HGNC'.
 '|HGNC:14027||||1|P1|CCDS13573.1|ENSP00000284967|Q9NYK5||UPI00001AEE66|||tolerated_low_confidence(0.17)|benign(0.001)'.
 '||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643|0.0003236|0|0|0|1.886e-05|0|0||||||||||||0.004643|gnomADe_AFR|||||||||,T'.
 '|upstream_gene_variant|MODIFIER|AP000223.1|ENSG00000260583|Transcript|ENST00000567517|antisense||||||||||rs142513484'.
-'|2407|-1||SNV|Clone_based_ensembl_gene||YES|||||||||||||||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643'.
+'||2407|-1||SNV|Clone_based_ensembl_gene||YES|||||||||||||||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643'.
 '|0.0003236|0|0|0|1.886e-05|0|0||||||||||||0.004643|gnomADe_AFR|||||||||	GT	0|0'
 ,'get_all_lines_by_InputBuffer - everything'
 );
@@ -380,9 +383,9 @@ SKIP: {
   is(
     $of->get_all_lines_by_InputBuffer($runner->get_InputBuffer)->[0],
     "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-    "CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|||test1|BAR,".
-    "T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|||test1|BAR,".
-    "T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|||test1|BAR\tGT\t0|0",
+    "CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|||test1|BAR,".
+    "T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|||test1|BAR,".
+    "T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|||test1|BAR\tGT\t0|0",
     'get_all_lines_by_InputBuffer - custom'
   );
 
@@ -397,9 +400,9 @@ SKIP: {
   is(
     $of->get_all_lines_by_InputBuffer($runner->get_InputBuffer)->[0],
     "21\t25585733\t.\tCATG\tTACG\t.\t.\t".
-    "CSQ=TACG|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1119-1122|||||||-1|||test1&del1&del2,".
-    "TACG|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1030-1033|988-991|330-331|HA/RT|CATGca/CGTAca|||-1|||test1&del1&del2,".
-    "TACG|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|||test1&del1&del2",
+    "CSQ=TACG|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1119-1122||||||||-1|||test1&del1&del2,".
+    "TACG|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1030-1033|988-991|330-331|HA/RT|CATGca/CGTAca||||-1|||test1&del1&del2,".
+    "TACG|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|||test1&del1&del2",
     'get_all_lines_by_InputBuffer - custom overlap'
   );
 }
@@ -414,7 +417,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t21_25585733_C/T\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||1||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||1||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||1|2407|-1|',
   "non-VCF input"
 );
 
@@ -429,7 +432,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585732\t21_25585733_C/-\tGC\tG\t.\t.\t".
-  'CSQ=-|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,-|frameshift_variant|HIGH||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/X|Gca/ca|||-1|,-|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'CSQ=-|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,-|frameshift_variant|HIGH||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/X|Gca/ca||||-1|,-|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   "non-VCF input - deletion"
 );
 
@@ -443,7 +446,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;BAR2=blah2;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'BAR=blah;BAR2=blah2;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   "trash existing CSQ 1"
 );
 
@@ -456,7 +459,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   "trash existing CSQ 2"
 );
 
@@ -469,7 +472,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   "trash existing CSQ 3"
 );
 
@@ -477,7 +480,7 @@ $of->{keep_csq} = 1;
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;CSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'BAR=blah;CSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   "keep existing CSQ"
 );
 $of->{keep_csq} = 0;
@@ -492,7 +495,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;BCSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||2407|-1|',
+  'BAR=blah;BCSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
   "dont trash BCSQ"
 );
 
@@ -521,7 +524,7 @@ is_deeply(
   [map {$of->headers->[$_]} (0,2,4)],
   [
     '##fileformat=VCFv4.1',
-    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG00096"
   ],
   'headers (all but VEP) - from input test2'
@@ -619,7 +622,7 @@ is_deeply(
 
 is(
   $of->headers->[-3],
-  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
+  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
   'headers - from input 2'
 );
 
@@ -685,21 +688,21 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   'MT	12848	rs267606899	C	T	.	.	CSQ='.
-'T|downstream_gene_variant|MODIFIER||4508|Transcript|4508||||||||||||3641|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4509|Transcript|4509||||||||||||4276|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4513|Transcript|4513||||||||||||4579|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4514|Transcript|4514||||||||||||2858|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|upstream_gene_variant|MODIFIER||4519|Transcript|4519||||||||||||1899|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4537|Transcript|4537||||||||||||2444|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4538|Transcript|4538||||||||||||711|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4539|Transcript|4539||||||||||||2082|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|missense_variant|MODERATE||4540|Transcript|4540||||||512|512|171|A/V|gCa/gTa|||1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4541|Transcript|4541||||||||||||1301|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4556|Transcript|4556||||||||||||1826|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4563|Transcript|4563||||||||||||2790|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4564|Transcript|4564||||||||||||642|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4566|Transcript|4566||||||||||||4484|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4568|Transcript|4568||||||||||||512|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4571|Transcript|4571||||||||||||3108|-1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4573|Transcript|4573||||||||||||2379|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4575|Transcript|4575||||||||||||583|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|upstream_gene_variant|MODIFIER||4576|Transcript|4576||||||||||||3040|1||rseq_mrna_nonmatch&rseq_no_comparison|',
+'T|downstream_gene_variant|MODIFIER||4508|Transcript|4508|||||||||||||3641|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4509|Transcript|4509|||||||||||||4276|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4513|Transcript|4513|||||||||||||4579|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4514|Transcript|4514|||||||||||||2858|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|upstream_gene_variant|MODIFIER||4519|Transcript|4519|||||||||||||1899|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4537|Transcript|4537|||||||||||||2444|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4538|Transcript|4538|||||||||||||711|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4539|Transcript|4539|||||||||||||2082|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|missense_variant|MODERATE||4540|Transcript|4540||||||512|512|171|A/V|gCa/gTa||||1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4541|Transcript|4541|||||||||||||1301|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4556|Transcript|4556|||||||||||||1826|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4563|Transcript|4563|||||||||||||2790|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4564|Transcript|4564|||||||||||||642|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4566|Transcript|4566|||||||||||||4484|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4568|Transcript|4568|||||||||||||512|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4571|Transcript|4571|||||||||||||3108|-1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4573|Transcript|4573|||||||||||||2379|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4575|Transcript|4575|||||||||||||583|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|upstream_gene_variant|MODIFIER||4576|Transcript|4576|||||||||||||3040|1||rseq_mrna_nonmatch&rseq_no_comparison|',
   "RefSeq MT transcripts are returned"
 );
 

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -420,7 +420,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t21_25585733_C/T\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||1|C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||1|C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||1|C/T|2407|-1|',
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   "non-VCF input"
 );
 

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -52,7 +52,7 @@ is_deeply(
   [
     '##fileformat=VCFv4.1',
     '##VEP="v1" time="test"',
-    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|custom_test">',
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|Original_allele|DISTANCE|STRAND|FLAGS|custom_test">',
     '##INFO=<ID=custom_test,Number=.,Type=String,Description="test.vcf.gz">',
     "##VEP-command-line='vep --assembly GRCh38 --cache_version 84 --database 0 --dir [PATH]/ --no_stats --offline'",
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
@@ -64,7 +64,7 @@ my $headers = get_runner({plugin => ['TestPlugin'], quiet => 1, input_file => $t
 is_deeply(
   [$headers->[-4], $headers->[-3], $headers->[-1]],
   [
-    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|test">',
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|Original_allele|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|test">',
     '##test=header',
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG00096"
   ],
@@ -74,7 +74,7 @@ is_deeply(
 $headers = get_runner({refseq => 1, fasta => $test_cfg->{fasta}, quiet => 1, input_file => $test_cfg->{test_vcf}, vcf => 1})->get_OutputFactory->headers;
 is(
   $headers->[-3],
-  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|REFSEQ_MATCH|REFSEQ_OFFSET|GIVEN_REF|USED_REF|BAM_EDIT">',
+  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|Original_allele|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|REFSEQ_MATCH|REFSEQ_OFFSET|GIVEN_REF|USED_REF|BAM_EDIT">',
   'headers - BAM_EDIT'
 );
 
@@ -100,6 +100,7 @@ is_deeply(
     'Codons',
     'Existing_variation',
     'MINIMISED',
+    'Original_allele',
     'DISTANCE',
     'STRAND',
     'FLAGS',
@@ -133,6 +134,7 @@ is_deeply(
     'Codons',
     'Existing_variation',
     'MINIMISED',
+    'Original_allele',
     'DISTANCE',
     'STRAND',
     'FLAGS',
@@ -166,6 +168,7 @@ is_deeply(
     'Codons',
     'Existing_variation',
     'MINIMISED',
+    'Original_allele',
     'DISTANCE',
     'STRAND',
     'FLAGS',
@@ -197,55 +200,55 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $cfg});
 
 is(
   $of->output_hash_to_vcf_info_chunk({}),
-  ('|' x 21),
+  ('|' x 22),
   'output_hash_to_vcf_info_chunk - empty'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => 'A'}),
-  'A'.('|' x 21),
+  'A'.('|' x 22),
   'output_hash_to_vcf_info_chunk'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => 'A'}, -1),
-  'T'.('|' x 21),
+  'T'.('|' x 22),
   'output_hash_to_vcf_info_chunk - allele revcomped'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Consequence => '-'}),
-  ('|' x 21),
+  ('|' x 22),
   'output_hash_to_vcf_info_chunk - "-" erased'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => '-'}),
-  '-'.('|' x 21),
+  '-'.('|' x 22),
   'output_hash_to_vcf_info_chunk - "-" intact for Allele'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => ';'}),
-  '%3B'.('|' x 21),
+  '%3B'.('|' x 22),
   'output_hash_to_vcf_info_chunk - ";" uri encoded'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => '|'}),
-  '&'.('|' x 21),
+  '&'.('|' x 22),
   'output_hash_to_vcf_info_chunk - "|" converted'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => ','}),
-  '&'.('|' x 21),
+  '&'.('|' x 22),
   'output_hash_to_vcf_info_chunk - "," converted'
 );
 
 is(
   $of->output_hash_to_vcf_info_chunk({Allele => 'A  G'}),
-  'A_G'.('|' x 21),
+  'A_G'.('|' x 22),
   'output_hash_to_vcf_info_chunk - whitespace converted'
 );
 
@@ -288,7 +291,7 @@ is(scalar @lines, scalar @{$ib->buffer}, 'get_all_lines_by_InputBuffer - count')
 is(
   $lines[0],
   "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|'.
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|'.
   "\tGT\t0|0",
   'get_all_lines_by_InputBuffer - check first'
 );
@@ -296,16 +299,16 @@ is(
 is(
   $lines[-1],
   "21\t25982445\trs141331202\tC\tT\t.\t.\t".
-  'CSQ=T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000346798||||||1157|1123|375|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000348990||||||1045|898|300|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000354192||||||857|730|244|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000357903||||||1233|1066|356|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000358918||||||1170|1123|375|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000359726||||||985|793|265|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000415997||||||326|328|110|V/I|Gtt/Att||||-1|cds_start_NF&cds_end_NF,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000439274||||||989|955|319|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000440126||||||1317|1051|351|V/I|Gtt/Att||||-1|,'.
-  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000448850||||||830|832|278|V/I|Gtt/Att||||-1|cds_start_NF'.
+  'CSQ=T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000346798||||||1157|1123|375|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000348990||||||1045|898|300|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000354192||||||857|730|244|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000357903||||||1233|1066|356|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000358918||||||1170|1123|375|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000359726||||||985|793|265|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000415997||||||326|328|110|V/I|Gtt/Att|||C/T||-1|cds_start_NF&cds_end_NF,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000439274||||||989|955|319|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000440126||||||1317|1051|351|V/I|Gtt/Att|||C/T||-1|,'.
+  'T|missense_variant|MODERATE||ENSG00000142192|Transcript|ENST00000448850||||||830|832|278|V/I|Gtt/Att|||C/T||-1|cds_start_NF'.
   "\tGT\t0|0",
   'get_all_lines_by_InputBuffer - check last'
 );
@@ -323,7 +326,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is(
   $lines[0],
   "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   'get_all_lines_by_InputBuffer - incomplete VCF entry filled out'
 );
 
@@ -333,7 +336,7 @@ $ib->buffer->[0]->get_all_TranscriptVariations->[0]->transcript->{stable_id} = '
 is(
   $lines[0],
   "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00&00_03&07%3B301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00&00_03&07%3B301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   'get_all_lines_by_InputBuffer - invalid character conversion'
 );
 
@@ -352,14 +355,14 @@ is(
   $lines[0],
 '21	25585733	rs142513484	C	T	.	.	CSQ=T|3_prime_UTR_variant'.
 '|MODIFIER|MRPL39|ENSG00000154719|Transcript|ENST00000307301|protein_coding|11/11||ENST00000307301.11:c.*18G>A||1122|'.
-'||||rs142513484|||-1||SNV|HGNC|HGNC:14027|YES|||5||CCDS33522.1|ENSP00000305682|Q9NYK5||UPI00001AEAC0|'.
+'||||rs142513484||C/T||-1||SNV|HGNC|HGNC:14027|YES|||5||CCDS33522.1|ENSP00000305682|Q9NYK5||UPI00001AEAC0|'.
 '|||||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643|0.0003236|0|0|0|1.886e-05|0|0||||||||||||0.004643|gnomADe_AFR||'.
 '|||||||,T|missense_variant|MODERATE|MRPL39|ENSG00000154719|Transcript|ENST00000352957|protein_coding|10/10|'.
-'|ENST00000352957.8:c.991G>A|ENSP00000284967.6:p.Ala331Thr|1033|991|331|A/T|Gca/Aca|rs142513484|||-1||SNV|HGNC'.
+'|ENST00000352957.8:c.991G>A|ENSP00000284967.6:p.Ala331Thr|1033|991|331|A/T|Gca/Aca|rs142513484||C/T||-1||SNV|HGNC'.
 '|HGNC:14027||||1|P1|CCDS13573.1|ENSP00000284967|Q9NYK5||UPI00001AEE66|||tolerated_low_confidence(0.17)|benign(0.001)'.
 '||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643|0.0003236|0|0|0|1.886e-05|0|0||||||||||||0.004643|gnomADe_AFR|||||||||,T'.
 '|upstream_gene_variant|MODIFIER|AP000223.1|ENSG00000260583|Transcript|ENST00000567517|antisense||||||||||rs142513484'.
-'||2407|-1||SNV|Clone_based_ensembl_gene||YES|||||||||||||||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643'.
+'||C/T|2407|-1||SNV|Clone_based_ensembl_gene||YES|||||||||||||||||0.0010|0.003|0.0014|0|0|0|0.0003478|0.004643'.
 '|0.0003236|0|0|0|1.886e-05|0|0||||||||||||0.004643|gnomADe_AFR|||||||||	GT	0|0'
 ,'get_all_lines_by_InputBuffer - everything'
 );
@@ -383,9 +386,9 @@ SKIP: {
   is(
     $of->get_all_lines_by_InputBuffer($runner->get_InputBuffer)->[0],
     "21\t25585733\trs142513484\tC\tT\t.\t.\t".
-    "CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|||test1|BAR,".
-    "T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|||test1|BAR,".
-    "T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|||test1|BAR\tGT\t0|0",
+    "CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|||test1|BAR,".
+    "T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|||test1|BAR,".
+    "T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|||test1|BAR\tGT\t0|0",
     'get_all_lines_by_InputBuffer - custom'
   );
 
@@ -400,9 +403,9 @@ SKIP: {
   is(
     $of->get_all_lines_by_InputBuffer($runner->get_InputBuffer)->[0],
     "21\t25585733\t.\tCATG\tTACG\t.\t.\t".
-    "CSQ=TACG|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1119-1122||||||||-1|||test1&del1&del2,".
-    "TACG|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1030-1033|988-991|330-331|HA/RT|CATGca/CGTAca||||-1|||test1&del1&del2,".
-    "TACG|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|||test1&del1&del2",
+    "CSQ=TACG|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1119-1122|||||||CATG/TACG||-1|||test1&del1&del2,".
+    "TACG|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1030-1033|988-991|330-331|HA/RT|CATGca/CGTAca|||CATG/TACG||-1|||test1&del1&del2,".
+    "TACG|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||CATG/TACG|2407|-1|||test1&del1&del2",
     'get_all_lines_by_InputBuffer - custom overlap'
   );
 }
@@ -417,7 +420,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t21_25585733_C/T\tC\tT\t.\t.\t".
-  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||1||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||1||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||1|2407|-1|',
+  'CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||1|C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||1|C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517||||||||||||1|C/T|2407|-1|',
   "non-VCF input"
 );
 
@@ -432,7 +435,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585732\t21_25585733_C/-\tGC\tG\t.\t.\t".
-  'CSQ=-|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,-|frameshift_variant|HIGH||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/X|Gca/ca||||-1|,-|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'CSQ=-|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/-||-1|,-|frameshift_variant|HIGH||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/X|Gca/ca|||C/-||-1|,-|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/-|2407|-1|',
   "non-VCF input - deletion"
 );
 
@@ -446,7 +449,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;BAR2=blah2;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'BAR=blah;BAR2=blah2;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   "trash existing CSQ 1"
 );
 
@@ -459,7 +462,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   "trash existing CSQ 2"
 );
 
@@ -472,7 +475,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'BAR=blah;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   "trash existing CSQ 3"
 );
 
@@ -480,7 +483,7 @@ $of->{keep_csq} = 1;
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;CSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'BAR=blah;CSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   "keep existing CSQ"
 );
 $of->{keep_csq} = 0;
@@ -495,7 +498,7 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is_deeply(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   "21\t25585733\t.\tC\tT\t.\t.\t".
-  'BAR=blah;BCSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122||||||||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca||||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||2407|-1|',
+  'BAR=blah;BCSQ=foo;CSQ=T|3_prime_UTR_variant|MODIFIER||ENSG00000154719|Transcript|ENST00000307301||||||1122|||||||C/T||-1|,T|missense_variant|MODERATE||ENSG00000154719|Transcript|ENST00000352957||||||1033|991|331|A/T|Gca/Aca|||C/T||-1|,T|upstream_gene_variant|MODIFIER||ENSG00000260583|Transcript|ENST00000567517|||||||||||||C/T|2407|-1|',
   "dont trash BCSQ"
 );
 
@@ -524,7 +527,7 @@ is_deeply(
   [map {$of->headers->[$_]} (0,2,4)],
   [
     '##fileformat=VCFv4.1',
-    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|Original_allele|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
     "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG00096"
   ],
   'headers (all but VEP) - from input test2'
@@ -622,7 +625,7 @@ is_deeply(
 
 is(
   $of->headers->[-3],
-  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
+  '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|MINIMISED|Original_allele|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID">',
   'headers - from input 2'
 );
 
@@ -688,21 +691,21 @@ $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});
 is(
   $of->get_all_lines_by_InputBuffer($ib)->[0],
   'MT	12848	rs267606899	C	T	.	.	CSQ='.
-'T|downstream_gene_variant|MODIFIER||4508|Transcript|4508|||||||||||||3641|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4509|Transcript|4509|||||||||||||4276|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4513|Transcript|4513|||||||||||||4579|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4514|Transcript|4514|||||||||||||2858|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|upstream_gene_variant|MODIFIER||4519|Transcript|4519|||||||||||||1899|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4537|Transcript|4537|||||||||||||2444|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4538|Transcript|4538|||||||||||||711|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4539|Transcript|4539|||||||||||||2082|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|missense_variant|MODERATE||4540|Transcript|4540||||||512|512|171|A/V|gCa/gTa||||1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4541|Transcript|4541|||||||||||||1301|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4556|Transcript|4556|||||||||||||1826|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4563|Transcript|4563|||||||||||||2790|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4564|Transcript|4564|||||||||||||642|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4566|Transcript|4566|||||||||||||4484|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
-'T|downstream_gene_variant|MODIFIER||4568|Transcript|4568|||||||||||||512|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4571|Transcript|4571|||||||||||||3108|-1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4573|Transcript|4573|||||||||||||2379|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4575|Transcript|4575|||||||||||||583|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|upstream_gene_variant|MODIFIER||4576|Transcript|4576|||||||||||||3040|1||rseq_mrna_nonmatch&rseq_no_comparison|',
+'T|downstream_gene_variant|MODIFIER||4508|Transcript|4508|||||||||||||C/T|3641|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4509|Transcript|4509|||||||||||||C/T|4276|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4513|Transcript|4513|||||||||||||C/T|4579|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4514|Transcript|4514|||||||||||||C/T|2858|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|upstream_gene_variant|MODIFIER||4519|Transcript|4519|||||||||||||C/T|1899|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4537|Transcript|4537|||||||||||||C/T|2444|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4538|Transcript|4538|||||||||||||C/T|711|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4539|Transcript|4539|||||||||||||C/T|2082|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|missense_variant|MODERATE||4540|Transcript|4540||||||512|512|171|A/V|gCa/gTa|||C/T||1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4541|Transcript|4541|||||||||||||C/T|1301|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4556|Transcript|4556|||||||||||||C/T|1826|-1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4563|Transcript|4563|||||||||||||C/T|2790|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4564|Transcript|4564|||||||||||||C/T|642|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4566|Transcript|4566|||||||||||||C/T|4484|1||rseq_mrna_nonmatch&rseq_no_comparison|,'.
+'T|downstream_gene_variant|MODIFIER||4568|Transcript|4568|||||||||||||C/T|512|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4571|Transcript|4571|||||||||||||C/T|3108|-1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4573|Transcript|4573|||||||||||||C/T|2379|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|downstream_gene_variant|MODIFIER||4575|Transcript|4575|||||||||||||C/T|583|1||rseq_mrna_nonmatch&rseq_no_comparison|,T|upstream_gene_variant|MODIFIER||4576|Transcript|4576|||||||||||||C/T|3040|1||rseq_mrna_nonmatch&rseq_no_comparison|',
   "RefSeq MT transcripts are returned"
 );
 

--- a/t/OutputFactory_VEP_output.t
+++ b/t/OutputFactory_VEP_output.t
@@ -172,7 +172,7 @@ is(
     3_prime_UTR_variant
     1122
     - - - - -
-    REF_ALLELE=C;IMPACT=MODIFIER;STRAND=-1
+    REF_ALLELE=C;IMPACT=MODIFIER;STRAND=-1;Original_allele=C/T
   )),
   'get_all_lines_by_InputBuffer - check first'
 );
@@ -193,7 +193,7 @@ is(
     V/I
     Gtt/Att
     -
-    REF_ALLELE=C;IMPACT=MODERATE;STRAND=-1;FLAGS=cds_start_NF
+    REF_ALLELE=C;IMPACT=MODERATE;STRAND=-1;FLAGS=cds_start_NF;Original_allele=C/T
   )),
   'get_all_lines_by_InputBuffer - check last'
 );
@@ -216,7 +216,7 @@ is(
   'HGVSc=ENST00000307301.11:c.*18G>A;'.
   'AF=0.0010;AFR_AF=0.003;AMR_AF=0.0014;EAS_AF=0;EUR_AF=0;SAS_AF=0;'.
   'gnomADe_AF=0.0003478;gnomADe_AFR_AF=0.004643;gnomADe_AMR_AF=0.0003236;gnomADe_ASJ_AF=0;'.
-  'gnomADe_EAS_AF=0;gnomADe_FIN_AF=0;gnomADe_NFE_AF=1.886e-05;gnomADe_OTH_AF=0;gnomADe_SAS_AF=0;MAX_AF=0.004643;MAX_AF_POPS=gnomADe_AFR',
+  'gnomADe_EAS_AF=0;gnomADe_FIN_AF=0;gnomADe_NFE_AF=1.886e-05;gnomADe_OTH_AF=0;gnomADe_SAS_AF=0;MAX_AF=0.004643;MAX_AF_POPS=gnomADe_AFR;Original_allele=C/T',
   'get_all_lines_by_InputBuffer - everything'
 );
 
@@ -251,7 +251,7 @@ SKIP: {
       3_prime_UTR_variant
       1122
       - - - - -
-      IMPACT=MODIFIER;STRAND=-1;test=test1;test_FILTER=PASS;test_FOO=BAR
+      IMPACT=MODIFIER;STRAND=-1;Original_allele=C/T;test=test1;test_FILTER=PASS;test_FOO=BAR
     )),
     'get_all_lines_by_InputBuffer - custom'
   );

--- a/t/Parser_VEP_input.t
+++ b/t/Parser_VEP_input.t
@@ -65,6 +65,10 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
+  'original_allele_string' => 'C/A',
+  'original_start' => 25587759,
+  'original_end' => 25587759, 
+  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A + test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'basic next test');
 
@@ -83,6 +87,10 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
+  'original_allele_string' => 'C/A',
+  'original_start' => 25587759,
+  'original_end' => 25587759,
+  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A - test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'negative strand (-)');
 
@@ -101,6 +109,10 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
+  'original_allele_string' => 'C/A',
+  'original_start' => 25587759,
+  'original_end' => 25587759,
+  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A -1 test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'negative strand (-1)');
 
@@ -119,6 +131,10 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
+  'original_allele_string' => 'C/A',
+  'original_start' => 25587759,
+  'original_end' => 25587759,
+  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'stubby');
 

--- a/t/Parser_VEP_input.t
+++ b/t/Parser_VEP_input.t
@@ -65,10 +65,6 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
-  'original_allele_string' => 'C/A',
-  'original_start' => 25587759,
-  'original_end' => 25587759, 
-  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A + test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'basic next test');
 
@@ -87,10 +83,6 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
-  'original_allele_string' => 'C/A',
-  'original_start' => 25587759,
-  'original_end' => 25587759,
-  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A - test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'negative strand (-)');
 
@@ -109,10 +101,6 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
-  'original_allele_string' => 'C/A',
-  'original_start' => 25587759,
-  'original_end' => 25587759,
-  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A -1 test)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'negative strand (-1)');
 
@@ -131,10 +119,6 @@ is_deeply($vf, bless( {
   'start' => '25587759',
   'seq_region_end' => '25587759',
   'seq_region_start' => '25587759',
-  'original_allele_string' => 'C/A',
-  'original_start' => 25587759,
-  'original_end' => 25587759,
-  'minimised' => 1,
   '_line' => [qw(21 25587759 25587759 C/A)]
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'stubby');
 

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -1214,6 +1214,7 @@ SKIP: {
          "allele_string" => "C/A",
          "assembly_name" => "GRCh38",
          "end" => 10524654,
+         "original_allele" => 'C/A',
          "id" => ".",
          "input" =>  "21 10524654 . C A",
          "intergenic_consequences" => [

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -246,7 +246,7 @@ is_deeply(
       3_prime_UTR_variant
       1122
       - - - - -
-      IMPACT=MODIFIER;STRAND=-1;MINIMISED=1;Original_allele=C/T
+      IMPACT=MODIFIER;STRAND=-1;Original_allele=C/T
     )),
     join("\t", qw(
       rs142513484
@@ -262,7 +262,7 @@ is_deeply(
       A/T
       Gca/Aca
       -
-      IMPACT=MODERATE;STRAND=-1;MINIMISED=1;Original_allele=C/T
+      IMPACT=MODERATE;STRAND=-1;Original_allele=C/T
     )),
     join("\t", qw(
       rs142513484
@@ -278,7 +278,7 @@ is_deeply(
       -
       -
       -
-      IMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1;Original_allele=C/T
+      IMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;Original_allele=C/T
     )),
   ],
   '_buffer_to_output'
@@ -298,7 +298,7 @@ is(
     3_prime_UTR_variant
     1122
     - - - - -
-    IMPACT=MODIFIER;STRAND=-1;MINIMISED=1;Original_allele=C/T
+    IMPACT=MODIFIER;STRAND=-1;Original_allele=C/T
   )),
   'next_output_line'
 );
@@ -438,9 +438,9 @@ is(scalar @tmp_lines, 41, 'run - count lines');
 is_deeply(
   [grep {!/^\#/} @tmp_lines],
   [
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1;MINIMISED=1;Original_allele=C/T\n",
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1;MINIMISED=1;Original_allele=C/T\n",
-    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1;Original_allele=C/T\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1;Original_allele=C/T\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1;Original_allele=C/T\n",
+    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;Original_allele=C/T\n",
   ],
   'run - lines content'
 );

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -246,7 +246,7 @@ is_deeply(
       3_prime_UTR_variant
       1122
       - - - - -
-      IMPACT=MODIFIER;STRAND=-1
+      IMPACT=MODIFIER;STRAND=-1;MINIMISED=1
     )),
     join("\t", qw(
       rs142513484
@@ -262,7 +262,7 @@ is_deeply(
       A/T
       Gca/Aca
       -
-      IMPACT=MODERATE;STRAND=-1
+      IMPACT=MODERATE;STRAND=-1;MINIMISED=1
     )),
     join("\t", qw(
       rs142513484
@@ -439,8 +439,8 @@ is_deeply(
   [grep {!/^\#/} @tmp_lines],
   [
     "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1;MINIMISED=1\n",
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1\n",
-    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1;MINIMISED=1\n",
+    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1\n",
   ],
   'run - lines content'
 );

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -278,7 +278,7 @@ is_deeply(
       -
       -
       -
-      IMPACT=MODIFIER;DISTANCE=2407;STRAND=-1
+      IMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1
     )),
   ],
   '_buffer_to_output'
@@ -298,7 +298,7 @@ is(
     3_prime_UTR_variant
     1122
     - - - - -
-    IMPACT=MODIFIER;STRAND=-1
+    IMPACT=MODIFIER;STRAND=-1;MINIMISED=1
   )),
   'next_output_line'
 );
@@ -438,7 +438,7 @@ is(scalar @tmp_lines, 41, 'run - count lines');
 is_deeply(
   [grep {!/^\#/} @tmp_lines],
   [
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1;MINIMISED=1\n",
     "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1\n",
     "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1\n",
   ],

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -246,7 +246,7 @@ is_deeply(
       3_prime_UTR_variant
       1122
       - - - - -
-      IMPACT=MODIFIER;STRAND=-1;MINIMISED=1
+      IMPACT=MODIFIER;STRAND=-1;MINIMISED=1;Original_allele=C/T
     )),
     join("\t", qw(
       rs142513484
@@ -262,7 +262,7 @@ is_deeply(
       A/T
       Gca/Aca
       -
-      IMPACT=MODERATE;STRAND=-1;MINIMISED=1
+      IMPACT=MODERATE;STRAND=-1;MINIMISED=1;Original_allele=C/T
     )),
     join("\t", qw(
       rs142513484
@@ -278,7 +278,7 @@ is_deeply(
       -
       -
       -
-      IMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1
+      IMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1;Original_allele=C/T
     )),
   ],
   '_buffer_to_output'
@@ -298,7 +298,7 @@ is(
     3_prime_UTR_variant
     1122
     - - - - -
-    IMPACT=MODIFIER;STRAND=-1;MINIMISED=1
+    IMPACT=MODIFIER;STRAND=-1;MINIMISED=1;Original_allele=C/T
   )),
   'next_output_line'
 );
@@ -438,9 +438,9 @@ is(scalar @tmp_lines, 41, 'run - count lines');
 is_deeply(
   [grep {!/^\#/} @tmp_lines],
   [
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1;MINIMISED=1\n",
-    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1;MINIMISED=1\n",
-    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000307301\tTranscript\t3_prime_UTR_variant\t1122\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;STRAND=-1;MINIMISED=1;Original_allele=C/T\n",
+    "rs142513484\t21:25585733\tT\tENSG00000154719\tENST00000352957\tTranscript\tmissense_variant\t1033\t991\t331\tA/T\tGca/Aca\t-\tIMPACT=MODERATE;STRAND=-1;MINIMISED=1;Original_allele=C/T\n",
+    "rs142513484\t21:25585733\tT\tENSG00000260583\tENST00000567517\tTranscript\tupstream_gene_variant\t-\t-\t-\t-\t-\t-\tIMPACT=MODIFIER;DISTANCE=2407;STRAND=-1;MINIMISED=1;Original_allele=C/T\n",
   ],
   'run - lines content'
 );
@@ -1091,6 +1091,7 @@ SKIP: {
         'end' => 25585733,
         'seq_region_name' => '21',
         'strand' => 1,
+        'original_allele' => 'C/T',
         'transcript_consequences' => [
           {
             'gene_id' => 'ENSG00000154719',


### PR DESCRIPTION
[ENSVAR-3378](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3378) 

The idea is to support indels in VEP default input and to get a minimised allele

### Testing
`vep --shift_3prime -i input.txt`

### Input
3 46358466 46358467 AA/AAG 1
3 46358467 46358467 A/AG 1
3 46358468 46358467 -/G 1
3 46358466 46358466 A/C 1
3 46358470 46358471 TA/GTA 1