### PR TITLE
Avoid custom annotation of skipped variants

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -304,6 +304,8 @@ sub annotate_InputBuffer {
 
   foreach my $chr(keys %by_chr) {
     foreach my $vf(@{$by_chr{$chr}}) {
+      next if $vf->{vep_skip}; # avoid annotating previously skipped variants
+
       my ($vf_start, $vf_end) = ($vf->{start}, $vf->{end});
       if ($parser->seek($self->get_source_chr_name($chr), $vf_start - 1, $vf_end + 1)) {
         $parser->next();


### PR DESCRIPTION
ENSVAR-5754, fixes #1414 

When a variant is skipped (for instance, for being too large based on `--max_sv_size`), custom annotation is still performed, which can take a long time for big variants. We should not add custom annotation to variants that are marked as skipped.

### Testing

- Test with multiple variants, some of which should be skipped, while others not, such as:
```
##fileformat=VCFv4.2
##contig=<ID=chr2,length=242193529>
##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
##ALT=<ID=DUP:TANDEM,Description="Tandem Duplication">
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO
1       2642609 .       G       A
1       2827694 rs2376870       CGTGGATGCGGGGAC C       SVTYPE=DEL;END=2827708
1       pos123  .       G       A
1       230710048       rs699   A       G
chr402  89828156        rs201106962     A       C
chr2    28983075        .       C       <DUP:TANDEM>    .       .       END=105279483;SVTYPE=DUP;SVLEN=76296408
18      23873048        rs867018739     Z       Y
18      23873048        rs867018739     C       T
19      804947  rs569478349     G       C
19      39735004        .       A       C
19      39735057        rs752685201     G       T
19      39735057        rs752685201     X       T
19      39737938        rs753930790     G       A
19      45687010        rs1964272       G       A
```

- bigwig file example: [hg38.phyloP100way.bw](https://downloads.molgeniscloud.org/downloads/vip/resources/GRCh38/hg38.phyloP100way.bw)

- Command example:
```
perl vep \
     --i $vcf \
     --o output/vep-output.vcf --vcf \
     --offline \
     --allow_non_variant \
     --custom input/hg38.phyloP100way.bw,phyloP,bigwig,exact,0
```