### PR TITLE
Fix failing `Bio::DB::BigFile` for Docker on ARM platforms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,7 +113,6 @@ ENV PERL5LIB_TMP $PERL5LIB:$OPT_SRC/ensembl-vep:$OPT_SRC/ensembl-vep/modules
 ENV PERL5LIB $PERL5LIB_TMP:$OPT_SRC/bioperl-live
 ENV KENT_SRC $OPT/src/kent-335_base/src
 ENV HTSLIB_DIR $OPT_SRC/htslib
-ENV MACHTYPE x86_64
 ENV DEPS $OPT_SRC
 ENV PATH $OPT_SRC/ensembl-vep:$OPT_SRC/var_c_code:$PATH
 ENV LANG_VAR en_US.UTF-8
@@ -140,7 +139,8 @@ RUN perl Makefile.PL && make && make install && rm -f Makefile* cpanfile
 
 WORKDIR $OPT_SRC
 # Install/compile more libraries
-RUN ensembl-vep/travisci/build_c.sh && \
+RUN export MACHTYPE=$(uname -m) &&\
+    ensembl-vep/travisci/build_c.sh && \
     # Remove unused Bio-DB-HTS files
     rm -rf Bio-HTS/cpanfile Bio-HTS/Build.PL Bio-HTS/Build Bio-HTS/_build Bio-HTS/INSTALL.pl && \
     # Install ensembl perl dependencies (cpanm)


### PR DESCRIPTION
[ENSVAR-5254](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5254): `Bio::DB::BigFile` installs successfully when assigning the correct `MACHTYPE` based on the platform.

Related with #1304 

### Testing

Build the Docker image on ARM platform and run a command like:
```
vep --id rs699 --database --db_version 109 --force
```