### PR TITLE
Print only file name as gff/gtf source

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
@@ -229,7 +229,7 @@ sub get_all_custom {
     my $opts = {
       config => $self->config,
       file => $hash{"file"},
-      short_name => $hash{"short_name"} || $hash{"file"},
+      short_name => $hash{"short_name"},
       format => $hash{"format"},
       type => $hash{"type"} || "overlap",
       report_coords => $hash{"coords"} || 0,

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -2295,8 +2295,8 @@ sub get_custom_headers {
     my @flatten_header = get_flatten(\@headers);
     my %pos = map { $flatten_header[$_]=~/o/?($flatten_header[$_]=>$_):() } 0..$#flatten_header if @flatten_header;
     
-    my $masked_file = "[PATH]/" . (basename $custom->{file});
-    # $masked_file =~ s/(\/[\w-]+?)+\//\[PATH\]\//g;
+    # To prevent printing internal directory mask filepath
+    my $masked_file = $custom->{file} =~ /\// ? "[PATH]/" . (basename $custom->{file}) : $custom->{file};
     
     if (grep { /^$custom->{short_name}$/ }  @flatten_header){
       my $pos = $pos{$custom->{short_name}} / 2;

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -2293,14 +2293,17 @@ sub get_custom_headers {
     
     my @flatten_header = get_flatten(\@headers);
     my %pos = map { $flatten_header[$_]=~/o/?($flatten_header[$_]=>$_):() } 0..$#flatten_header if @flatten_header;
-
+    
+    my $masked_file = $custom->{file};
+    $masked_file =~ s/(\/[\w-]+?)+\//\[PATH\]\//g;
+    
     if (grep { /^$custom->{short_name}$/ }  @flatten_header){
       my $pos = $pos{$custom->{short_name}} / 2;
-      $headers[$pos][1] .= ",$custom->{file}";
+      $headers[$pos][1] .= ",$masked_file";
     } else {
       push @headers, [
         $custom->{short_name},
-        sprintf("%s", $custom->{file})
+        sprintf("%s", $masked_file)
       ];
     }
 
@@ -2308,16 +2311,16 @@ sub get_custom_headers {
       my $sub_id = sprintf("%s_%s", $custom->{short_name}, $field);
       if (grep { /^$sub_id$/ } @flatten_header){
         my $pos = $pos{$sub_id} / 2;
-        $headers[$pos][1] .= ",$custom->{file}";
+        $headers[$pos][1] .= ",$masked_file";
       } elsif ($field eq "PC") {
         push @headers, [
           $sub_id,
-          sprintf("Percentage of input variant covered by reference variant from %s", $custom->{file})
+          sprintf("Percentage of input variant covered by reference variant from %s", $masked_file)
         ];
       } else {
         push @headers, [
           $sub_id,
-          sprintf("%s field from %s", $field, $custom->{file})
+          sprintf("%s field from %s", $field, $masked_file)
         ];
       }
     }

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -69,6 +69,7 @@ package Bio::EnsEMBL::VEP::OutputFactory;
 
 use base qw(Bio::EnsEMBL::VEP::BaseVEP);
 
+use File::Basename;
 use Scalar::Util qw(looks_like_number);
 use Bio::EnsEMBL::Utils::Scalar qw(assert_ref);
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
@@ -2294,8 +2295,8 @@ sub get_custom_headers {
     my @flatten_header = get_flatten(\@headers);
     my %pos = map { $flatten_header[$_]=~/o/?($flatten_header[$_]=>$_):() } 0..$#flatten_header if @flatten_header;
     
-    my $masked_file = $custom->{file};
-    $masked_file =~ s/(\/[\w-]+?)+\//\[PATH\]\//g;
+    my $masked_file = "[PATH]/" . (basename $custom->{file});
+    # $masked_file =~ s/(\/[\w-]+?)+\//\[PATH\]\//g;
     
     if (grep { /^$custom->{short_name}$/ }  @flatten_header){
       my $pos = $pos{$custom->{short_name}} / 2;

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -17,6 +17,7 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
+use File::Basename;
 use FindBin qw($Bin);
 use lib $Bin;
 use VEPTestingConfig;
@@ -1813,7 +1814,7 @@ SKIP: {
     [
       [
         'test',
-        $test_cfg->{custom_vcf}
+        "[PATH]/" . (basename $test_cfg->{custom_vcf})
       ]
     ],
     'get_custom_headers'
@@ -1843,7 +1844,7 @@ SKIP: {
     [
       [
         'test',
-        $test_cfg->{custom_vcf} . ',' . $test_cfg->{custom_vcf_2}
+        "[PATH]/" . (basename $test_cfg->{custom_vcf}) . ',' . "[PATH]/" . (basename $test_cfg->{custom_vcf_2})
       ]
     ],
     'get_multiple_custom_headers'


### PR DESCRIPTION
With https://github.com/Ensembl/ensembl-vep/pull/1317 the `source_name` has been default to `file`. It results in full file path being printed in the output. before the logic was to print only the file name in the output.

Revert back to previous logic.

### Test
```
chr2	32198	.	A	G
```

```
vep  --i  <input_file> --assembly GRCh37 --fasta path/to/CHM13.fa --gff path/to/Homo_sapiens-GCA_009914755.4-2022_06-genes.gff3.gz --force --vcf
```