### PR TITLE
Nextflow: Support multiple VEP config files

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -52,13 +52,13 @@ The following config files are used and can be modified depending on user requir
 #### Options
 
 ```bash
-  --vcf VCF                 Sorted and bgzipped VCF. Alternatively, can also be a direcotry containing VCF files.
-  --bin_size INT            Input file is split into multiple files with a given number of variants. Enables faster run in expense of more jobs. Default: 100
-  --vep_config FILENAME     VEP config file. Default: vep_config/vep.ini
+  --vcf VCF                 Sorted and bgzipped VCF. Alternatively, can also be a directory containing VCF files
+  --bin_size INT            Number of variants used to split input VCF into multiple jobs. Default: 100
+  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1
-  --outdir DIRNAME          Name of output dir. Default: outdir
-  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <output_prefix>.vcf.gz
-  --skip_check [0,1]        Skip checking for tabix index file of input VCF. Enables the first module to load from cache if -resume is used. Default: 0
+  --outdir DIRNAME          Name of output directory. Default: outdir
+  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <vcf>-<output_prefix>.vcf.gz
+  --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
 ```
 
 ---

--- a/nextflow/nf_modules/check_VCF.nf
+++ b/nextflow/nf_modules/check_VCF.nf
@@ -34,7 +34,11 @@ process checkVCF {
 
   script:
   """
-  bgzip -t ${input_vcf} || bgzip -c ${input_vcf} > ${input_vcf}.gz
+  [ -f *gz ] || bgzip -c ${input_vcf} > ${input_vcf}.gz
   [ -f *gz.tbi ] || tabix -p vcf -f *.gz
+
+  # quickly test tabix -- ensures both bgzip and tabix are okay
+  chr=\$(tabix -l *.gz | head -n1)
+  tabix *.gz \${chr}:1-10001
   """
 }

--- a/nextflow/nf_modules/check_VCF.nf
+++ b/nextflow/nf_modules/check_VCF.nf
@@ -34,5 +34,21 @@ process checkVCF {
   bgzip -t ${ input_vcf}
   tabix -p vcf -f ${ input_vcf}
   """
+}
 
+process checkInput {
+  /*
+  Function to check input files
+  */
+  input:
+  val vcf_count
+  val config_count
+
+  """
+  if [ "${vcf_count}" -gt "1" ] && [ "${config_count}" -gt "1" ]
+  then
+    echo "Multiple VCF and VEP config files are currently not supported"
+    exit 1
+  fi
+  """
 }

--- a/nextflow/nf_modules/check_VCF.nf
+++ b/nextflow/nf_modules/check_VCF.nf
@@ -38,20 +38,3 @@ process checkVCF {
   [ -f *gz.tbi ] || tabix -p vcf -f *.gz
   """
 }
-
-process checkInput {
-  /*
-  Function to check input files
-  */
-  input:
-  val vcf_count
-  val config_count
-
-  """
-  if [ "${vcf_count}" -gt "1" ] && [ "${config_count}" -gt "1" ]
-  then
-    echo "Multiple VCF and VEP config files are currently not supported"
-    exit 1
-  fi
-  """
-}

