### PR TITLE
Hotfix: remove deprecated VERSION argument from `INSTALL.pl`

### DIFF
--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -1911,7 +1911,7 @@ Options
 -h | --help        Display this message and quit
 
 -d | --DESTDIR     Set destination directory for API install (default = './')
---CACHE_VERSION    Set data (cache, FASTA) version to install if different from --VERSION (default = $VERSION)
+--CACHE_VERSION    Set data (cache, FASTA) version to install (default = $VERSION)
 -c | --CACHEDIR    Set destination directory for cache files (default = '$ENV{HOME}/.vep/')
 
 -a | --AUTO        Run installer without user prompts. Use "a" (API + Faidx/htslib),

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -385,25 +385,6 @@ sub update() {
 
   my $current_branch = $CURRENT_VERSION_DATA->{'ensembl-vep'}->{release};
 
-  my $api_branch  = $API_VERSION;
-     $api_branch  =~ s/release\///;
-
-  # branch provided by the "--VERSION" flag
-  if ($api_branch != $current_branch) {
-    print "The 'VERSION' installation flag has been deprecated.\n\n";
-    my $branch = looks_like_number($API_VERSION) ? 'release/'.$API_VERSION : $API_VERSION;
-    if(`which git` && -d $RealBin.'/.git') {
-      print "Please, use git to update '$module' using the commands:\n\n";
-      print "\tgit pull\n";
-      print "\tgit checkout $branch\n\n";
-    }
-    else {
-      print "Please, re-download '$module' with the desired version.\n\n";
-    }
-    print "Exit VEP install script\n";
-    exit(0);
-  }
-
   my $message;
 
   # don't have latest

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -319,14 +319,14 @@ if($AUTO) {
 
 else {
   my $api_msg = 
-      "  - Install v$API_VERSION of the Ensembl API for use by the VEP. " .
+      " - Install v$API_VERSION of the Ensembl API for use by the VEP. " .
       "It will not affect any existing installations of the Ensembl API that you may have.\n";
 
   print "Hello! This installer will help you set up VEP v$API_VERSION, including:\n" .
     ($NO_UPDATE ? "" : $api_msg) .
-    "  - Download and install cache files from Ensembl's FTP server.\n" .
-    "  - Download FASTA files from Ensembl's FTP server.\n" .
-    ($NO_PLUGINS ? "" : "  - Download VEP plugins.\n") . "\n"
+    " - Download and install cache files from Ensembl's FTP server.\n" .
+    " - Download FASTA files from Ensembl's FTP server.\n" .
+    ($NO_PLUGINS ? "" : " - Download VEP plugins.\n") . "\n"
     unless $QUIET;
 
   # run subs

--- a/INSTALL.pl
+++ b/INSTALL.pl
@@ -151,7 +151,6 @@ my $config = {};
 GetOptions(
   $config,
   'DESTDIR|d=s',
-  'VERSION|v=i', # Deprecated
   'CACHE_VERSION|e=i',
   'ASSEMBLY|y=s',
   'BIOPERL|b=s',
@@ -198,7 +197,6 @@ $config = read_config_from_environment($config);
 
 # Quick fix: this script should use $config instead of multiple global variables
 $DEST_DIR     ||=  $config->{DESTDIR};
-$API_VERSION  ||=  $config->{VERSION};
 $DATA_VERSION ||=  $config->{CACHE_VERSION};
 $ASSEMBLY     ||=  $config->{ASSEMBLY};
 $BIOPERL_URL  ||=  $config->{BIOPERL};
@@ -387,7 +385,6 @@ sub update() {
 
   my $current_branch = $CURRENT_VERSION_DATA->{'ensembl-vep'}->{release};
 
-  # Check if the $API_VERSION has been set by the deprecated "--VERSION" flag
   my $api_branch  = $API_VERSION;
      $api_branch  =~ s/release\///;
 

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -53,7 +53,7 @@ use warnings;
 use base qw(Exporter);
 
 our $VEP_VERSION     = 109;
-our $VEP_SUB_VERSION = 1;
+our $VEP_SUB_VERSION = 2;
 
 our @EXPORT_OK = qw(
   @FLAG_FIELDS


### PR DESCRIPTION
Fixes #1354: error thrown when setting the environment variable `VEP_VERSION` with something other than the major version of VEP, given that the script tries to fetch `ensembl` repository based on the version in `VEP_VERSION`:

```
$ export VEP_VERSION=109.1
$ perl INSTALL.pl --NO_TEST --NO_UPDATE --NO_HTSLIB --NO_BIOPERL -a a
Setting up directories

Downloading required Ensembl API files
 - fetching ensembl
curl failed (404), trying to fetch using LWP::Simple
LWP::Simple failed (404), trying to fetch using HTTP::Tiny
ERROR: Failed last resort of using HTTP::Tiny to download https://github.com/Ensembl/ensembl/archive/release/109.1.zip
```

This argument was already deprecated in [release/96](https://github.com/Ensembl/ensembl-vep/commit/9d4684b2b15b535462d89e7ecb35ed2ce7a82d31) and doesn't work properly, so it was simply removed.

## Testing

Exporting VEP_VERSION variable in Bash should not affect the INSTALL.pl script. These commands should run fine now:

```
export VEP_VERSION=109.1
perl INSTALL.pl --NO_TEST --NO_UPDATE --NO_HTSLIB --NO_BIOPERL -a a
```