### PR TITLE
Avoid error for alternative allele in first line of VCF input

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -794,6 +794,7 @@ sub skipped_variant_msg {
 
   $msg = "Line $line_number skipped " . $msg if defined $line_number;
   $self->warning_msg("WARNING: " . $msg . "\n");
+  $self->{skip_line} = 1;
 
   $self->skipped_variants({
     line => $line,

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -683,18 +683,29 @@ sub get_SO_term {
   my $type = shift || join(",", @{ $self->get_alternatives });
   my $abbrev;
 
-  if ($type =~ /\<CN/i) {
+  if ($type =~ /DUP:TANDEM|CNV:TR/) {
+    # including <CNV:TR>,<CNV:TR>
+    $abbrev = "TDUP";
+  } elsif ($type =~ /CNV/) {
+    # including <CNV>,<CNV>
+    $abbrev = "CNV";
+  } elsif ($type =~ /CN=?[0-9]/i) {
     # ALT: "<CN0>", "<CN0>,<CN2>,<CN3>" "<CN2>" => SVTYPE: DEL, CNV, DUP
     $abbrev = "CNV";
     $abbrev = "DEL" if $type =~ /\<CN=?0\>/;
     $abbrev = "DUP" if $type =~ /\<CN=?2\>/;
-  } elsif ($type =~ /^\<|^\[|\]$|\>$/) {
+  } elsif ($type =~ /[\[\]]/) {
+    $abbrev = "BND";
+  } elsif ($type =~ /^\<|\>$/) {
     $abbrev = $type;
     $abbrev =~ s/\<|\>//g;
     $abbrev =~ s/\:.+//g;
   } else {
     $abbrev = $type;
   }
+
+  ## unsupported SV types
+  $self->skipped_variant_msg("$abbrev type is not supported") if $abbrev eq "CPX";
 
   my %terms = (
     INS  => 'insertion',

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -571,7 +571,7 @@ sub validate_vf {
   # uppercase allele string
   $vf->{allele_string} =~ tr/[a-z]/[A-Z]/;
 
-  unless($vf->{allele_string} =~ /([ACGT-]+\/*)+/) {
+  unless($vf->{allele_string} =~ /([ACGTN-]+\/*)+/) {
     $self->skipped_variant_msg(
       "Invalid allele string " . $vf->{allele_string} . " or possible parsing error"
     );

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -442,8 +442,7 @@ sub detect_format {
 
     # VCF: 20  14370  rs6054257  G  A  29  0  NS=58;DP=258;AF=0.786;DB;H2  GT:GQ:DP:HQ
     elsif ( $self->Bio::EnsEMBL::VEP::Parser::VCF::validate_line(@data) ) {
-      # do some more thorough checking on the ALTs
-      $format = 'vcf' if $self->Bio::EnsEMBL::VEP::Parser::VCF::validate_alts($data[4]);
+      $format = 'vcf';
     }
 
     # ensembl: 20  14370  14370  A/G  +

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -132,29 +132,6 @@ sub validate_line {
 }
 
 
-=head2 validate_alts
-
-  Example    : $valid = $self->validate_alts('A,T,C');
-  Description: Check if alternative alleles are valid.
-  Returntype : bool
-  Exceptions : none
-  Caller     : $self->SUPER::detect_format()
-  Status     : Stable
-
-=cut
-
-sub validate_alts {
-  my $self = shift;
-  my $alts = shift;
-
-  my $ok = 1;
-  foreach my $alt(split(',', $alts)) {
-    $ok = 0 unless $alt =~ /^[\.ACGTN\-\*]+$|^(\<[\w\:\*\=]+\>)$|^[\[\w\:\]]+$/i;
-  }
-  return $ok;
-}
-
-
 =head2 parser
 
   Example    : $io_parser = $parser->parser();

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -595,7 +595,7 @@ ok(
 ## rejoin on minimal
 
 $ib = get_runner({
-  input_file => $test_cfg->create_input_file([qw(21 25741665 . CAGAAGAAAG TAGAAGAAAG,C . . .)]),
+  input_file => $test_cfg->create_input_file([('21', '25741665', '.', 'CAGAAGAAAG', 'TAGAAGAAAG,C', '.', '.', '.')]),
   minimal => 1,
 })->get_InputBuffer;
 $of = Bio::EnsEMBL::VEP::OutputFactory::VCF->new({config => $ib->config});

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -502,7 +502,7 @@ $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   file => $test_cfg->create_input_file([qw(21 25587758 sv_del T <DEL> . . .)]),
   valid_chromosomes => [21]
 })->next();
-like($tmp, qr/VCF line.+looks incomplete/, 'StructuralVariationFeature del without end or length');
+like($tmp, qr/deletion looks incomplete/, 'StructuralVariationFeature del without end or length');
 
 open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 
@@ -520,7 +520,7 @@ my $vf_del = Bio::EnsEMBL::VEP::Parser::VCF->new({
 });
 
 my $sv = $vf_del->next();
-ok($tmp =~ /VCF line.+looks incomplete/, 'StructuralVariationFeature del without end or length (2 variants)');
+ok($tmp =~ /deletion looks incomplete/, 'StructuralVariationFeature del without end or length (2 variants)');
 open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 
 delete($sv->{adaptor});
@@ -620,7 +620,7 @@ is_deeply($cvf, bless( {
                 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - CPX skipped');
 
 
-ok($tmp =~ /variant CPX is of a non-supported type/, 'StructuralVariationFeature - skip CPX warning');
+like($tmp, qr/CPX type is not supported/, 'StructuralVariationFeature - skip CPX warning');
 
 open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";
 


### PR DESCRIPTION
[ENSVAR-4587](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4587): `detect_format()` throws an error if the first VCF line contains a malformatted alternative allele based on a (pretty rigid) regex (that is not used for any other lines). This error can be raised even when VEP supports that alternative allele if the regex is not kept up-to-date.

To avoid the error, issues with VCF format should be dealt with on a line-by-line basis. This PR removes the check for the alternative allele and improves checking for issues line-by-line (without using a strict regex).

# Changelog

* [Ignore alternative allele when checking VCF format](https://github.com/Ensembl/ensembl-vep/commit/8e7af98df3ddd735495cc08a9d27851925d6b01f)
* [Support `N` as an alternative allele (used in telomere breakends)](https://github.com/Ensembl/ensembl-vep/commit/6428f0a9d0913e311df25bdefe656b4fb0ea145a)
* [Improve SV type detection](https://github.com/Ensembl/ensembl-vep/commit/af5e99dfdb65b6852ea81fae1547d0e58fd2e247):
  * Support `<DUP:TANDEM>` as `TDUP`
  * Avoid relying on `SVTYPE` to detect SV type (deprecated in [VCF 4.4](https://samtools.github.io/hts-specs/VCFv4.4.pdf))
  * Add more skipped variants to skipped variants log

# Example VCF

```
##fileformat=VCFv4.4
##fileDate=20090805                          
##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens">
##contig=<ID=21,length=46944323,assembly=B36,md5=f1b74b7f9f4cdbaeb6832ee86cb426c6,species="Homo sapiens">
##contig=<ID=22,length=49691432,assembly=B36,md5=2041e6a0c914b48dd537922cca63acb8,species="Homo sapiens">
##contig=<ID=ctgn1,length=49691432,assembly=B36,md5=2041e6a0c914b48dd537922cca63acb8,species="Homo sapiens">
#CHROM POS ID       REF ALT           QUAL FILTER INFO
1      0   bnd_X    N   .[13:123457[  .    .	  .
1      2   .        T   <CPX>         .    .	  .
1      2   .        T   <INS>         .    .	  .
1      2   .        T   <INS:ME>         .    .      .
1      2   .        T   <DUP>         .    .	  .
1      2   .        T   <DUP:TANDEM>         .    .	 .
1      2   .        T   <INV>         .    .	  .
chr1   2   .   T   <DEL>     .    .	 SVLEN=2;SVCLAIM=DJ;EVENT=DEL_symbolic;END=4          GT    0/1
chr1   2   .   T   <DEL:ME>     .    .      SVLEN=2;SVCLAIM=DJ;EVENT=DEL_symbolic;END=4          GT    0/1
chr1   2 delbp1 T  T[chrA:5[ .    .	 MATEID=delbp2;EVENT=DEL_split_bp_cn                  GT    0/1
chr1   2 delbp2 A  ]chrA:2]A .    .	 MATEID=delbp1;EVENT=DEL_split_bp_cn                  GT    0/1
chr1   2   .   T  <DEL>     .    .	SVLEN=2;SVCLAIM=D;EVENT=DEL_split_bp_cn;END=4                  GT    0/1
chr1   5   .   G   GAAA      .    .	 EVENT=homology_seq                  GT    1/1
chr1   5   .   G   <DUP>     .    .	 SVLEN=3;CIPOS=0,5;EVENT=homology_dup                  GT    0/1
chr1   14  .    T   <INS>     .    .	  IMPRECISE;SVLEN=100;CILEN=-50,50;CIPOS=-10,10;END=14 GT    0/1
chr1   14  .    G   .CCCCCCG  .    .	  EVENT=single_breakend
chr1 100 . T <CNV>,<CNV> . . END=130;SVLEN=30,30;CN=1,2 GT:CN 1/2:3
chr1 100 cnv_notation T <CNV:TR>,<CNV:TR> . . END=130;SVLEN=30,30;CN=3,0.9666;RUS=CAG,CAG,CA,CAG;RN=1,3;RB=90,15,2,12  GT:P>
chr1 100 . T <CNV:TR> . . END=130;SVLEN=30;CN=6.5;RUS=CAG;RUC=65;CIRUC=-15,. GT ./.
1    4370  .    G   <*>   .   .   .
1    4389  .    T  TC,<*> .   .   .
chr1 10000 . T <CNV:TR> . . END=20000;SVLEN=20000;CN=1.25;RUL=10000;RUC=5;RUB=10000,10500,11000,11500,12000 GT ./.
2  321681 . G G]17:198982] .  .   .
```