### PR TITLE
Stop coverage for perl 5.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
   include:
     - stage: trigger_dependent_builds
       script: ./travisci/trigger-dependent-build.sh
+      perl: "5.14"
 
 notifications:
   email:

--- a/travisci/harness.sh
+++ b/travisci/harness.sh
@@ -20,7 +20,7 @@ fi
 
 rt=$?
 if [ $rt -eq 0 ]; then
-  if [ "$COVERALLS" = 'true' ]; then
+  if [[ "$COVERALLS" = 'true' && ! "${TRAVIS_PERL_VERSION}" =~ 5.10 ]]; then
     echo "Running Devel::Cover coveralls report"
     cover --nosummary -report coveralls
   fi


### PR DESCRIPTION
Devel::Cover have updated there minimal Perl supported version to v5.12.0 -
https://github.com/pjcj/Devel--Cover/blob/v1.40/Changes (see 1.39 release)

All ensembl-vep travis build will fails on 5.10 coverage test.

- temporarily stopping coverage for perl 5.10
- update trigger-dependency stage to use 5.14 (it was using perl 5.10 before)