### PR TITLE
Fix option shift_genomic

### DIFF
--- a/vep
+++ b/vep
@@ -173,7 +173,7 @@ GetOptions(
   'ambiguity',               # Add allele ambiguity code
   'var_synonyms', 	     # include variation synonyms in output
   'shift_3prime=i',          # enables shifting of all variants to 3prime
-  'shift_genomic',           # adds genomic shifting to output, and provides shifting of intergenic variants
+  'shift_genomic=i',         # adds genomic shifting to output, and provides shifting of intergenic variants
   'shift_length',	     # adds the length of the transcript directional shift to output
 
   # cache stuff


### PR DESCRIPTION
In the documentation, the option `shift_genomic` accepts a value (0 or 1) however running vep with `shift_genomic 1` throws an error:
`ERROR: Unexpected extra command-line parameter(s): 1 at /hps/software/users/ensembl/repositories/dlemos/ensembl-vep/vep line 220.`