### PR TITLE
Fix hgvs_offset in OutputFactory 

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1612,7 +1612,7 @@ sub TranscriptVariationAllele_to_output_hash {
     # HGVS
     if($self->{hgvsc}) {
       my $hgvs_t = $vfoa->hgvs_transcript(undef, !$self->param('shift_3prime'));
-      my $offset = defined($vfoa->{shift_hash}) ? $vfoa->{shift_hash}->{_hgvs_offset} : 0;
+      my $offset = $vfoa->hgvs_offset;
 
       $hash->{HGVSc} = $hgvs_t if $hgvs_t;
       $hash->{HGVS_OFFSET} = $offset * $strand if $offset && $hgvs_t;


### PR DESCRIPTION
For input
`14      56634842        rs10601913      CA      C       209.73  PASS`
hgvs_offset is missing for `NM_017799.4:c.1725-42del` (issue reported here https://github.com/Ensembl/ensembl-vep/issues/1371)

The hgvs_offset for hgvsp is fetched from `$vfoa->hgvs_offset` ([method hgvs_offset](https://github.com/Ensembl/ensembl-variation/blob/release/110/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L1741))
while for hgvsc is `defined($vfoa->{shift_hash}) ? $vfoa->{shift_hash}->{_hgvs_offset} : 0` which returns 0
the issue is probably caused by [this line](https://github.com/Ensembl/ensembl-variation/blob/release/110/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L1366)

This PR updates the way hgvs_offset is fetched for hgvsc. 