### PR TITLE
Docker fix: silence warnings for invalid options from ENV and INI config

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -59,6 +59,7 @@ package Bio::EnsEMBL::VEP::Config;
 
 use File::Spec;
 use Getopt::Long;
+Getopt::Long::Configure("pass_through");
 
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect;
@@ -981,11 +982,7 @@ sub is_valid_param {
 
   # Run GetOptions to check validity of parameter
   my $res = {};
-
-  # Ignore STDERR from GetOptions to avoid warnings about invalid params
-  GetOptions($res, @VEP_PARAMS) or
-    warn("Ignoring unsupported option '${key}' found via ENV variable or INI file\n");
-
+  GetOptions($res, @VEP_PARAMS);
   my $is_valid = %$res ? 1 : 0;
 
   # Restore command-line arguments

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -1042,7 +1042,7 @@ sub read_config_from_file {
 
   close CONFIG;
 
-  $self->status_msg("Read configuration from $file") if $self->param('verbose');
+  $self->status_msg("Read configuration from $file") if $config->{verbose};
 
   return $config;
 }
@@ -1066,30 +1066,41 @@ sub read_config_from_environment {
   my $self = shift;
   my $config = shift;
 
-  for my $key (keys %ENV) {
+  for my $var (keys %ENV) {
     # Look for environment variables that start with VEP_
-    next unless $key =~ "^VEP_";
+    next unless $var =~ "^VEP_";
 
     # Avoid setting empty strings
-    my $value = $ENV{$key};
+    my $value = $ENV{$var};
     next if $value eq "";
 
     # Assumption: VEP arguments are always lowercase
-    $key = lc $key;
-    $key =~ s/^VEP_//ig;
+    my $key = lc $var;
+       $key =~ s/^VEP_//ig;
 
-    next unless is_valid_param($config, $key, $value);
+    my $valid = is_valid_param($config, $key, $value);
+    unless ($valid) {
+      $self->status_msg("Ignored unsupported option '${key}=${value}' from environment variable $var\n")
+        if $config->{verbose};
+      next;
+    }
 
     if (grep {$key eq $_} @ALLOW_MULTIPLE) {
       # Properly set flags that can be specified more than once
       push @{$config->{$key}}, $value;
+
+      my $msg = "Appended '${key}=${value}' from environment variable $var (full value of ${key}: ['" .
+                join("', '", @{ $config->{$key} }) . "'])\n";
+      $self->status_msg($msg) if $config->{verbose};
     } else {
       $config->{$key} ||= $value;
+      $self->status_msg("Set '${key}=${value}' from environment variable $var\n")
+        if $config->{verbose};
     }
   }
 
   $self->status_msg("Read configuration from environment variables")
-    if $self->param('verbose');
+    if $config->{verbose};
 
   return $config;
 }

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -139,7 +139,7 @@ sub new {
     # detect format
     if(lc($format) eq 'guess' || lc($format) eq 'detect' || lc($format) eq 'auto') {
       $format = $self->detect_format();
-      $self->warning_msg("No input file format specified - detected $format format") if $self->param('verbose') && defined $format;
+      $self->status_msg("No input file format specified - detected $format format") if $self->param('verbose') && defined $format;
     }
 
     die("ERROR: Can't detect input format\n") unless $format;


### PR DESCRIPTION
After #1361, when running VEP in Docker, we get lots of warnings regarding pre-set environment variables for `INSTALL.pl` that are invalid in VEP:

```bash
$ vep --id rs699 --database --db_version 109 --force
Unknown option: no_update
Ignoring unsupported option 'no_update' found via ENV variable or INI file
Unknown option: no_plugins
Ignoring unsupported option 'no_plugins' found via ENV variable or INI file
Unknown option: pluginsdir
Ignoring unsupported option 'pluginsdir' found via ENV variable or INI file
Unknown option: no_htslib
Ignoring unsupported option 'no_htslib' found via ENV variable or INI file
```

These flags are good to have set up at all times in Docker to abstract users from the internal directory of the Docker image. This PR silently discards invalid options from ENV and INI config file by using the option `pass_through` from GetOpts.

### Testing

Run the following code with and without the changes in this PR:
```bash
export VEP_VERSION="109.3"
export VEP_JSON=0
vep --id rs699 --database --db_version 109 --force
```

* VEP should not print warning messages with these changes.
* In the command line of the VCF output, `--version 109.3` does not appear (which means it was silently discarded, as desired).