### PR TITLE
Update impact of `feature_elongation` consequences (e110)

### DIFF
--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -1470,7 +1470,7 @@ $vfoa = $of->get_all_StructuralVariationOverlapAlleles($ib->buffer->[0])->[1];
 is_deeply(
   $of->BaseStructuralVariationOverlapAllele_to_output_hash($vfoa),
   {
-    'IMPACT' => 'MODIFIER',
+    'IMPACT' => 'HIGH',
     'Consequence' => [
       'coding_sequence_variant',
       'feature_elongation'
@@ -1500,7 +1500,7 @@ $vfoa = $of->get_all_StructuralVariationOverlapAlleles($ib->buffer->[0])->[1];
 is_deeply(
   $of->StructuralVariationOverlapAllele_to_output_hash($vfoa),
   {
-    'IMPACT' => 'MODIFIER',
+    'IMPACT' => 'HIGH',
     'Consequence' => [
       'coding_sequence_variant',
       'feature_elongation'
@@ -1518,7 +1518,7 @@ $of->{allele_number} = 1;
 is_deeply(
   $of->StructuralVariationOverlapAllele_to_output_hash($vfoa),
   {
-    'IMPACT' => 'MODIFIER',
+    'IMPACT' => 'HIGH',
     'Consequence' => [
       'coding_sequence_variant',
       'feature_elongation'
@@ -1540,7 +1540,7 @@ $of->{flag_pick} = 1;
 is_deeply(
   $of->StructuralVariationOverlapAllele_to_output_hash($vfoa),  
   {
-    'IMPACT' => 'MODIFIER',
+    'IMPACT' => 'HIGH',
     'Consequence' => [
       '3_prime_UTR_variant',
       'feature_elongation'
@@ -1644,7 +1644,7 @@ is_deeply(
   $of->TranscriptStructuralVariationAllele_to_output_hash($vfoa, {}),
   {
     'STRAND' => -1,
-    'IMPACT' => 'MODIFIER',
+    'IMPACT' => 'HIGH',
     'Consequence' => [
       'coding_sequence_variant',
       'feature_elongation'


### PR DESCRIPTION
[ENSVAR-3733](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3733): change impact of `feature_elongation` from `MODIFIER` to `HIGH` in VEP unit tests

Only merge for e110 (requires documentation updates: https://github.com/Ensembl/public-plugins/pull/643).

Expect Travis-CI to fail until https://github.com/Ensembl/ensembl-variation/pull/928 is merged