### PR TITLE
refactor: add non-ordered options to custom

### DIFF
--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -3,7 +3,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       identification within third-party archives.
 
    Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-   Copyright [2016-2023] EMBL-European Bioinformatics Institute
+   Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/convert_cache.pl
+++ b/convert_cache.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/filter_vep
+++ b/filter_vep
@@ -3,7 +3,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/haplo
+++ b/haplo
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -171,10 +171,6 @@ sub get_all_regions_by_InputBuffer {
   my ($min, $max) = (1e10, 0);
 
   foreach my $vf(@{$buffer->buffer}) {
-
-    # skip long and unsupported types of SV; doing this here to avoid stopping looping
-    next if $vf->{vep_skip};
-
     my $chr = $vf->{chr} || $vf->slice->seq_region_name;
     throw("ERROR: Cannot get chromosome from VariationFeature") unless $chr;
 

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/BaseCacheVariation.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/BaseCacheVariation.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/BaseSerialized.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/BaseSerialized.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/RegFeat.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/RegFeat.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/Transcript.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/Variation.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/Variation.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/VariationTabix.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/VariationTabix.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/RegFeat.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/RegFeat.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/StructuralVariation.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/StructuralVariation.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Variation.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Variation.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BED.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BED.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BigWig.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BigWig.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GTF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GTF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/VCF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
@@ -210,7 +210,7 @@ sub get_all_custom {
 
     foreach my $param(@params) {
       my ($key, $val) = split('=', $param);
-      die("ERROR: Failed to parse parameter $param; Please add <NAME_OF_PARAMETER>=$param\n") unless defined($key) && defined($val);
+      die("ERROR: Failed to parse parameter $param; Please add $param=<VALUE_OF_PARAMETER>\n") unless defined($key) && defined($val);
       $hash{$key} = $val;
     }
 

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
@@ -214,6 +214,7 @@ sub get_all_custom {
       $hash{$key} = $val;
     }
 
+    throw("ERROR: No format specified for custom annotation source. " $hash{"file"} . "\n") unless $hash{"format"};
     throw("ERROR: Access to remote data files disabled\n") if $self->param('no_remote') && $hash{"file"} =~ /^(ht|f)tp:\/\/.+/;
 
     my $opts = {

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
@@ -214,7 +214,8 @@ sub get_all_custom {
       $hash{$key} = $val;
     }
 
-    throw("ERROR: No format specified for custom annotation source. " $hash{"file"} . "\n") unless $hash{"format"};
+    throw("ERROR: No file was added for custom annotation. " . $hash{"file"} . "\n") unless defined($hash{"file"});
+    throw("ERROR: No format specified for custom annotation source. " . $hash{"file"} . "\n") unless defined($hash{"format"});
     throw("ERROR: Access to remote data files disabled\n") if $self->param('no_remote') && $hash{"file"} =~ /^(ht|f)tp:\/\/.+/;
 
     my $opts = {

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
@@ -214,7 +214,7 @@ sub get_all_custom {
       $hash{$key} = $val;
     }
 
-    throw("ERROR: No file was added for custom annotation. " . $hash{"file"} . "\n") unless defined($hash{"file"});
+    throw("ERROR: No file was added for custom annotation.\n") unless defined($hash{"file"});
     throw("ERROR: No format specified for custom annotation source. " . $hash{"file"} . "\n") unless defined($hash{"format"});
     throw("ERROR: Access to remote data files disabled\n") if $self->param('no_remote') && $hash{"file"} =~ /^(ht|f)tp:\/\/.+/;
 

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
@@ -214,8 +214,8 @@ sub get_all_custom {
       $hash{$key} = $val;
     }
 
-    throw("ERROR: No file was added for custom annotation.\n") unless defined($hash{"file"});
-    throw("ERROR: No format specified for custom annotation source. " . $hash{"file"} . "\n") unless defined($hash{"format"});
+    throw("ERROR: No 'file=' was added for custom annotation source.\nLINE: --custom $custom_string\n") unless defined($hash{"file"});
+    throw("ERROR: No 'format=' specified for custom annotation source.\nLINE: --custom $custom_string\n") unless defined($hash{"format"});
     throw("ERROR: Access to remote data files disabled\n") if $self->param('no_remote') && $hash{"file"} =~ /^(ht|f)tp:\/\/.+/;
 
     my $opts = {

--- a/modules/Bio/EnsEMBL/VEP/AnnotationType/RegFeat.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationType/RegFeat.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/AnnotationType/Variation.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationType/Variation.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/CacheDir.pm
+++ b/modules/Bio/EnsEMBL/VEP/CacheDir.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -303,14 +303,14 @@ our @OPTION_SETS = (
   {
     flags => ['gff'],
     set   => {
-      custom => '%gff%,,gff'
+      custom => 'file=%gff%,format=gff'
     }
   },
   
   {
     flags => ['gtf'],
     set   => {
-      custom => '%gtf%,,gtf'
+      custom => 'file=%gtf%,format=gtf'
     }
   },
   

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ our %DEFAULTS = (
   failed            => 0,
   core_type         => 'core',
   polyphen_analysis => 'humvar',
-  pick_order        => [qw(mane canonical appris tsl biotype ccds rank length ensembl refseq )],
+  pick_order        => [qw(canonical appris tsl biotype ccds rank length ensembl refseq mane)],
   terminal_width    => 48,
   vcf_info_field    => 'CSQ',
   ucsc_data_root    => 'http://hgdownload.cse.ucsc.edu/goldenpath/',
@@ -380,7 +380,8 @@ our %REQUIRES = (
   original  => [qw(filters)],
   phyloP    => [qw(ucsc_assembly)],
   phastCons => [qw(ucsc_assembly)],
-  custom_multi_allelic => [qw(custom)]
+  custom_multi_allelic => [qw(custom)],
+  ga4gh_vrs => [qw(json)]
 );
 
 # incompatible options
@@ -396,8 +397,7 @@ our %INCOMPATIBLE = (
   tab         => [qw(vcf json)],
   individual  => [qw(minimal)],
   check_ref   => [qw(lookup_ref)],
-  check_svs   => [qw(offline)],
-  ga4gh_vrs   => [qw(vcf)]
+  check_svs   => [qw(offline)]
 );
 
 # deprecated/replaced flags
@@ -487,7 +487,7 @@ sub new {
     $config->{cache} = 1;
   }
 
-  my $config_command = "";
+  my $config_command;
 
   my @skip_opts = qw(web_output host port stats_file user warning_file input_data);
 

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ use warnings;
 
 use base qw(Exporter);
 
-our $VEP_VERSION     = 110;
+our $VEP_VERSION     = 109;
 our $VEP_SUB_VERSION = 0;
 
 our @EXPORT_OK = qw(
@@ -76,7 +76,6 @@ our @FLAG_FIELDS = (
   { flag => 'variant_class',   fields => ['VARIANT_CLASS']},
   { flag => 'minimal',         fields => ['MINIMISED']},
   { flag => 'spdi',            fields => ['SPDI']},
-  { flag => 'ga4gh_vrs',       fields => ['GA4GH_VRS']},
 
   # gene-related
   { flag => 'symbol',          fields => ['SYMBOL','SYMBOL_SOURCE','HGNC_ID'] },
@@ -173,7 +172,6 @@ our %FIELD_DESCRIPTIONS = (
   'HGVSp'              => 'HGVS protein sequence name',
   'HGVSg'              => 'HGVS genomic sequence name',
   'SPDI'               => 'Genomic SPDI notation',
-  'GA4GH_VRS'          => 'GA4GH Variation Representation Specification',
   'SIFT'               => 'SIFT prediction and/or score',
   'PolyPhen'           => 'PolyPhen prediction and/or score',
   'EXON'               => 'Exon number(s) / total',

--- a/modules/Bio/EnsEMBL/VEP/FilterSet.pm
+++ b/modules/Bio/EnsEMBL/VEP/FilterSet.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/Cache/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/Cache/Transcript.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/Database/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/Database/Transcript.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/File/GFF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/File/GFF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/File/GTF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationSource/File/GTF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationType/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/AnnotationType/Transcript.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/InputBuffer.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/Parser/VCF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Haplo/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Haplo/Runner.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -209,6 +209,8 @@ sub next {
   if(my $parser = $self->parser) {
     while(@$buffer < $buffer_size && (my $vf = $parser->next)) {
 
+      # skip long and unsupported types of SV; doing this here to avoid stopping looping
+      next if $vf->{vep_skip};
 
       # exit the program if the maximum number of variants not ordered in the input file is reached
       if (!$self->param('no_check_variants_order') &&

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/BaseTab.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/BaseTab.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ use base qw(Bio::EnsEMBL::VEP::OutputFactory);
 
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Variation::Utils::Constants;
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(ga4gh_vrs_from_spdi);
 
 use Bio::EnsEMBL::VEP::Utils qw(numberify);
 
@@ -221,16 +222,7 @@ sub get_all_output_hashes_by_InputBuffer {
 
   foreach my $vf(@{$buffer->buffer}) {
 
-    my $hash;
-
-    # Include non-annotated line
-    if ($vf->{vep_skip}){
-      $hash->{input} = join($self->{delimiter}, @{$vf->{_line}}) if defined($vf->{_line});
-      push @return, $hash;
-      next;  
-    }
-
-    $hash = {
+    my $hash = {
       id              => $vf->{variation_name},
       seq_region_name => $vf->{chr},
       start           => $vf->{start},
@@ -370,6 +362,12 @@ sub add_VariationFeatureOverlapAllele_info {
     foreach my $key(grep {defined($vfoa_hash->{$_})} keys %rename) {
       $vfoa_hash->{$rename{$key}} = $vfoa_hash->{$key};
       delete $vfoa_hash->{$key};
+    }
+    if (defined($vfoa_hash->{ga4gh_spdi})) {
+      my $ga4gh_vrs = ga4gh_vrs_from_spdi($vfoa_hash->{ga4gh_spdi});
+      if ($ga4gh_vrs) {
+          $vfoa_hash->{ga4gh_vrs} = $ga4gh_vrs;
+      }
     }
     push @{$hash->{$ftype.'_consequences'}}, $vfoa_hash;
   }

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/Tab.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/Tab.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -279,12 +279,6 @@ sub get_all_lines_by_InputBuffer {
   $self->rejoin_variants_in_InputBuffer($buffer) if $buffer->rejoin_required;
 
   foreach my $vf(@{$buffer->buffer}) {
-
-    # Include non-annotated line
-    if ($vf->{vep_skip}){
-      push @return, join("\t", @{$vf->{_line}}) if $vf->{vep_skip};
-      next;  
-    }
 
     my $line;
     my $fieldname = $self->{vcf_info_field} || 'CSQ';

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Parser/CAID.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/CAID.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Parser/ID.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/ID.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Parser/SPDI.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/SPDI.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -481,9 +481,7 @@ sub create_StructuralVariationFeatures {
       DEL  => 'deletion',
       TDUP => 'tandem_duplication',
       DUP  => 'duplication',
-      CNV  => 'copy_number_variation',
-      INV  => 'inversion',
-      BND  => 'breakpoint'
+      CNV  => 'copy_number_variation'
     );
 
     $so_term = defined $terms{$type} ? $terms{$type} : $type;

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/BaseVEP.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DistributeDumps.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DistributeDumps.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DumpVEP_conf.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DumpVEP_conf.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -71,8 +71,7 @@ sub default_options {
     dump_vep_data_dir       => $self->o('data_dir') . '/dump_vep',
     
     # temporary space
-    tmp_base_dir            => '/hps/nobackup/flicek/ensembl/variation',
-    tmp_dir                 => catdir($self->o('tmp_base_dir'), $ENV{'USER'}, $self->o('pipeline_name'), 'vepdump'),
+    tmp_dir                 => catdir('/hps/nobackup/flicek/ensembl', $ENV{'USER'}, $self->o('pipeline_name'), 'vepdump'),
         
     # dump databases of this version number
     ensembl_release => undef,
@@ -133,7 +132,7 @@ sub default_options {
             ],
           },
           GRCh38 => {
-            bam => $self->o('dump_vep_data_dir').'/GCF_000001405.40_GRCh38.p14_knownrefseq_alns.bam',
+            bam => $self->o('dump_vep_data_dir').'/GCF_000001405.39_GRCh38.p13_knownrefseq_alns.bam',
             freq_vcf => [
               {
                 file => $self->o('dump_vep_data_dir').'/1KG.phase3.GRCh38_2018_02_26.vcf.gz',

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Core.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Core.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Otherfeatures.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Otherfeatures.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Regulation.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Regulation.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/FinishDump.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/FinishDump.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/InitDump.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/InitDump.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/JoinVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/JoinVEP.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/MergeVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/MergeVEP.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -272,8 +272,6 @@ sub check_dirs {
         or $file eq 'all_vars.gz'
         or $file eq 'all_vars.gz.tbi'
         or $file eq 'all_vars.gz.csi';
-        
-      die("ERROR: File size of $file does not look right\n") if -z $file;
 
       if($file =~ /var/) {
         die("ERROR: Cache should not contain var files, found $file in $dir/$chr\n") unless $has_var;

--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/TranscriptTree.pm
+++ b/modules/Bio/EnsEMBL/VEP/TranscriptTree.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/Utils.pm
+++ b/modules/Bio/EnsEMBL/VEP/Utils.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/Bio/EnsEMBL/VEP/VariantRecoder.pm
+++ b/modules/Bio/EnsEMBL/VEP/VariantRecoder.pm
@@ -1,6 +1,6 @@
 =head1 LICENSE
 
-Copyright [2016-2023] EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -296,7 +296,7 @@ sub _get_all_results {
 
   my $ga4gh_vrs = 0;
   if ($want_keys{'ga4gh_vrs'}) {
-    $want_keys{'spdi'} = 1;
+    $want_keys{'ga4gh_spdi'} = 1;
     $ga4gh_vrs = 1;
   }
 
@@ -470,14 +470,17 @@ sub _get_all_results {
       add_to_output($mane_by_allele{$allele}, \%key_mane, $results->{$line_id}->{$allele} ||= {input => $line_id});
     }
 
-    # Adding GA4GH VRS allele objects based on SPDI
+    # Adding GA4GH VRS allele objects
+    # The genomic refseq SPDI are stored in 'ga4gh_spdi'
+    # The find_in_ref calls make the ga4gh_spdi unique
     if ($ga4gh_vrs) {
       for my $allele (keys %{$results->{$line_id}}) {
-        next if (! exists $results->{$line_id}->{$allele}->{'spdi'});
-        my @spdis = @{$results->{$line_id}->{$allele}->{'spdi'}};
-        for my $spdi (@spdis) {
-          push @{$results->{$line_id}->{$allele}->{'ga4gh_vrs'}}, ga4gh_vrs_from_spdi($spdi);
+        next if (! exists $results->{$line_id}->{$allele}->{'ga4gh_spdi'});
+        my @ga4gh_spdis = @{$results->{$line_id}->{$allele}->{'ga4gh_spdi'}};
+        for my $ga4gh_spdi (@ga4gh_spdis) {
+          push @{$results->{$line_id}->{$allele}->{'ga4gh_vrs'}}, ga4gh_vrs_from_spdi($ga4gh_spdi);
         }
+        delete($results->{$line_id}->{$allele}->{'ga4gh_spdi'});
       }
     }
 

--- a/t/AnnotationSource.t
+++ b/t/AnnotationSource.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSourceAdaptor.t
+++ b/t/AnnotationSourceAdaptor.t
@@ -92,14 +92,17 @@ $asa->param('check_existing', 1);
 is_deeply(ref($asa->get_all()->[0]), 'Bio::EnsEMBL::VEP::AnnotationSource::Cache::Variation', 'get_all - var comes first');
 $asa->param('check_existing', 0);
 
-$asa->param('custom', [$test_cfg->{custom_vcf}]);
-throws_ok {$asa->get_all_custom} qr/No format/, 'get_all_custom - no format';
+# $asa->param('custom', [$test_cfg->{custom_vcf}]);
+# throws_ok {$asa->get_all_custom} qr/No format/, 'get_all_custom - no format';
 
-$asa->param('custom', [$test_cfg->{custom_vcf}.',test,foo,exact']);
-throws_ok {$asa->get_all_custom} qr/Unknown or unsupported format foo/, 'get_all_custom - invalid format';
+$asa->param('custom', ['test=' . $test_cfg->{custom_vcf} . ',format=vcf,short_name=foo,type=exact']);
+throws_ok {$asa->get_all_custom} qr/No 'file=' was added for custom annotation source./, 'get_all_custom - invalid file';
+
+$asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',test=vcf,short_name=foo,type=exact']);
+throws_ok {$asa->get_all_custom} qr/No 'format=' specified for custom annotation source./, 'get_all_custom - invalid format';
 
 $asa->param('no_remote', 1);
-$asa->param('custom', ['http://foo.bar.com/file,test,foo,exact']);
+$asa->param('custom', ['file=http://foo.bar.com/file,format=test,short_name=foo,type=exact']);
 throws_ok {$asa->get_all_custom} qr/Access to remote data files disabled/, 'get_all_custom - no_remote';
 $asa->param('no_remote', 0);
 
@@ -112,7 +115,7 @@ SKIP: {
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
   skip 'Bio::DB::HTS::Tabix module not available', 5 unless $Bio::EnsEMBL::VEP::AnnotationSource::File::CAN_USE_TABIX_PM;
 
-  $asa->param('custom', [$test_cfg->{custom_vcf}.',test,vcf,exact']);
+  $asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=exact']);
   is_deeply(
     $asa->get_all_custom(),
     [
@@ -126,7 +129,7 @@ SKIP: {
         'info' => {
           'custom_info' => {
             'short_name' => 'test',
-            'report_coords' => undef,
+            'report_coords' => 0,
             'file' => $test_cfg->{custom_vcf},
             'type' => 'exact'
           }
@@ -136,7 +139,7 @@ SKIP: {
     'get_all_custom'
   );
 
-  $asa->param('custom', [$test_cfg->{custom_vcf}.',test,vcf']);
+  $asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf']);
   is_deeply(
     $asa->get_all_custom(),
     [
@@ -150,7 +153,7 @@ SKIP: {
         'info' => {
           'custom_info' => {
             'short_name' => 'test',
-            'report_coords' => undef,
+            'report_coords' => 0,
             'file' => $test_cfg->{custom_vcf},
             'type' => 'overlap'
           }
@@ -160,7 +163,7 @@ SKIP: {
     'get_all_custom - default overlap type'
   );
 
-  $asa->param('custom', [$test_cfg->{custom_vcf}.',test,vcf,overlap,1']);
+  $asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=overlap,coords=1']);
   is_deeply(
     $asa->get_all_custom(),
     [
@@ -184,7 +187,7 @@ SKIP: {
     'get_all_custom - report_coords'
   );
 
-  $asa->param('custom', [$test_cfg->{custom_vcf}.',test,vcf,overlap,1,FOO,BAR']);
+  $asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=overlap,coords=1,fields=FOO%BAR']);
   is_deeply(
     $asa->get_all_custom(),
     [
@@ -212,7 +215,7 @@ SKIP: {
 
   my $test = $test_cfg->{test_vcf_MT};
   $test =~ s/MT.vcf.gz/\#\#\#CHR\#\#\#\.vcf.gz/;
-  $asa->param('custom', [$test.',test,vcf,overlap,1,FOO,BAR']);
+  $asa->param('custom', ['file=' . $test . ',short_name=test,format=vcf,type=overlap,coords=1,fields=FOO%BAR']);
   is_deeply(
     $asa->get_all_custom(),
     [

--- a/t/AnnotationSourceAdaptor.t
+++ b/t/AnnotationSourceAdaptor.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSourceAdaptor.t
+++ b/t/AnnotationSourceAdaptor.t
@@ -92,14 +92,14 @@ $asa->param('check_existing', 1);
 is_deeply(ref($asa->get_all()->[0]), 'Bio::EnsEMBL::VEP::AnnotationSource::Cache::Variation', 'get_all - var comes first');
 $asa->param('check_existing', 0);
 
-# $asa->param('custom', [$test_cfg->{custom_vcf}]);
-# throws_ok {$asa->get_all_custom} qr/No format/, 'get_all_custom - no format';
-
 $asa->param('custom', ['test=' . $test_cfg->{custom_vcf} . ',format=vcf,short_name=foo,type=exact']);
 throws_ok {$asa->get_all_custom} qr/No 'file=' was added for custom annotation source./, 'get_all_custom - invalid file';
 
 $asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',test=vcf,short_name=foo,type=exact']);
 throws_ok {$asa->get_all_custom} qr/No 'format=' specified for custom annotation source./, 'get_all_custom - invalid format';
+
+$asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',format=foo,short_name=test,type=exact']);
+throws_ok {$asa->get_all_custom} qr/Unknown or unsupported format foo/, 'get_all_custom - invalid format value';
 
 $asa->param('no_remote', 1);
 $asa->param('custom', ['file=http://foo.bar.com/file,format=test,short_name=foo,type=exact']);

--- a/t/AnnotationSource_Cache.t
+++ b/t/AnnotationSource_Cache.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Cache_RegFeat.t
+++ b/t/AnnotationSource_Cache_RegFeat.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Cache_Transcript.t
+++ b/t/AnnotationSource_Cache_Transcript.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Cache_Variation.t
+++ b/t/AnnotationSource_Cache_Variation.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Cache_VariationTabix.t
+++ b/t/AnnotationSource_Cache_VariationTabix.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Database_RegFeat.t
+++ b/t/AnnotationSource_Database_RegFeat.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Database_StructuralVariation.t
+++ b/t/AnnotationSource_Database_StructuralVariation.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Database_Transcript.t
+++ b/t/AnnotationSource_Database_Transcript.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_Database_Variation.t
+++ b/t/AnnotationSource_Database_Variation.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_File.t
+++ b/t/AnnotationSource_File.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_File_BED.t
+++ b/t/AnnotationSource_File_BED.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_File_BigWig.t
+++ b/t/AnnotationSource_File_BigWig.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_File_GFF.t
+++ b/t/AnnotationSource_File_GFF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_File_GTF.t
+++ b/t/AnnotationSource_File_GTF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/AnnotationSource_File_VCF.t
+++ b/t/AnnotationSource_File_VCF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/BaseVEP.t
+++ b/t/BaseVEP.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/CacheDir.t
+++ b/t/CacheDir.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Config.t
+++ b/t/Config.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Config.t
+++ b/t/Config.t
@@ -90,7 +90,7 @@ $cfg = Bio::EnsEMBL::VEP::Config->new({check_frequency => 1});
 is($cfg->param('check_existing'), 1, 'option sets, multiple in same out 2');
 
 $cfg = Bio::EnsEMBL::VEP::Config->new({gff => 'test'});
-is_deeply($cfg->param('custom'), ['test,,gff'], 'option sets, substitution');
+is_deeply($cfg->param('custom'), ['file=test,format=gff'], 'option sets, substitution');
 
 $cfg = Bio::EnsEMBL::VEP::Config->new({ucsc_assembly => 'hg38', phyloP => [7, 100], custom => []});
 is_deeply(

--- a/t/FilterSet.t
+++ b/t/FilterSet.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Haplo_AnnotationSource_Cache_Transcript.t
+++ b/t/Haplo_AnnotationSource_Cache_Transcript.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Haplo_AnnotationSource_Database_Transcript.t
+++ b/t/Haplo_AnnotationSource_Database_Transcript.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Haplo_AnnotationSource_File_GFF.t
+++ b/t/Haplo_AnnotationSource_File_GFF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Haplo_AnnotationSource_File_GTF.t
+++ b/t/Haplo_AnnotationSource_File_GTF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Haplo_InputBuffer.t
+++ b/t/Haplo_InputBuffer.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Haplo_Parser_VCF.t
+++ b/t/Haplo_Parser_VCF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Haplo_Runner.t
+++ b/t/Haplo_Runner.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/InputBuffer.t
+++ b/t/InputBuffer.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -1800,7 +1800,7 @@ SKIP: {
 
   $runner = get_annotated_buffer_runner({
     input_file => $test_cfg->create_input_file([qw(21 25606454 test G C . . .)]),
-    custom => [$test_cfg->{custom_vcf}.',test,vcf'],
+    custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf'],
     quiet => 1,
     warning_file => 'STDERR',
   });
@@ -1829,7 +1829,8 @@ SKIP: {
 
   $runner = get_annotated_buffer_runner({
     input_file => $test_cfg->create_input_file([qw(21 25606454 test G C . . .)]),
-    custom => [$test_cfg->{custom_vcf}.',test,vcf', $test_cfg->{custom_vcf_2}.',test,vcf'],
+    custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf',
+               'file=' . $test_cfg->{custom_vcf_2} . ',short_name=test,format=vcf'],
     quiet => 1,
     warning_file => 'STDERR',
   });

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -602,7 +602,7 @@ SKIP: {
       input_file => $test_cfg->{test_vcf},
       everything => 1,
       dir => $test_cfg->{cache_root_dir},
-      custom => [$test_cfg->{custom_vcf}.',test,vcf,exact,,FOO'],
+      custom => ['file=' . $test_cfg->{custom_vcf}.',short_name=test,format=vcf,type=exact,fields=FOO'],
     });
     $of = Bio::EnsEMBL::VEP::OutputFactory::JSON->new({config => $ib->config});
     @lines = @{$of->get_all_lines_by_InputBuffer($ib)};
@@ -628,7 +628,7 @@ SKIP: {
       input_data => "21\t25585733\t.\tCATG\tTACG",
       everything => 1,
       dir => $test_cfg->{cache_root_dir},
-      custom => [$test_cfg->{custom_vcf}.',test,vcf,overlap'],
+      custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=overlap'],
     });
     $of = Bio::EnsEMBL::VEP::OutputFactory::JSON->new({config => $ib->config});
     @lines = @{$of->get_all_lines_by_InputBuffer($ib)};

--- a/t/OutputFactory_Tab.t
+++ b/t/OutputFactory_Tab.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/OutputFactory_Tab.t
+++ b/t/OutputFactory_Tab.t
@@ -207,7 +207,7 @@ SKIP: {
 
   $runner = get_annotated_buffer_runner({
     input_file => $test_cfg->{test_vcf},
-    custom => [$test_cfg->{custom_vcf}.',test,vcf,exact,,FOO'],
+    custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=exact,fields=FOO'],
     output_format => 'tab',
   });
   $of = $runner->get_OutputFactory;

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -372,7 +372,7 @@ SKIP: {
 
   $runner = get_runner({
     input_file => $test_cfg->{test_vcf},
-    custom => [$test_cfg->{custom_vcf}.',test,vcf,exact,,FOO'],
+    custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=exact,fields=FOO'],
     output_format => 'vcf',
   });
   $of = $runner->get_OutputFactory;
@@ -389,7 +389,7 @@ SKIP: {
 
   $runner = get_runner({
     input_data => "21\t25585733\t.\tCATG\tTACG",
-    custom => [$test_cfg->{custom_vcf}.',test,vcf,overlap'],
+    custom => ['file=' . $test_cfg->{custom_vcf}.',short_name=test,format=vcf,type=overlap'],
     output_format => 'vcf',
   });
   $of = $runner->get_OutputFactory;

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/OutputFactory_VEP_output.t
+++ b/t/OutputFactory_VEP_output.t
@@ -232,7 +232,7 @@ SKIP: {
 
   $runner = get_annotated_buffer_runner({
     input_file => $test_cfg->{test_vcf},
-    custom => [$test_cfg->{custom_vcf}.',test,vcf,exact,,FOO'],
+    custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=exact,fields=sFOO'],
     output_format => 'vep',
   });
   $of = $runner->get_OutputFactory;

--- a/t/OutputFactory_VEP_output.t
+++ b/t/OutputFactory_VEP_output.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/OutputFactory_VEP_output.t
+++ b/t/OutputFactory_VEP_output.t
@@ -232,7 +232,7 @@ SKIP: {
 
   $runner = get_annotated_buffer_runner({
     input_file => $test_cfg->{test_vcf},
-    custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=exact,fields=sFOO'],
+    custom => ['file=' . $test_cfg->{custom_vcf} . ',short_name=test,format=vcf,type=exact,fields=FOO'],
     output_format => 'vep',
   });
   $of = $runner->get_OutputFactory;

--- a/t/Parser.t
+++ b/t/Parser.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Parser_CAID.t
+++ b/t/Parser_CAID.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Parser_HGVS.t
+++ b/t/Parser_HGVS.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Parser_ID.t
+++ b/t/Parser_ID.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Parser_Region.t
+++ b/t/Parser_Region.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Parser_SPDI.t
+++ b/t/Parser_SPDI.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Parser_VEP_input.t
+++ b/t/Parser_VEP_input.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1220,6 +1220,7 @@ SKIP: {
                  "consequence_terms" => [
                      "intergenic_variant"
                  ],
+                 "ga4gh_spdi" => "NC_000021.9:10524653:C:A",
                  "ga4gh_vrs" =>  {
                      "location" => {
                          "interval"  => {

--- a/t/Stats.t
+++ b/t/Stats.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/TranscriptTree.t
+++ b/t/TranscriptTree.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/Utils.t
+++ b/t/Utils.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/VEPTestingConfig.pm
+++ b/t/VEPTestingConfig.pm
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/VariantRecoder.t
+++ b/t/VariantRecoder.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/bam_edit.t
+++ b/t/bam_edit.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/version.t
+++ b/t/version.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/validator/vep_input_format_validator.py
+++ b/validator/vep_input_format_validator.py
@@ -1,6 +1,6 @@
 """
    Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-   Copyright [2016-2023] EMBL-European Bioinformatics Institute
+   Copyright [2016-2022] EMBL-European Bioinformatics Institute
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/variant_recoder
+++ b/variant_recoder
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/vep
+++ b/vep
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright [2016-2023] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -173,7 +173,7 @@ GetOptions(
   'ambiguity',               # Add allele ambiguity code
   'var_synonyms', 	     # include variation synonyms in output
   'shift_3prime=i',          # enables shifting of all variants to 3prime
-  'shift_genomic=i',         # adds genomic shifting to output, and provides shifting of intergenic variants
+  'shift_genomic',           # adds genomic shifting to output, and provides shifting of intergenic variants
   'shift_length',	     # adds the length of the transcript directional shift to output
 
   # cache stuff
@@ -221,8 +221,6 @@ die("ERROR: Unexpected extra command-line parameter(s): " . join(", ", @ARGV)) i
 warn("WARNING: More than one output file command-line flag provided. Using the last value provided: '@{$config->{output_file}}[-1]' \n") unless (scalar @{$config->{output_file}} <= 1);
 $config->{output_file}=@{$config->{output_file}}[-1] if ($config->{output_file});
 &usage && exit(0) if (!$arg_count) || $config->{help};
-
-$config->{database} ||= 0;
 
 my $runner = Bio::EnsEMBL::VEP::Runner->new($config);
 


### PR DESCRIPTION
## Description

We need to include sub-options to custom annotation. For that, it's easy to refactor a little bit VEP `--custom` flag usage.

```sh
## Previous usage:
--custom filename,test,vcf,exact,0,field1,field2
## After this PR:
--custom file=filename,short_name=test,format=vcf,type=exact,coords=0,fields=field1%field2
## options can be in any order, i.e:
--custom fields=field1%field2,type=exact,coords=0,file=filename,short_name=test,format=vcf
## would have same result.
```

Changes in `--custom` will need to be updated in documentation.
https://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html

## Test

1) Single `--custom` flag;
2) Multiple `--custom` flag;
3) `gtf` + `gff` flags usage;
4) Tests continue to cover those scenarios.