### PR TITLE
Build Docker image for ARM and x86

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Docker
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: nunoagostinho/ensembl-vep
+          tags: |
+            # example of Docker tag: release_109.3 (for consistency with previous releases)
+            type=match,pattern=release/(.*),group=1,prefix=release_
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: nunoagostinho
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: nunoagostinho/ensembl-vep
+          images: ${{ secrets.DOCKERHUB_USER }}/ensembl-vep
           tags: |
             # example of Docker tag: release_109.3 (for consistency with previous releases)
             type=match,pattern=release/(.*),group=1,prefix=release_
@@ -30,7 +30,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: nunoagostinho
+          username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BRANCH=main
+ARG BRANCH=release/110
 
 ###################################################
 # Stage 1 - docker container to build ensembl-vep #


### PR DESCRIPTION
Based on issue https://github.com/Ensembl/ensembl-vep/issues/1304 and PR #1367, this PR uses GitHub Actions to run the following actions every time we publish a new release:
1. Build a Docker image for both `linux/amd64` and `linux/arm64` platforms
2. Tag with release version (`release_109.3`, for instance) and `latest`
3. Upload to our DockerHub account

In the settings of our GitHub repo, we will need to set up `DOCKERHUB_USER` and `DOCKERHUB_TOKEN` (the token must include write permissions).

### Testing

1. Go to a GitHub fork of `ensembl-vep`.
2. Set up `DOCKERHUB_USER` and `DOCKERHUB_TOKEN` based on your personal DockerHub account.
3. Merge this PR changes with the `main` branch of your fork.
4. Create a release with a usual name (`release/110.3`, for instance).
    - The GitHub Action will replace the invalid character `/` with `_`. I am not sure what happens if the release name is different... but that shouldn't happen anyway (?)
5. Go to the **Actions** tab and see if any action was triggered.
6. After the final Docker image is built, pull it from your personal account and run VEP with a command like:
```
vep --id rs699 --database --db_version 109 --force
```