### PR TITLE
Fix vep dump for regulation build

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
@@ -244,6 +244,7 @@ sub get_chr_jobs {
   } @slices;
 
   delete($self->{_var_dba}) if $self->{_var_dba};
+  delete($self->{_rfa}) if $self->{_rfa};
 
   # now distribute the slices into jobs
   # jobs can contain multiple slices


### PR DESCRIPTION
Marc reported failure for dump vep for vertebrates - 
http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensro&host=mysql-ens-hive-prod-1&port=4575&dbname=enseven_dump_vep_vert_110

The `create_dump_jobs` was trying to call `sus_scrofa` regulation database although the job was for `gallus_gallus`. It because that regulation dba already existed from previous job [here](https://github.com/Ensembl/ensembl-vep/blob/fc75dcc5534f92d4cf6614ef6c1ad81c2cd01cfb/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm#L320).

We need to delete regulation dba just like variation.

### Test pipeline - 
http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=snhossain_dump_vep_test_110&passwd=xxxxx