### PR TITLE
bugfix: resolve many-to-one situation in nextflow-vep

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -57,7 +57,8 @@ The following config files are used and can be modified depending on user requir
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1
   --outdir DIRNAME          Name of output directory. Default: outdir
-  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <vcf>-<output_prefix>.vcf.gz
+  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <output_prefix>_VEP.vcf.gz.
+                            NOTE: Do not use this parameter if you are expecting multiple output files.
   --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
 ```
 

--- a/nextflow/nf_modules/check_VCF.nf
+++ b/nextflow/nf_modules/check_VCF.nf
@@ -20,10 +20,10 @@ process checkVCF {
   errorStrategy 'ignore'
 
   input:
-  tuple path(vcf), path(vcf_index), path(vep_config), val(output_dir), val(index_type)
+  tuple path(vcf), path(vcf_index), path(vep_config), val(index_type)
   
   output:
-  tuple path("*.gz", includeInputs: true), path ("*.gz.{tbi,csi}", includeInputs: true), path(vep_config), val(output_dir), val(index_type)
+  tuple path("*.gz", includeInputs: true), path ("*.gz.{tbi,csi}", includeInputs: true), path(vep_config), val(index_type)
 
   afterScript "rm *.vcf *.vcf.tbi *.vcf.csi"
 

--- a/nextflow/nf_modules/generate_splits.nf
+++ b/nextflow/nf_modules/generate_splits.nf
@@ -21,11 +21,11 @@ process generateSplits {
   label 'bcftools'
 
   input:
-  tuple path(vcf), path(vcf_index), path(vep_config), val(output_dir), val(index_type)
+  tuple path(vcf), path(vcf_index), path(vep_config), val(index_type)
   val(bin_size)
 
   output:
-  tuple path(vcf), path(vcf_index), path("x*"), path(vep_config), val(output_dir), val(index_type)
+  tuple path(vcf), path(vcf_index), path("x*"), path(vep_config), val(index_type)
 
   shell:
   """

--- a/nextflow/nf_modules/merge_VCF.nf
+++ b/nextflow/nf_modules/merge_VCF.nf
@@ -22,14 +22,19 @@ process mergeVCF {
   cache 'lenient'
    
   input:
-  tuple val(original_vcf), path(vcf_files), path(index_files), path(vep_config), val(index_type)
-  val output_dir
+  tuple val(original_vcf), path(vcf_files), path(index_files), val(vep_config), val(index_type),
+    val(one_to_many),
+    val(output_dir)
   
   output:
   val("${output_dir}/${merged_vcf}")
 
   script:
   merged_vcf = merged_vcf ?: file(original_vcf).getName().replace(".vcf", "_VEP.vcf")
+  merged_vcf = one_to_many ? merged_vcf.replace(
+    "_VEP.vcf", 
+    "_" + file(vep_config).getName().replace(".ini", "") + "_VEP.vcf"
+  ) : merged_vcf
   index_flag = index_type == "tbi" ? "-t" : "-c"
   
   """

--- a/nextflow/nf_modules/merge_VCF.nf
+++ b/nextflow/nf_modules/merge_VCF.nf
@@ -22,7 +22,7 @@ process mergeVCF {
   cache 'lenient'
    
   input:
-  tuple val(original_vcf), path(vcf_files), path(index_files), val(index_type)
+  tuple val(original_vcf), path(vcf_files), path(index_files), path(vep_config), val(index_type)
   val output_dir
   
   output:

--- a/nextflow/nf_modules/merge_VCF.nf
+++ b/nextflow/nf_modules/merge_VCF.nf
@@ -22,7 +22,8 @@ process mergeVCF {
   cache 'lenient'
    
   input:
-  tuple val(original_vcf), path(vcf_files), path(index_files), val(output_dir), val(index_type)
+  tuple val(original_vcf), path(vcf_files), path(index_files), val(index_type)
+  val output_dir
   
   output:
   val("${output_dir}/${merged_vcf}")

--- a/nextflow/nf_modules/process_input.nf
+++ b/nextflow/nf_modules/process_input.nf
@@ -8,7 +8,7 @@ nextflow.enable.dsl=2
 
 process processInput {
   /*
-  Generate input for subsequent jobs. It works like merge operator and it helps creating one-to-one or many-to-one or many-to-one relationship between vcf file, vep_config, and output_dir
+  Generate input for subsequent jobs.
 
   Returns
   -------
@@ -22,12 +22,10 @@ process processInput {
   cpus params.cpus
 
   input:
-  path vcf
-  path vep_config
-  val output_dir
+  tuple path(vcf), path(vep_config)
 
   output:
-  tuple path(vcf), env(vcf_index), path(vep_config), val(output_dir), env(index_type)
+  tuple path(vcf), env(vcf_index), path(vep_config), env(index_type)
   
   script:
   """

--- a/nextflow/nf_modules/run_vep.nf
+++ b/nextflow/nf_modules/run_vep.nf
@@ -25,7 +25,7 @@ process runVEP {
   tuple val(original_vcf), path(vcf), path(vcf_index), path(vep_config), val(index_type)
   
   output:
-  tuple val(original_vcf), path(out_vcf), path("${out_vcf}.{tbi,csi}"), val(index_type), emit: files
+  tuple val(original_vcf), path(out_vcf), path("${out_vcf}.{tbi,csi}"), path(vep_config), val(index_type), emit: files
   path("*.vcf.gz_summary.*")
 
   script:

--- a/nextflow/nf_modules/run_vep.nf
+++ b/nextflow/nf_modules/run_vep.nf
@@ -25,7 +25,7 @@ process runVEP {
   tuple val(original_vcf), path(vcf), path(vcf_index), path(vep_config), val(index_type)
   
   output:
-  tuple val(original_vcf), path(out_vcf), path("${out_vcf}.{tbi,csi}"), path(vep_config), val(index_type), emit: files
+  tuple val(original_vcf), path(out_vcf), path("${out_vcf}.{tbi,csi}"), val("${vep_config}"), val(index_type), emit: files
   path("*.vcf.gz_summary.*")
 
   script:

--- a/nextflow/nf_modules/run_vep.nf
+++ b/nextflow/nf_modules/run_vep.nf
@@ -22,10 +22,10 @@ process runVEP {
   label 'vep'
 
   input:
-  tuple val(original_vcf), path(vcf), path(vcf_index), path(vep_config), val(output_dir), val(index_type)
+  tuple val(original_vcf), path(vcf), path(vcf_index), path(vep_config), val(index_type)
   
   output:
-  tuple val(original_vcf), path(out_vcf), path("${out_vcf}.{tbi,csi}"), val(output_dir), val(index_type), emit: files
+  tuple val(original_vcf), path(out_vcf), path("${out_vcf}.{tbi,csi}"), val(index_type), emit: files
   path("*.vcf.gz_summary.*")
 
   script:

--- a/nextflow/nf_modules/split_VCF.nf
+++ b/nextflow/nf_modules/split_VCF.nf
@@ -22,10 +22,10 @@ process splitVCF {
   label 'bcftools'
 
   input:
-  tuple path(vcf), path(vcf_index), path(split_file), path(vep_config), val(output_dir), val(index_type)
+  tuple path(vcf), path(vcf_index), path(split_file), path(vep_config), val(index_type)
 
   output:
-  tuple val("${vcf}"), path("${prefix}*.vcf.gz"), path("${prefix}*.vcf.gz.{tbi,csi}"), path(vep_config), val(output_dir), val(index_type)
+  tuple val("${vcf}"), path("${prefix}*.vcf.gz"), path("${prefix}*.vcf.gz.{tbi,csi}"), path(vep_config), val(index_type)
 
   afterScript 'rm x*'
 


### PR DESCRIPTION
nextflow-vep many-to-one (and one-to-many) situation with VCF and VEP config file was not working.

This is because giving them as separate channel to `processInputs()` does not work as expected (it is supposed to work like `combine()`). Nextflow handles if one of them is not a channel. 

But going through that route was only considered because of many-to-many situation, and as we are ot supporting that situation I simply used `combine()` which works fine.

**Note** - also stopped channeling `output_dir` through the workflow, it is used only by the `mergeVCF` step. So we can just give input to that step.