### PR TITLE
Write skipped variants to file

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -363,7 +363,7 @@ sub dump_skipped_variants {
   if ( $self->param('skipped_variants_file') && defined $skipped ) {
     my $fh = $self->get_skipped_variants_file_handle();
 
-    printf $fh "[VEP skipped the following variants from input file %s]\n",
+    printf $fh "[VEP skipped the following variants from %s]\n",
            $self->param('input_file');
 
     for my $var (@$skipped) {

--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -173,6 +173,37 @@ sub stats {
 }
 
 
+=head2 skipped_variants
+
+  Arg 1      : (optional) hash $value with line, line_number and description
+  Example    : $skipped_variants = $obj->skipped_variants()
+  Description: Get/set skipped variants for this VEP run. Cached on shared
+               config object so all derived objects will share.
+  Returntype : Arrayref
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub skipped_variants {
+  my $self = shift;
+  my $value = shift;
+
+  my $config = $self->config;
+
+  if (!exists($config->{_skipped_variants})) {
+    $config->{_skipped_variants} = [];
+  }
+
+  if (defined $value) {
+    push @{ $config->{_skipped_variants} }, $value;
+  }
+
+  return $config->{_skipped_variants};
+}
+
+
 =head2 species
 
   Example    : $species = $obj->species()
@@ -726,6 +757,46 @@ sub warning_msg {
   print $fh $text;
 
   warn($text) unless $self->param('quiet');
+}
+
+
+=head2 skipped_variant_msg
+
+  Arg 1      : string $description
+  Arg 2      : (optional) int $line_number
+  Example    : $obj->skipped_variant_msg("Cannot parse variant location", 451)
+  Description: Prints a given skipped variant as a warning message (based on
+               handle given by $self->warning_fh) and writes to file if
+               $self->param->{skipped_variants_file} is defined.
+  Returntype : none
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub skipped_variant_msg {
+  my $self = shift;
+  my $description = shift;
+  my $line_number = shift || $self->line_number;
+
+  my $msg = $description;
+  my $line = $self->parser->{current_block};
+  if (defined $line) {
+    my $maxChar = 50;
+    $line =~ s/\t/ /g; # replace tabs with spaces to improve readability
+    $line = substr($line, 0, $maxChar - 4) . "..." if length($line) > $maxChar;
+    $msg = "(" . $line . "): " . $msg;
+  }
+
+  $msg = "Line $line_number skipped " . $msg if defined $line_number;
+  $self->warning_msg("WARNING: " . $msg . "\n");
+
+  $self->skipped_variants({
+    line => $line,
+    line_number => $line_number,
+    description => $description
+  });
 }
 
 

--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -781,7 +781,7 @@ sub skipped_variant_msg {
   my $line_number = shift || $self->line_number;
 
   my $msg = $description;
-  my $line = $self->parser->{current_block};
+  my $line = $self->{parser}->{current_block} if defined $self->{parser};
   if (defined $line) {
     my $maxChar = 50;
     $line =~ s/\t/ /g; # replace tabs with spaces to improve readability

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -166,6 +166,7 @@ our @VEP_PARAMS = (
   'stats_html',              # write stats as html
   'no_stats',                # don't write stats file
   'warning_file=s',          # file to write warnings to
+  'skipped_variants_file=s', # file name to log skipped variants (not logged otherwise)
   'force_overwrite|force',   # force overwrite of output file if already exists
   'terms|t=s',               # consequence terms to use e.g. NCBI, SO
   'coding_only',             # only return results for consequences in coding regions

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -597,6 +597,8 @@ sub validate_vf {
   return $self->validate_svf($vf) if ref($vf) eq 'Bio::EnsEMBL::Variation::StructuralVariationFeature';
 
   # uppercase allele string
+  $vf->{allele_string} =~ tr/[a-z]/[A-Z]/;
+
   unless($vf->{allele_string} =~ /([ACGT-]+\/*)+/) {
     $self->skipped_variant_msg(
       "Invalid allele string " . $vf->{allele_string} . " or possible parsing error"

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -532,16 +532,16 @@ sub validate_vf {
 
   # sanity checks
   unless(looks_like_number($vf->{start}) && looks_like_number($vf->{end})) {
-    $self->warning_msg("WARNING: Start ".$vf->{start}." or end ".$vf->{end}." coordinate invalid on line ".$self->line_number);
+    $self->skipped_variant_msg(
+      "Invalid start '" . $vf->{start} . "' or end '" . $vf->{end} . "' coordinate"
+    );
     return 0;
   }
 
   # check start <= end + 1
   if($vf->{start} > $vf->{end} + 1) {
-    $self->warning_msg(
-      "WARNING: start > end+1 : (START=".$vf->{start}.
-      ", END=".$vf->{end}.
-      ") on line ".$self->line_number."\n"
+    $self->skipped_variant_msg(
+      "start > end+1 : (START=" . $vf->{start} . ", END=" . $vf->{end} . ")"
     );
     return 0;
   }
@@ -566,8 +566,9 @@ sub validate_vf {
 
         # could not transform
         else {
-          $self->warning_msg(
-            "WARNING: Chromosome ".$vf->{chr}." not found in annotation sources or synonyms and could not transform to toplevel on line ".$self->line_number
+          $self->skipped_variant_msg(
+            "Chromosome " . $vf->{chr} . 
+              " not found in annotation sources or synonyms and could not transform to toplevel"
           );
           return 0;
         }
@@ -575,8 +576,8 @@ sub validate_vf {
 
       # no slice
       else {
-        $self->warning_msg(
-          "WARNING: Could not fetch slice for chromosome ".$vf->{chr}." on line ".$self->line_number
+        $self->skipped_variant_msg(
+          "Could not fetch slice for chromosome " . $vf->{chr}
         );
         return 0;
       }
@@ -584,8 +585,9 @@ sub validate_vf {
 
     # offline, can't transform
     else {
-      $self->warning_msg(
-        "WARNING: Chromosome ".$vf->{chr}." not found in annotation sources or synonyms on line ".$self->line_number.". \nChromosome ".$vf->{chr}. " does not overlap any features"
+      $self->skipped_variant_msg(
+        "Chromosome " . $vf->{chr} . " not found in annotation sources or synonyms; " .
+          "chromosome " . $vf->{chr} . " does not overlap any features"
       );
       return 0;
     }
@@ -595,22 +597,20 @@ sub validate_vf {
   return $self->validate_svf($vf) if ref($vf) eq 'Bio::EnsEMBL::Variation::StructuralVariationFeature';
 
   # uppercase allele string
-  $vf->{allele_string} =~ tr/[a-z]/[A-Z]/;
-
   unless($vf->{allele_string} =~ /([ACGT-]+\/*)+/) {
-    $self->warning_msg("WARNING: Invalid allele string ".$vf->{allele_string}." on line ".$self->line_number." or possible parsing error\n");
+    $self->skipped_variant_msg(
+      "Invalid allele string " . $vf->{allele_string} . " or possible parsing error"
+    );
     return 0;
   }
 
   # insertion should have start = end + 1
   if($vf->{allele_string} =~ /^\-\// && $vf->{start} != $vf->{end} + 1) {
     my $variant_name = (defined $vf->name) ? "for variant (".$vf->name.") " : "";
-    $self->warning_msg(
-      "WARNING: Alleles look like an insertion (".
-      $vf->{allele_string}.
+    $self->skipped_variant_msg(
+      "Alleles look like an insertion (" . $vf->{allele_string} .
       ") but coordinates are not start = end + 1 (START=".
-      $vf->{start}.", END=".$vf->{end}.
-      ") ".$variant_name."on line ".$self->line_number."\n"
+      $vf->{start} . ", END=" . $vf->{end} . ") " . $variant_name
     );
     return 0;
   }
@@ -627,10 +627,10 @@ sub validate_vf {
   my $alt_allele = $alleles[-1];
 
   if($ref_allele =~ /^[ACGT]*$/ && ($vf->{end} - $vf->{start}) + 1 != length($ref_allele)) {
-    $self->warning_msg(
-       "WARNING: Length of reference allele (".$ref_allele.
-       " length ".length($ref_allele).") does not match co-ordinates ".$vf->{start}."-".$vf->{end}.
-       " on line ".$self->line_number
+    $self->skipped_variant_msg(
+       "Length of reference allele (" . $ref_allele . " length " .
+         length($ref_allele) . ") does not match coordinates " .
+         $vf->{start} . "-" . $vf->{end}
     );
     return 0;
   }
@@ -649,7 +649,10 @@ sub validate_vf {
       my $slice_ref_allele = $self->_get_ref_allele($vf);
 
       if(!defined($slice_ref_allele)) {
-        $self->warning_msg("WARNING: Could not fetch sub-slice from ".$vf->{chr}.":".$vf->{start}."\-".$vf->{end}."\(".$vf->{strand}."\) on line ".$self->line_number);
+        $self->skipped_variant_msg(
+          "Could not fetch sub-slice from " . $vf->{chr} . ":" . $vf->{start} .
+            "\-" . $vf->{end} . "\(" . $vf->{strand} . "\)"
+        );
       }
       if(defined($slice_ref_allele)) {
         if (uc($slice_ref_allele) ne uc($ref_allele)){
@@ -664,11 +667,10 @@ sub validate_vf {
 
     if(!$ok) {
       $vf->{check_ref_failed} = 1;
-      $self->warning_msg(
-        "WARNING: Specified reference allele $ref_allele ".
-        "does not match Ensembl reference allele".
-        ($slice_ref_allele ? " $slice_ref_allele" : "").
-        " on line ".$self->line_number
+      $self->skipped_variant_msg(
+        "Specified reference allele $ref_allele " .
+        "does not match Ensembl reference allele" .
+        ($slice_ref_allele ? " $slice_ref_allele" : "")
       );
       return 0;
     }
@@ -678,7 +680,9 @@ sub validate_vf {
     my $slice_ref_allele = $ref_allele eq '' ? '' : $self->_get_ref_allele($vf);
 
     if(!defined($slice_ref_allele)) {
-      $self->warning_msg("WARNING: Could not reference allele for ".$vf->{chr}.":".$vf->{start}."\-".$vf->{end}."\(".$vf->{strand}."\) on line ".$self->line_number);
+      $self->skipped_variant_msg(
+        "Could not fetch reference allele for " . $vf->{chr} . ":" .
+          $vf->{start} . "\-" . $vf->{end} . "\(" . $vf->{strand} . "\)");
       return 0;
     }
 

--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -173,6 +173,7 @@ sub finish {
   }
 
   $self->dump_stats unless $self->param('no_stats');
+  $self->dump_skipped_variants if $self->param('skipped_variants_file');
 
   revert_fasta() if $self->fasta_db;
 

--- a/t/BaseVEP.t
+++ b/t/BaseVEP.t
@@ -241,6 +241,23 @@ open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 is($bv->get_database_assembly, undef, 'get_database_assembly - no DB');
 
 
+## skipped_variant_msg tests
+############################
+
+open(SAVE, ">&STDERR") or die "Can't save STDERR\n";
+
+close STDERR;
+open STDERR, '>', \$tmp;
+
+$bv->skipped_variant_msg("Invalid variant", 3);
+like($tmp, qr/Invalid variant/, 'skipped_variant_msg - warning about invalid variant');
+
+my $skipped = $bv->skipped_variants();
+like($skipped->[0]->{description}, qr/Invalid variant/, 'skipped_variant_msg - description');
+ok($skipped->[0]->{line_number} == 3, 'skipped_variant_msg - line number');
+is($skipped->[0]->{line}, undef, 'skipped_variant_msg - line content');
+
+open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 
 ## DATABASE TESTS
 #################

--- a/t/Parser.t
+++ b/t/Parser.t
@@ -160,10 +160,10 @@ is($p->validate_vf(get_vf({allele_string => 'A/C', chr => 2})), 0, 'validate_vf 
 ok($tmp =~ /Chromosome .* not found/, 'validate_vf - chromosome not in valid list 2');
 
 is($p->validate_vf(get_vf({allele_string => 'G/C', start => 'foo'})), 0, 'validate_vf - start is not number 1');
-ok($tmp =~ /coordinate invalid/, 'validate_vf - start is not number 2');
+like($tmp, qr/Invalid start 'foo' .* coordinate/, 'validate_vf - start is not number 2');
 
 is($p->validate_vf(get_vf({allele_string => 'G/C', end => 'foo'})), 0, 'validate_vf - end is not number 1');
-ok($tmp =~ /coordinate invalid/, 'validate_vf - end is not number 2');
+like($tmp, qr/Invalid .* end '1' coordinate/, 'validate_vf - end is not number 2');
 
 is($p->validate_vf(get_vf({allele_string => 'G/C', start => 3, end => 1})), 0, 'validate_vf - start > end+1 1');
 ok($tmp =~ /start \> end\+1/, 'validate_vf - start > end+1 2');


### PR DESCRIPTION
[ENSVAR-4683](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4683): report variants skipped and reason (based on user request #1088)

Check also flag documentation in https://github.com/Ensembl/public-plugins/pull/669

### Changelog

* For each line of input file, all variants that are skipped because of parsing issues raise a warning. This warning was improved to also contain the line content.
* Add new argument `--skipped_variants_file` that writes skipped variants to a given file path
  * If argument is not provided, the skipped variants file is written
  * If file already exists, you will need to use `--force_overwrite` or use another filename

### Testing

1. Prepare a VCF with malformatted variants:

```
1       2642609 .       G       A
1       2827694 rs2376870       CGTGGATGCGGGGAC C       SVTYPE=DEL;END=2827708
1       pos123  .       G       A
1       230710048       rs699   A       G
chr402  89828156        rs201106962     A       C
18      23873048        rs867018739     Z       Y
18      23873048        rs867018739     C       T
19      804947  rs569478349     G       C
19      39735004        .       A       C
19      39735057        rs752685201     G       T
19      39735057        rs752685201     X       T
19      39737938        rs753930790     G       A
19      45687010        rs1964272       G       A
``` 

2. Run VEP with `--skipped_variants_file` argument:
```
vep --i sample.vcf --offline --skipped_variants_file skipped.txt
```

3. Check `skipped.txt` contents (results should be similar to the command-line warnings):

```
[VEP skipped the following variants from input file input/sample.vcf]
Line 3          1 pos123 . G A                                  Invalid start 'pos123' or end '0' coordinate
Line 5          chr402 89828156 rs201106962 A C                 Chromosome chr402 not found in annotation sources or synonyms; chromosome chr402 does not overlap any features
Line 6          18 23873048 rs867018739 Z Y                     Invalid allele string Z/Y or possible parsing error
```

4. Run again the same VEP command: a warning should complain that a file with name `skipped.txt` already exists
5. Run the VEP command without `--skipped_variants_file`; no skipped variant file should be created