### PR TITLE
Allow recursive tmp_dir creation in DumpVEP

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
@@ -33,6 +33,7 @@ use strict;
 use warnings;
 
 use FileHandle;
+use File::Path qw(mkpath);
 
 use Bio::EnsEMBL::VEP::Config;
 use Bio::EnsEMBL::VEP::AnnotationSource::Database::Variation;
@@ -109,7 +110,7 @@ sub run {
     my $tmp_dir = $self->param('tmp_dir');
     
     unless(-e $tmp_dir){
-      mkdir($tmp_dir) or die "Cannot create temp_dir - $!";
+      mkpath($tmp_dir) or die "Cannot create temp_dir - $!";
     }
    
     foreach my $chr(keys %{{map {$_->{chr} => 1} @{$self->param('regions')}}}) {


### PR DESCRIPTION
### Issue
The default `tmp_dir` in DumpVEP pipeline can be [recursive](https://github.com/Ensembl/ensembl-vep/blob/fc75dcc5534f92d4cf6614ef6c1ad81c2cd01cfb/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/DumpVEP_conf.pm#L74). It can also be recursive if given as such in cmd argument. 
The pipeline only allows non-recursive dir creation and thus fails if `tmp_dir` not created manually before running the pipeline.

### Solution
Allow non-recursive `tmp_dir` creation

### Test
Tested on cat vep dump - http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=snhossain_dump_vep_felis_catus_110&passwd=xxxxx