### PR TITLE
Avoid smartmatch

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -469,7 +469,7 @@ sub _record_overlaps_VF {
     return 0 if defined $ref_class && defined $vf_class && $ref_class ne $vf_class;
   }
 
-  if($type ~~ [ 'overlap', 'within', 'surrounding' ]) {
+  if($type eq 'overlap' || $type eq 'within' || $type eq 'surrounding') {
     # account for insertions in Ensembl world where s = e+1
     my ($vs, $ve) = ($vf->{start}, $vf->{end});
     ($vs, $ve) = ($ve, $vs) if $vs > $ve;


### PR DESCRIPTION
Smartmatch is an experimental feature that throws warnings in newer versions of Perl. This PR intends to replace a smart match with an equivalent `if` statement.