--- a/nextflow/nf_modules/merge_VCF.nf
+++ b/nextflow/nf_modules/merge_VCF.nf
@@ -38,8 +38,7 @@ process mergeVCF {
   tuple val(original), path(vcfFiles), path(indexFiles)
 
   output:
-  path("${ original }_vep_${ mergedVCF }.vcf.gz*")
-
+  path("*.vcf.gz*")
 
   script: 
   """

--- a/nextflow/nf_modules/run_vep.nf
+++ b/nextflow/nf_modules/run_vep.nf
@@ -7,7 +7,6 @@
 nextflow.enable.dsl=2
 
 // defaults
-prefix = "vep"
 params.outdir = ""
 params.cpus = 1
 
@@ -22,7 +21,7 @@ process runVEP {
       2) A tabix index for that VCF output file
   */
   publishDir "${params.outdir}/vep-summary",
-    pattern: "${original}-${prefix}-*.vcf.gz_summary.*",
+    pattern: "vep-${original}-${vep_config}-*.vcf.gz_summary.*",
     mode:'move'
   cpus params.cpus
   label 'vep'
@@ -32,8 +31,8 @@ process runVEP {
   each path(vep_config)
   
   output:
-  tuple val(original), path("${original}-${prefix}-*.vcf.gz"), path("${original}-${prefix}-*.vcf.gz.tbi"), emit: vcf
-  path("${original}-${prefix}-*.vcf.gz_summary.*")
+  tuple val(original), path("*.vcf.gz"), path("*.vcf.gz.tbi"), emit: vcf
+  path("*.vcf.gz_summary.*")
 
   script:
   if( !vcfFile.exists() ) {
@@ -44,7 +43,7 @@ process runVEP {
   }
   else {
     """
-    out=${original}-${prefix}-${vcfFile}
+    out=vep-${original}-${vep_config}-${vcfFile}
     vep -i ${vcfFile} -o \${out} --vcf --compress_output bgzip --format vcf --config ${vep_config}
     tabix -p vcf \${out}
     """	

--- a/nextflow/nf_modules/run_vep.nf
+++ b/nextflow/nf_modules/run_vep.nf
@@ -29,7 +29,7 @@ process runVEP {
 
   input:
   tuple val(original), path(vcfFile), path(indexFile)
-  path(vep_config)
+  each path(vep_config)
   
   output:
   tuple val(original), path("${original}-${prefix}-*.vcf.gz"), path("${original}-${prefix}-*.vcf.gz.tbi"), emit: vcf

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -35,13 +35,13 @@ Usage:
   nextflow run workflows/run_vep.nf --vcf <path-to-vcf> --vep_config vep_config/vep.ini
 
 Options:
-  --vcf VCF                 Sorted and bgzipped VCF. Alternatively, can also be a direcotry containing VCF files
-  --bin_size INT            Input file is split into multiple files with a given number of variants. Enables faster run in expense of more jobs. Default: 100
-  --vep_config FILENAME     VEP config file. Default: vep_config/vep.ini
+  --vcf VCF                 Sorted and bgzipped VCF. Alternatively, can also be a directory containing VCF files
+  --bin_size INT            Number of variants used to split input VCF into multiple jobs. Default: 100
+  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1
-  --outdir DIRNAME          Name of output dir. Default: outdir
-  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <output_prefix>.vcf.gz
-  --skip_check [0,1]        Skip checking for tabix index file of input VCF. Enables the first module to load from cache if -resume is used. Default: 0
+  --outdir DIRNAME          Name of output directory. Default: outdir
+  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <vcf>-<output_prefix>.vcf.gz
+  --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
   """
   exit 1
 }
@@ -63,34 +63,42 @@ if( !params.vcf) {
   exit 1, "Undefined --vcf parameter. Please provide the path to a VCF file"
 }
 
