### PR TITLE
Hotfix: update dir masking pattern in header

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -498,7 +498,14 @@ sub new {
     next if !defined($value) || (ref($value) eq "ARRAY" && @{$value} == 0) || grep { /$flag/ } @skip_opts;
 
     $value = join(" --$flag ", @{$value}) if ref($value) eq "ARRAY";
-    $value =~ s/(\/[\w-]+?)+\//\[PATH\]\//g;
+    
+    if ($^O eq "MSWin32"){
+      $value =~ s/.+(?=\\)/\[PATH\]/g;
+    }
+    else {
+      $value =~ s/.+(?=\/)/\[PATH\]/g;
+    }
+    
     $config_command .= $value eq 1? "--$flag "  : "--$flag $value ";
   }
 

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -53,7 +53,7 @@ use warnings;
 use base qw(Exporter);
 
 our $VEP_VERSION     = 109;
-our $VEP_SUB_VERSION = 2;
+our $VEP_SUB_VERSION = 3;
 
 our @EXPORT_OK = qw(
   @FLAG_FIELDS


### PR DESCRIPTION
https://github.com/Ensembl/ensembl-vep/issues/1357

Solves one of the reason causing test failure - account for non-standard character in dir name when masking them for header.

Test command:
```
vep --force_overwrite -i home/test.this/test.vcf  --assembly GRCh38 --database --db_version 109 
```

Notes:
- The only time it would not add [PATH] replacing the given dir is when we are giving just the file name (e.g. `-i test.vcf`) but that is intended behavior and won't fail test ([test data](https://github.com/Ensembl/ensembl-vep/blob/c5669c88cf93d9b399e680a9c7b6e3774bef25a0/t/VEPTestingConfig.pm#L54) always has some dir path).
- When the dir does not have `/` at the end it will not mask the leaf dir (e.g. `/home/test/test_this` -> `[PATH]/test_this`) which is fine as the intention is to mask the absolute path. It also does not fail test.

