### PR TITLE
Fix results when enabling `--no_stats`

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -952,7 +952,16 @@ sub VariationFeature_to_output_hash {
   # check_ref tests
   $hash->{CHECK_REF} = 'failed' if defined($vf->{check_ref_failed});
 
-  $self->stats->log_VariationFeature($vf, $hash) unless $self->{no_stats};
+  unless ($self->{no_stats}) {
+    $self->stats->log_VariationFeature($vf, $hash);
+  } else {
+    # get overlap consequences to fix codon/nucleotide changes
+    for my $vfo (@{ $vf->get_all_VariationFeatureOverlaps }) {
+      for my $allele (@{ $vfo->get_all_alternate_VariationFeatureOverlapAlleles }) {
+        $allele->get_all_OverlapConsequences;
+      }
+    }
+  }
 
   return $hash;
 }


### PR DESCRIPTION
[ENSVAR-4494](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4494): related with #1034 

When running `--no_stats`, consequences for `--hgvs` can be wrongly calculated. This PR adds missing logic required when running `--no_stats` to return the expected results.

However, this adds extra steps that can make VEP slower with `-no_stats` -- we need to benchmark how slow adding this can be for a large amount of variants.

## Testing

Running with or without `--no_stats --hgvs` should return the same results when using the following input VCF:

```
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
chr3	42210085	.	C	CGGAGGA,CGGA	359	PASS	.
chr14	24300643	.	A	AGAGGAG,AGAG	694	PASS	.
```