### PR TITLE
Fixed Original allele where allele string not defined

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -876,7 +876,7 @@ sub VariationFeature_to_output_hash {
 
   my $hash = {
     Uploaded_variation  => $vf->variation_name ne '.' ? $vf->variation_name : ($vf->{original_chr} || $vf->{chr}).'_'.$vf->{start}.'_'.($vf->{allele_string} || $vf->{class_SO_term}),
-    Original_allele     => ($vf->{original_allele_string} || $vf->{allele_string} || $vf->{class_SO_term}),
+    Original_allele     => ($vf->{original_allele_string} || $vf->{allele_string} || $vf->{class_SO_term} || "" ),
     Location            => ($vf->{chr} || $vf->seq_region_name).':'.format_coords($vf->{start}, $vf->{end}),
   };
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -876,7 +876,7 @@ sub VariationFeature_to_output_hash {
 
   my $hash = {
     Uploaded_variation  => $vf->variation_name ne '.' ? $vf->variation_name : ($vf->{original_chr} || $vf->{chr}).'_'.$vf->{start}.'_'.($vf->{allele_string} || $vf->{class_SO_term}),
-    Original_allele     => ($vf->{original_allele_string} || $vf->{allele_string}),
+    Original_allele     => ($vf->{original_allele_string} || $vf->{allele_string} || $vf->{class_SO_term}),
     Location            => ($vf->{chr} || $vf->seq_region_name).':'.format_coords($vf->{start}, $vf->{end}),
   };
 

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -1325,7 +1325,7 @@ is_deeply(
   $of->VariationFeature_to_output_hash($ib->buffer->[0]),
   {
     'Uploaded_variation' => 'sv_dup',
-    'Original_allele' => undef,
+    'Original_allele' => "duplication",
     'Location' => '21:25606615-25606616'
   },
   'SV - VariationFeature_to_output_hash'


### PR DESCRIPTION
Bugfix for [ensembl-vep#1313](https://github.com/Ensembl/ensembl-vep/pull/1313)

For SVs, allele_string is not defined. In such a case Original allele points to SO term