### PR TITLE
Standardise SV types across inputs: VEP, VCF and Region

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -659,7 +659,8 @@ sub validate_vf {
 
 =head2 get_SO_term
 
-  Example    : $ref_allele = $parser->get_SO_term($vf);
+  Arg 1      : string $type
+  Example    : $ref_allele = $parser->get_SO_term($type);
   Description: Returns the Sequence Ontology term based on a given variant type.
                Returns undef if failed to fetch the appropriate term.
   Returntype : string
@@ -671,10 +672,9 @@ sub validate_vf {
 
 sub get_SO_term {
   my $self = shift;
-  # set a default that we do not expect to see
   my $type = shift;
-
   my $abbrev;
+
   if ($type =~ /\<CN/i) {
     # ALT: "<CN0>", "<CN0>,<CN2>,<CN3>" "<CN2>" => SVTYPE: DEL, CNV, DUP
     $abbrev = "CNV";

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -657,6 +657,49 @@ sub validate_vf {
   return 1;
 }
 
+=head2 get_SO_term
+
+  Example    : $ref_allele = $parser->get_SO_term($vf);
+  Description: Returns the Sequence Ontology term based on a given variant type.
+               Returns undef if failed to fetch the appropriate term.
+  Returntype : string
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub get_SO_term {
+  my $self = shift;
+  # set a default that we do not expect to see
+  my $type = shift;
+
+  my $abbrev;
+  if ($type =~ /\<CN/i) {
+    # ALT: "<CN0>", "<CN0>,<CN2>,<CN3>" "<CN2>" => SVTYPE: DEL, CNV, DUP
+    $abbrev = "CNV";
+    $abbrev = "DEL" if $type =~ /\<CN=?0\>/;
+    $abbrev = "DUP" if $type =~ /\<CN=?2\>/;
+  } elsif ($type =~ /^\<|^\[|\]$|\>$/) {
+    $abbrev = $type;
+    $abbrev =~ s/\<|\>//g;
+    $abbrev =~ s/\:.+//g;
+  } else {
+    $abbrev = $type;
+  }
+
+  my %terms = (
+    INS  => 'insertion',
+    DEL  => 'deletion',
+    TDUP => 'tandem_duplication',
+    DUP  => 'duplication',
+    CNV  => 'copy_number_variation',
+    INV  => 'inversion',
+    BND  => 'breakpoint'
+  );
+
+  return $terms{$abbrev};
+}
 
 =head2 _get_ref_allele
 

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -412,69 +412,38 @@ sub detect_format {
     next unless @data;
 
     # region chr21:10-10:1/A
-    if (
-      scalar @data == 1 &&
-      $data[0] =~ /^[^\:]+\:\d+\-\d+(\:[\-\+]?1)?[\/\:](ins|dup|del|[ACGTN-]+)$/i
-    ) {
+    if ( $self->Bio::EnsEMBL::VEP::Parser::Region::validate_line(@data) ) {
       $format = 'region';
     }
 
     # SPDI: NC_000016.10:68684738:G:A
-    elsif (
-      scalar @data == 1 &&
-      $data[0] =~ /^(.*?\:){2}([^\:]+|)$/i
-    ) {
+    elsif ($self->Bio::EnsEMBL::VEP::Parser::SPDI::validate_line(@data) ) {
       $format = 'spdi';
     }
 
     # CAID: CA9985736
-    elsif (
-      scalar @data == 1 &&
-      $data[0] =~ /^CA\d{1,}$/i
-    ) {
+    elsif ( $self->Bio::EnsEMBL::VEP::Parser::CAID::validate_line(@data) ) {
       $format = 'caid';
     }
 
     # HGVS: ENST00000285667.3:c.1047_1048insC
-    elsif (
-      scalar @data == 1 &&
-      $data[0] =~ /^([^\:]+)\:.*?([cgmrp]?)\.?([\*\-0-9]+.*)$/i
-    ) {
+    elsif ( $self->Bio::EnsEMBL::VEP::Parser::HGVS::validate_line(@data) ) {
       $format = 'hgvs';
     }
 
     # variant identifier: rs123456
-    elsif (
-      scalar @data == 1
-    ) {
+    elsif ( $self->Bio::EnsEMBL::VEP::Parser::ID::validate_line(@data) ) {
       $format = 'id';
     }
 
     # VCF: 20  14370  rs6054257  G  A  29  0  NS=58;DP=258;AF=0.786;DB;H2  GT:GQ:DP:HQ
-    elsif (
-      $data[0] =~ /(chr)?\w+/ &&
-      $data[1] =~ /^\d+$/ &&
-      $data[3] && $data[3] =~ /^[ACGTN\-\.]+$/i &&
-      $data[4]
-    ) {
-
+    elsif ( $self->Bio::EnsEMBL::VEP::Parser::VCF::validate_line(@data) ) {
       # do some more thorough checking on the ALTs
-      my $ok = 1;
-
-      foreach my $alt(split(',', $data[4])) {
-        $ok = 0 unless $alt =~ /^[\.ACGTN\-\*]+$|^(\<[\w\:\*]+\>)$/i;
-      }
-
-      $format = 'vcf' if $ok;
+      $format = 'vcf' if $self->Bio::EnsEMBL::VEP::Parser::VCF::validate_alts($data[4]);
     }
 
     # ensembl: 20  14370  14370  A/G  +
-    elsif (
-      $data[0] =~ /\w+/ &&
-      $data[1] =~ /^\d+$/ &&
-      $data[2] && $data[2] =~ /^\d+$/ &&
-      $data[3] && $data[3] =~ /(ins|dup|del)|([ACGTN-]+\/[ACGTN-]+)/i
-    ) {
+    elsif ( $self->Bio::EnsEMBL::VEP::Parser::VEP_input::validate_line(@data) ) {
       $format = 'ensembl';
     }
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/CAID.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/CAID.pm
@@ -108,6 +108,25 @@ sub new {
 }
 
 
+=head2 validate_line
+
+  Example    : $valid = $self->validate_line();
+  Description: Check if input line can be read using this format.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_line {
+  my $self = shift;
+  my @line = @_;
+
+  return ( scalar @line == 1 && $line[0] =~ /^CA\d{1,}$/i );
+}
+
+
 =head2 parser
 
   Example    : $io_parser = $parser->parser();

--- a/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/HGVS.pm
@@ -109,6 +109,28 @@ sub new {
 }
 
 
+=head2 validate_line
+
+  Example    : $valid = $self->validate_line();
+  Description: Check if input line can be read using this format.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_line {
+  my $self = shift;
+  my @line = @_;
+
+  return (
+    scalar @line == 1 &&
+      $line[0] =~ /^([^\:]+)\:.*?([cgmrp]?)\.?([\*\-0-9]+.*)$/i
+  );
+}
+
+
 =head2 parser
 
   Example    : $io_parser = $parser->parser();

--- a/modules/Bio/EnsEMBL/VEP/Parser/ID.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/ID.pm
@@ -105,6 +105,24 @@ sub new {
 }
 
 
+=head2 validate_line
+
+  Example    : $valid = $self->validate_line();
+  Description: Check if input line can be read using this format.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_line {
+  my $self = shift;
+  my @line = @_;
+
+  return ( scalar @line == 1 );
+}
+
 =head2 parser
 
   Example    : $io_parser = $parser->parser();

--- a/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
@@ -206,19 +206,8 @@ sub create_VariationFeatures {
   my $vf;
   
   # sv?
-  if($allele =~ /^(INS|DEL|DUP)$/) {
-    my $so_term;
-
-    # convert to SO term
-    my %terms = (
-      INS  => 'insertion',
-      DEL  => 'deletion',
-      TDUP => 'tandem_duplication',
-      DUP  => 'duplication'
-    );
-
-    $so_term = defined $terms{$allele} ? $terms{$allele} : $allele;
-
+  my $so_term = $self->get_SO_term($allele);
+  if(defined($so_term)) {
     $vf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new_fast({
       start          => $start,
       end            => $end,

--- a/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
@@ -124,6 +124,28 @@ sub new {
 }
 
 
+=head2 validate_line
+
+  Example    : $valid = $self->validate_line();
+  Description: Check if input line can be read using this format.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_line {
+  my $self = shift;
+  my @line = @_;
+
+  return (
+    scalar @line == 1 &&
+      $line[0] =~ /^[^\:]+\:\d+\-\d+(\:[\-\+]?1)?[\/\:]([a-z]{3,}|[ACGTN-]+)$/i
+  );
+}
+
+
 =head2 parser
 
   Example    : $io_parser = $parser->parser();
@@ -167,7 +189,7 @@ sub create_VariationFeatures {
 
   my $region = $parser->get_value();
 
-  return [] unless $region =~ /^([^\:]+)\:(\d+)\-(\d+)(\:[\-\+]?1)?[\/\:](ins|dup|del|[ACGTN-]+)$/i;
+  return [] unless validate_line($region);
   my ($chr, $start, $end) = ($1, $2, $3);
 
   my ($strand, $allele);

--- a/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
@@ -124,6 +124,11 @@ sub new {
 }
 
 
+sub _valid_line_regex {
+  return qr/^([^:]+):(\d+)-(\d+)(:[-\+]?1)?[\/:]([a-z]{3,}|[ACGTN-]+)$/i;
+}
+
+
 =head2 validate_line
 
   Example    : $valid = $self->validate_line();
@@ -139,10 +144,7 @@ sub validate_line {
   my $self = shift;
   my @line = @_;
 
-  return (
-    scalar @line == 1 &&
-      $line[0] =~ /^[^\:]+\:\d+\-\d+(\:[\-\+]?1)?[\/\:]([a-z]{3,}|[ACGTN-]+)$/i
-  );
+  return ( scalar @line == 1 && $line[0] =~ _valid_line_regex() );
 }
 
 
@@ -189,7 +191,7 @@ sub create_VariationFeatures {
 
   my $region = $parser->get_value();
 
-  return [] unless validate_line($region);
+  return [] unless $region =~ _valid_line_regex();
   my ($chr, $start, $end) = ($1, $2, $3);
 
   my ($strand, $allele);

--- a/modules/Bio/EnsEMBL/VEP/Parser/SPDI.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/SPDI.pm
@@ -101,6 +101,25 @@ sub new {
 }
 
 
+=head2 validate_line
+
+  Example    : $valid = $self->validate_line();
+  Description: Check if input line can be read using this format.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_line {
+  my $self = shift;
+  my @line = @_;
+
+  return ( scalar @line == 1 && $line[0] =~ /^(.*?\:){2}([^\:]+|)$/i );
+}
+
+
 =head2 parser
 
   Example    : $io_parser = $parser->parser();

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -108,6 +108,53 @@ sub new {
 }
 
 
+=head2 validate_line
+
+  Example    : $valid = $self->validate_line();
+  Description: Check if input line can be read using this format.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_line {
+  my $self = shift;
+  my @line = @_;
+
+  return (
+    $line[0] =~ /(chr)?\w+/ &&
+      $line[1] =~ /^\d+$/ &&
+      $line[3] && $line[3] =~ /^[ACGTN\-\.]+$/i &&
+      $line[4]
+  );
+}
+
+
+=head2 validate_alts
+
+  Example    : $valid = $self->validate_alts('A,T,C');
+  Description: Check if alternative alleles are valid.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_alts {
+  my $self = shift;
+  my $alts = shift;
+
+  my $ok = 1;
+  foreach my $alt(split(',', $alts)) {
+    $ok = 0 unless $alt =~ /^[\.ACGTN\-\*]+$|^(\<[\w\:\*]+\>)$/i;
+  }
+  return $ok;
+}
+
+
 =head2 parser
 
   Example    : $io_parser = $parser->parser();

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -501,7 +501,7 @@ sub create_StructuralVariationFeatures {
   my $so_term = $self->get_SO_term($type) || $type;
   if($start >= $end && $so_term =~ /del/i) {
     my $line = join("\t", @$record);
-      $self->warning_msg("WARNING: line " . $self->line_number . " looks incomplete, skipping:\n$line\n");
+    $self->warning_msg("WARNING: VCF line " . $self->line_number . " looks incomplete, skipping:\n$line\n");
     $skip = 1;
   }
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -90,7 +90,7 @@ sub validate_line {
     $line[0] =~ /\w+/ &&
       $line[1] =~ /^\d+$/ &&
       $line[2] && $line[2] =~ /^\d+$/ &&
-      $line[3] && $line[3] =~ /([a-z]{2,})|([ACGTN-]+\/[ACGTN-]+)/i
+      $line[3] && $line[3] =~ /([a-z]{3,})|([ACGTN-]+\/[ACGTN-]+)/i
   );
 }
 
@@ -158,17 +158,7 @@ sub create_VariationFeatures {
 
   # sv?
   if($allele_string !~ /\//) {
-    my $so_term;
-
-    # convert to SO term
-    my %terms = (
-      INS  => 'insertion',
-      DEL  => 'deletion',
-      TDUP => 'tandem_duplication',
-      DUP  => 'duplication'
-    );
-
-    $so_term = defined $terms{$allele_string} ? $terms{$allele_string} : $allele_string;
+    my $so_term = $self->get_SO_term($allele_string) || $allele_string;
 
     $vf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new_fast({
       start          => $start,

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -90,7 +90,7 @@ sub validate_line {
     $line[0] =~ /\w+/ &&
       $line[1] =~ /^\d+$/ &&
       $line[2] && $line[2] =~ /^\d+$/ &&
-      $line[3] && $line[3] =~ /([a-z]{3,})|([ACGTN-]+\/[ACGTN-]+)/i
+      $line[3] && $line[3] =~ /([a-z]{2,})|([ACGTN-]+\/[ACGTN-]+)/i
   );
 }
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VEP_input.pm
@@ -71,6 +71,30 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning);
 use Bio::EnsEMBL::IO::Parser::VEP_input;
 
 
+=head2 validate_line
+
+  Example    : $valid = $self->validate_line();
+  Description: Check if input line can be read using this format.
+  Returntype : bool
+  Exceptions : none
+  Caller     : $self->SUPER::detect_format()
+  Status     : Stable
+
+=cut
+
+sub validate_line {
+  my $self = shift;
+  my @line = @_;
+
+  return (
+    $line[0] =~ /\w+/ &&
+      $line[1] =~ /^\d+$/ &&
+      $line[2] && $line[2] =~ /^\d+$/ &&
+      $line[3] && $line[3] =~ /([a-z]{2,})|([ACGTN-]+\/[ACGTN-]+)/i
+  );
+}
+
+
 =head2 parser
 
   Example    : $io_parser = $parser->parser();

--- a/t/Parser_Region.t
+++ b/t/Parser_Region.t
@@ -170,6 +170,40 @@ is_deeply($vf, bless( {
   '_line' => [qw(21:25587759-25587769/DUP)]
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV dup');
 
+$vf = Bio::EnsEMBL::VEP::Parser::Region->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21:25587759-25587769/INV)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor}); delete($vf->{slice});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => '21:25587759-25587769/INV',
+  'class_SO_term' => 'inversion',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21:25587759-25587769/INV)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV inv');
+
+$vf = Bio::EnsEMBL::VEP::Parser::Region->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21:25587759-25587769/DEL)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor}); delete($vf->{slice});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => '21:25587759-25587769/DEL',
+  'class_SO_term' => 'deletion',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21:25587759-25587769/DEL)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV del');
+
 
 # warning_msg prints to STDERR
 no warnings 'once';

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -475,11 +475,32 @@ close STDERR;
 open STDERR, '>', \$tmp;
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
-  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, warning_file => 'STDERR'}),
-  file => $test_cfg->create_input_file([qw(21 25587758 sv_dup T <DEL> . . .)]),
+  config => $cfg,
+  file => $test_cfg->create_input_file([qw(21 25587758 sv_del T <DEL> . . SVLEN=11)]),
   valid_chromosomes => [21]
 })->next();
-ok($tmp =~ /VCF line.+looks incomplete/, 'StructuralVariationFeature del without end or length');
+delete($vf->{adaptor}); delete($vf->{_line});
+is_deeply($vf, bless( {
+  'outer_end' => 25587769,
+  'chr' => '21',
+  'inner_end' => 25587769,
+  'outer_start' => 25587759,
+  'end' => 25587769,
+  'seq_region_end' => 25587769,
+  'inner_start' => 25587759,
+  'strand' => 1,
+  'class_SO_term' => 'deletion',
+  'variation_name' => 'sv_del',
+  'start' => 25587759,
+  'seq_region_start' => 25587759
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature del');
+
+$vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(21 25587758 sv_del T <DEL> . . .)]),
+  valid_chromosomes => [21]
+})->next();
+like($tmp, qr/VCF line.+looks incomplete/, 'StructuralVariationFeature del without end or length');
 
 open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -468,11 +468,7 @@ is_deeply($vf, bless( {
   'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature fuzzy');
 
-no warnings 'once';
-open(SAVE, ">&STDERR") or die "Can't save STDERR\n"; 
-
-close STDERR;
-open STDERR, '>', \$tmp;
+## test deletion and deletion warnings
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => $cfg,
@@ -494,6 +490,12 @@ is_deeply($vf, bless( {
   'start' => 25587759,
   'seq_region_start' => 25587759
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature del');
+
+no warnings 'once';
+open(SAVE, ">&STDERR") or die "Can't save STDERR\n"; 
+
+close STDERR;
+open STDERR, '>', \$tmp;
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, warning_file => 'STDERR'}),

--- a/t/Parser_VEP_input.t
+++ b/t/Parser_VEP_input.t
@@ -139,6 +139,108 @@ is_deeply($vf, bless( {
   '_line' => [qw(21 25587759 25587769 DUP + test)]
 }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV dup');
 
+$vf = Bio::EnsEMBL::VEP::Parser::VEP_input->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21 25587759 25587769 INV + test)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => 'test',
+  'class_SO_term' => 'inversion',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21 25587759 25587769 INV + test)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV inv');
+
+$vf = Bio::EnsEMBL::VEP::Parser::VEP_input->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21 25587759 25587769 DEL + test)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => 'test',
+  'class_SO_term' => 'deletion',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21 25587759 25587769 DEL + test)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV del 1');
+
+$vf = Bio::EnsEMBL::VEP::Parser::VEP_input->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21 25587759 25587769 <DEL> + test)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => 'test',
+  'class_SO_term' => 'deletion',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21 25587759 25587769 <DEL> + test)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV del 2');
+
+$vf = Bio::EnsEMBL::VEP::Parser::VEP_input->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21 25587759 25587769 <CN0> + test)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => 'test',
+  'class_SO_term' => 'deletion',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21 25587759 25587769 <CN0> + test)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV CN0');
+
+$vf = Bio::EnsEMBL::VEP::Parser::VEP_input->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21 25587759 25587769 <CN2> + test)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => 'test',
+  'class_SO_term' => 'duplication',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21 25587759 25587769 <CN2> + test)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV CN2');
+
+$vf = Bio::EnsEMBL::VEP::Parser::VEP_input->new({
+  config => $cfg, file => $test_cfg->create_input_file([qw(21 25587759 25587769 <CN3> + test)]),
+  valid_chromosomes => [21]
+})->next();
+delete($vf->{adaptor});
+is_deeply($vf, bless( {
+  'chr' => '21',
+  'strand' => '1',
+  'variation_name' => 'test',
+  'class_SO_term' => 'copy_number_variation',
+  'end' => '25587769',
+  'start' => '25587759',
+  'seq_region_end' => '25587769',
+  'seq_region_start' => '25587759',
+  '_line' => [qw(21 25587759 25587769 <CN3> + test)]
+}, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ), 'SV CN3');
+
 
 # warning_msg prints to STDERR
 no warnings 'once';


### PR DESCRIPTION
[ENSVAR-5226](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5226)

### Changelog

- Validation of each format is now encapsulated in the respective file
- All SO terms are now standardised and available in `Parser.pm` for any input: INS, DEL, TDUP, DUP, CNV, INV, BND (including if encapsulated in `<>`)
    - `VEP_input` now accepts the same terms as `VCF`, including `INV`, `BND`, `<CN3>`, `<DEL>`, etc.
    - Given the validation restrictions, `Region` accepts most terms, except if encapsulated in `<>` like `<CN0>` and `<INV>`

### Discussion

Does it make sense to accept all SV types in all types of inputs? For instance:
* What does `INS` do if we don't have the inserted sequence in `VEP_input`/`Region`?
* What is the purpose of `CNV` without specifying number of copies?
* `BND` can be specified without mates, but VEP currently does not support breakend variants (not for long if we merge https://github.com/Ensembl/ensembl-vep/pull/1399)

### Testing

* I added unit tests to test new changes, so please check if VEP works with some random example inputs
* VCF input should return the same result before and after the changes
* Test that `VEP_input` accepts the new terms. Example:
```
1   20000     30000     <CN4>   +    cn4
1   881907    881906    -/C     +
5   140532    140532    T/C     +
12  1017956   1017956   T/A     +
12  1017956   1017956   INV     +    inv1
2   946507    946507    G/C     +
14  19584687  19584687  C/T     -
19  66520     66520     G/A     +    var1
8   150029    150029    A/T     +    var2
```

* Test that `Region` accepts the new terms. Example:
```
chr21:10-10:1/A
chr21:10-20:1/DUP
21:25587759-25587769/INV
```