### PR TITLE
Run VEP with SV IDs

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -792,7 +792,8 @@ sub skipped_variant_msg {
     $msg = "(" . $line . "): " . $msg;
   }
 
-  $msg = "Line $line_number skipped " . $msg if defined $line_number;
+  $msg = (defined $line_number and not defined $self->param('input_data')) ?
+    "line $line_number skipped " . $msg : "variant skipped " . $msg;
   $self->warning_msg("WARNING: " . $msg . "\n");
   $self->{skip_line} = 1;
 

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -518,6 +518,14 @@ sub validate_vf {
     return 0;
   }
 
+  # check against size upperlimit to avoid memory problems
+  my $len = $vf->{end} - $vf->{start};
+  my $max_sv_size = $self->param('max_sv_size');
+  if( $len > $max_sv_size ){
+    $self->skipped_variant_msg("variant size ($len) is bigger than --max_sv_size ($max_sv_size)");
+    return 0;
+  }
+
   # check we have this chr in any of the annotation sources
   # otherwise try to map to toplevel if available
   unless($self->_have_chr($vf)) {

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -526,6 +526,7 @@ sub validate_vf {
       "variant size ($len) is bigger than --max_sv_size ($max_sv_size)"
     );
     $vf->{vep_skip} = 1;
+    return 0 if $self->param('rest');
   }
 
   # check we have this chr in any of the annotation sources

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -123,7 +123,7 @@ sub new {
 
   my $self = $class->SUPER::new(@_);
 
-  $self->add_shortcuts([qw(dont_skip check_ref chr lrg minimal delimiter lookup_ref)]);
+  $self->add_shortcuts([qw(dont_skip check_ref chr lrg minimal delimiter lookup_ref max_sv_size)]);
 
   my $hashref = $_[0];
 
@@ -520,10 +520,12 @@ sub validate_vf {
 
   # check against size upperlimit to avoid memory problems
   my $len = $vf->{end} - $vf->{start};
-  my $max_sv_size = $self->param('max_sv_size');
+  my $max_sv_size = $self->{max_sv_size};
   if( $len > $max_sv_size ){
-    $self->skipped_variant_msg("variant size ($len) is bigger than --max_sv_size ($max_sv_size)");
-    return 0;
+    $self->skipped_variant_msg(
+      "variant size ($len) is bigger than --max_sv_size ($max_sv_size)"
+    );
+    $vf->{vep_skip} = 1;
   }
 
   # check we have this chr in any of the annotation sources

--- a/modules/Bio/EnsEMBL/VEP/Parser/ID.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/ID.pm
@@ -179,12 +179,21 @@ sub create_VariationFeatures {
 
   my $v_obj = $ad->fetch_by_name($id);
 
-  unless($v_obj) {
-    $self->warning_msg("WARNING: No variant found with ID \'$id\'");
-    return $self->create_VariationFeatures();
-  }
+  my @vfs;
+  if ($v_obj) {
+    @vfs = @{$v_obj->get_all_VariationFeatures};
+  } else {
+    # search for ID in structural variants
+    my $sva = $self->get_adaptor('variation', 'StructuralVariation');
+    $v_obj  = $sva->fetch_by_name($id);
 
-  my @vfs = @{$v_obj->get_all_VariationFeatures};
+    if ($v_obj) {
+      @vfs = @{$v_obj->get_all_StructuralVariationFeatures};
+    } else {
+      $self->warning_msg("WARNING: No variant found with ID \'$id\'");
+      return $self->create_VariationFeatures();
+    }
+  }
 
   unless(@vfs) {
     $self->warning_msg("WARNING: No mappings found for variant \'$id\'");

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -102,7 +102,7 @@ sub new {
   my $self = $class->SUPER::new(@_);
 
   # add shortcuts to these params
-  $self->add_shortcuts([qw(allow_non_variant gp individual process_ref_homs phased max_sv_size)]);
+  $self->add_shortcuts([qw(allow_non_variant gp individual process_ref_homs phased)]);
 
   return $self;
 }
@@ -517,12 +517,6 @@ sub create_StructuralVariationFeatures {
   my $alt = join(",", @$alts);
   my $type = $info->{SVTYPE} || $alt;
   my $so_term = $self->get_SO_term($type) || $type;
-
-  ## check against size upperlimit to avoid memory problems
-  my $len = $end - $start;
-  if( $len > $self->{max_sv_size} ){
-    $self->skipped_variant_msg("variant size ($len) is bigger than --max_sv_size (" . $self->{max_sv_size} . ")");
-  }
 
   # work out the end coord
   if(defined($info->{END})) {

--- a/t/Parser_ID.t
+++ b/t/Parser_ID.t
@@ -53,7 +53,7 @@ SKIP: {
   my $can_use_db = $db_cfg && scalar keys %$db_cfg && !$@;
 
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
-  skip 'No local database configured', 4 unless $can_use_db;
+  skip 'No local database configured', 5 unless $can_use_db;
 
   my $multi = Bio::EnsEMBL::Test::MultiTestDB->new('homo_vepiens') if $can_use_db;
   
@@ -107,6 +107,47 @@ SKIP: {
   delete($vf->{$_}) for qw(adaptor variation slice variation_name);
 
   is_deeply($vf, $expected, 'basic input test');
+
+  ## structural variant ID test
+  $p = Bio::EnsEMBL::VEP::Parser::ID->new({
+    config => $cfg,
+    file => $test_cfg->create_input_file('nsv917902'),
+    valid_chromosomes => [21],
+  });
+
+  is(ref($p), 'Bio::EnsEMBL::VEP::Parser::ID', 'class ref');
+
+  my $expected_sv = bless( {
+    'is_somatic' => '0',
+    'class_attrib_id' => 7,
+    'allele_freq' => undef,
+    'outer_start' => undef,
+    'seq_region_start' => 7749532,
+    '_study_id' => 5123,
+    'strand' => 1,
+    'seq_region_end' => 46568202,
+    'class_SO_term' => 'copy_number_variation',
+    'allele_string' => undef,
+    '_line' => [
+      'nsv917902'
+    ],
+    'outer_end' => undef,
+    'chr' => '21',
+    'inner_end' => 46568202,
+    '_source_id' => 11,
+    'allele_count' => undef,
+    'end' => 46568202,
+    'length' => undef,
+    'breakpoint_order' => undef,
+    'inner_start' => 7749532,
+    'start' => 7749532,
+    '_structural_variation_id' => 55104096  
+  }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' );
+
+  $vf = $p->next();
+  delete($vf->{$_}) for qw(adaptor variation slice variation_name);
+
+  is_deeply($vf, $expected_sv, 'sv input test');
 
 
   my $tmp;

--- a/t/Parser_ID.t
+++ b/t/Parser_ID.t
@@ -53,7 +53,7 @@ SKIP: {
   my $can_use_db = $db_cfg && scalar keys %$db_cfg && !$@;
 
   ## REMEMBER TO UPDATE THIS SKIP NUMBER IF YOU ADD MORE TESTS!!!!
-  skip 'No local database configured', 5 unless $can_use_db;
+  skip 'No local database configured', 11 unless $can_use_db;
 
   my $multi = Bio::EnsEMBL::Test::MultiTestDB->new('homo_vepiens') if $can_use_db;
   
@@ -111,7 +111,7 @@ SKIP: {
   ## structural variant ID test
   $p = Bio::EnsEMBL::VEP::Parser::ID->new({
     config => $cfg,
-    file => $test_cfg->create_input_file('nsv917902'),
+    file => $test_cfg->create_input_file('nsv183342'),
     valid_chromosomes => [21],
   });
 
@@ -119,36 +119,35 @@ SKIP: {
 
   my $expected_sv = bless( {
     'is_somatic' => '0',
-    'class_attrib_id' => 7,
+    'class_attrib_id' => 10,
     'allele_freq' => undef,
     'outer_start' => undef,
-    'seq_region_start' => 7749532,
-    '_study_id' => 5123,
+    'seq_region_start' => 25002717,
+    '_study_id' => 4279,
     'strand' => 1,
-    'seq_region_end' => 46568202,
-    'class_SO_term' => 'copy_number_variation',
+    'seq_region_end' => 25002717,
+    'class_SO_term' => 'insertion',
     'allele_string' => undef,
     '_line' => [
-      'nsv917902'
+      'nsv183342'
     ],
     'outer_end' => undef,
     'chr' => '21',
-    'inner_end' => 46568202,
+    'inner_end' => undef,
     '_source_id' => 11,
     'allele_count' => undef,
-    'end' => 46568202,
+    'end' => 25002717,
     'length' => undef,
     'breakpoint_order' => undef,
-    'inner_start' => 7749532,
-    'start' => 7749532,
-    '_structural_variation_id' => 55104096  
+    'inner_start' => undef,
+    'start' => 25002717,
+    '_structural_variation_id' => 56669931  
   }, 'Bio::EnsEMBL::Variation::StructuralVariationFeature' );
 
   $vf = $p->next();
   delete($vf->{$_}) for qw(adaptor variation slice variation_name);
 
   is_deeply($vf, $expected_sv, 'sv input test');
-
 
   my $tmp;
   no warnings 'once';
@@ -193,6 +192,16 @@ SKIP: {
   is_deeply($vf, $expected, 'parse input file with empty lines');
 
   ok($tmp =~ /Skipped 2 empty lines/, 'empty line warning');
+
+  # sv max size limit
+  $tmp = '';
+  $p = Bio::EnsEMBL::VEP::Parser::ID->new({
+    config => $cfg,
+    file => $test_cfg->create_input_file('nsv917902'),
+    valid_chromosomes => [21],
+  });
+  $p->next();
+  like($tmp, qr/nsv917902.* variant size .* is bigger than --max_sv_size/, 'SV bigger than max_sv_size warning');
 
   # restore STDERR
   open(STDERR, ">&SAVE") or die "Can't restore STDERR\n";

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -108,6 +108,7 @@ is_deeply($runner->get_Parser, bless({
   'minimal' => undef,
   'lrg' => undef,
   'delimiter' => ' ',
+  'max_sv_size' => 10000000,
 }, 'Bio::EnsEMBL::VEP::Parser::VEP_input' ), 'get_Parser');
 
 is_deeply($runner->get_InputBuffer, bless({
@@ -125,6 +126,7 @@ is_deeply($runner->get_InputBuffer, bless({
     'minimal' => undef,
     'lrg' => undef,
     'delimiter' => ' ',
+    'max_sv_size' => 10000000,
   }, 'Bio::EnsEMBL::VEP::Parser::VEP_input' ),
   'buffer_size' => $runner->param('buffer_size'),
   'minimal' => undef,


### PR DESCRIPTION
ENSVAR-5793

Currently, VEP only returns non-structural variants when using variation IDs.

This PR expands the feature to also allow VEP to return SV using their ID[^1].

### Testing

```
perl vep --id esv1815690  --database --force
perl vep --id esv1850194  --database --force
perl vep --id nsv1000164  --database --force
perl vep --id cnvi0117333 --database --force
perl vep --id CN_571740   --database --force
```

This also works by running `perl vep -i input.txt --database --force`, where the input file contains the identifiers:
```
esv1815690
esv1850194
rs699
nsv1000164
cnvi0117333
CN_571740
```

[^1]: Some SV IDs supported in the Ensembl browser (like [`nsv443016`](http://wp-np2-11.ebi.ac.uk:6070/Sus_scrofa/StructuralVariation/Mappings?r=7:67148496-67211415;sv=nsv443016;svf=665;vdb=variation)) don't work because they are not part of the species database.