### PR TITLE
fix: Get old usage back to VEP custom

### DIFF
--- a/t/AnnotationSourceAdaptor.t
+++ b/t/AnnotationSourceAdaptor.t
@@ -93,10 +93,10 @@ is_deeply(ref($asa->get_all()->[0]), 'Bio::EnsEMBL::VEP::AnnotationSource::Cache
 $asa->param('check_existing', 0);
 
 $asa->param('custom', ['test=' . $test_cfg->{custom_vcf} . ',format=vcf,short_name=foo,type=exact']);
-throws_ok {$asa->get_all_custom} qr/No 'file=' was added for custom annotation source./, 'get_all_custom - invalid file';
+throws_ok {$asa->get_all_custom} qr/No file was added for custom annotation source./, 'get_all_custom - invalid file';
 
 $asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',test=vcf,short_name=foo,type=exact']);
-throws_ok {$asa->get_all_custom} qr/No 'format=' specified for custom annotation source./, 'get_all_custom - invalid format';
+throws_ok {$asa->get_all_custom} qr/No format specified for custom annotation source./, 'get_all_custom - invalid format';
 
 $asa->param('custom', ['file=' . $test_cfg->{custom_vcf} . ',format=foo,short_name=test,type=exact']);
 throws_ok {$asa->get_all_custom} qr/Unknown or unsupported format foo/, 'get_all_custom - invalid format value';


### PR DESCRIPTION
Jira: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5028)

## Description

After our team review meeting, it was advised that we need to keep old custom usage. This PR reintegrate old usage, altered in this PR (https://github.com/Ensembl/ensembl-vep/pull/1339)

## Test

```sh
## Previous usage:
--custom filename,test,vcf,exact,0,field1,field2
## After this PR:
--custom file=filename,short_name=test,format=vcf,type=exact,coords=0,fields=field1%field2
## options can be in any order, i.e:
--custom fields=field1%field2,type=exact,coords=0,file=filename,short_name=test,format=vcf
## would have same result.
```

1) Check if old + new usage are working.