-log.info 'Starting workflow.....'
+def processInput (input, pattern) {
+  if (input instanceof String) {
+    // If vcf is a String, process as file or directory
+    files = file(input)
+    if ( !files.exists() ) {
+      exit 1, "The specified VCF input does not exist: ${files}"
+    }
+
+    if (files.isDirectory()) {
+      files = Channel.fromPath("${files}/${pattern}")
+    }
+  } else {
+    // If vcf is a Channel, just pass along
+    files = input
+  }
+  return files
+}
 
 workflow vep {
   take:
     vcf
     vep_config
   main:
-    if(vcf instanceof String){
-      vcfInput = file(vcf)
-      if( !vcfInput.exists() ) {
-        exit 1, "The specified VCF input does not exist: ${vcfInput}"
-      }
+    vcf = processInput(vcf, pattern="*.gz")
+    vep_config = processInput(vep_config, pattern="*.ini")
 
-      if (vcfInput.isDirectory()) {
-        checkVCF(Channel.fromPath("${vcfInput}/*.gz"))
-      } else {
-        checkVCF(vcfInput)
-      }
-    }
-    else {
-      checkVCF(vcf)
-    }
+    // Prepare input VCF files (bgzip + tabix)
+    checkVCF(vcf)
 
+    // Split VCF by bin size
     splitVCF(checkVCF.out, params.bin_size)
 
-    vep_config = Channel.fromPath(vep_config, relative: true).first()
+    // Run VEP for each split VCF file and for each VEP config
     runVEP(splitVCF.out.files.transpose(), vep_config)
 
+    // Merge split VCF files (creates one output VCF for each input VCF)
     mergeVCF(runVEP.out.vcf.groupTuple())
   emit:
     mergeVCF.out

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -80,14 +80,14 @@ workflow vep {
     vcf
     vep_config
   main:
-    if (!vep_config) {
-      exit 1, "Undefined --vep_config parameter. Please provide a VEP config file"
-    }
-    
     if (!vcf) {
       exit 1, "Undefined --vcf parameter. Please provide the path to a VCF file"
     }
-  
+
+    if (!vep_config) {
+      exit 1, "Undefined --vep_config parameter. Please provide a VEP config file"
+    }
+
     // Raise error if we have multiple VCF files and VEP config files as input
     // This would require mapping the VCF to the config files
     vcf = processInput(vcf, pattern="*.{vcf,gz}", true)

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -49,7 +49,7 @@ Options:
 
 def processInput (input, pattern, is_vcf) {
   if (input instanceof String) {
-    // If vcf is a String, process as file or directory
+    // if input is a String, process as file or directory
     files = file(input)
     if ( !files.exists() ) {
       exit 1, "The specified input does not exist: ${input}"
@@ -65,7 +65,7 @@ def processInput (input, pattern, is_vcf) {
       }
     }
   } else {
-    // If vcf is a Channel, just pass along
+    // if input is a Channel, just pass along
     files = input
   }
   return files

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -20,7 +20,7 @@ params.skip_check = 0
 params.help = false
 
 // module imports
-include { checkVCF } from '../nf_modules/check_VCF.nf'
+include { checkInput; checkVCF } from '../nf_modules/check_VCF.nf'
 include { splitVCF } from '../nf_modules/split_VCF.nf' 
 include { mergeVCF } from '../nf_modules/merge_VCF.nf'  
 include { runVEP } from '../nf_modules/run_vep.nf'
@@ -86,8 +86,11 @@ workflow vep {
     vcf
     vep_config
   main:
+    // Raise error if we have multiple VCF files and VEP config files as input
+    // This would require mapping the VCF to the config files
     vcf = processInput(vcf, pattern="*.gz")
     vep_config = processInput(vep_config, pattern="*.ini")
+    checkInput(vcf.count(), vep_config.count())
 
     // Prepare input VCF files (bgzip + tabix)
     checkVCF(vcf)

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -56,18 +56,22 @@ def processInput (input, pattern, is_vcf) {
     }
 
     if (files.isDirectory()) {
-      files = Channel.fromPath("${files}/${pattern}")
+      files = "${files}/${pattern}"
     }
-    if (is_vcf) {
-      files = files.multiMap {
-        vcf: it
-        vcf_index: "${it}.tbi"
-      }
-    }
+    files = Channel.fromPath(files)
   } else {
     // if input is a Channel, just pass along
     files = input
   }
+
+  if (is_vcf) {
+    // add tabix-index files for VCF input (to be checked if they exist later)
+    files = files.multiMap { it ->
+      vcf: it
+      vcf_index: "${it}.tbi"
+    }
+  }
+
   return files
 }
 


### PR DESCRIPTION
- Support multiple VEP config files
- Raise error if setting multiple VCF files and VEP config files (currently unsupported)
- Allow to input a Channel of VCF and automatically add tabix index files
- Differentiate output filename to avoid name collisions
- Improve speed when checking bgzip and tabix files