### PR TITLE
nextflow-vep: allow output dir as channel and more splits

### DIFF
--- a/nextflow/nf_modules/generate_splits.nf
+++ b/nextflow/nf_modules/generate_splits.nf
@@ -29,6 +29,6 @@ process generateSplits {
 
   shell:
   """
-  bcftools query -f'%CHROM\t%POS\n' ${vcf} | uniq | split -l ${bin_size}
+  bcftools query -f'%CHROM\t%POS\n' ${vcf} | uniq | split -a 3 -l ${bin_size}
   """
 }

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -70,6 +70,10 @@ def createChannels (input, pattern) {
 }
 
 def toAbsolute (dir_path) {
+  if (! (dir_path instanceof String)){
+    dir_path = dir_path.toString();
+  }
+
   def dir = new File(dir_path)
   
   if (!dir.isAbsolute()) {

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -77,7 +77,7 @@ def createOutputChannel (output) {
     if (!dir.isAbsolute()) {
         output = "${launchDir}/${output}";
     }
-    return Channel.fromPath(toAbsolute(output))
+    return Channel.fromPath(output)
   }
   
   return output;

--- a/t/MultiTestDB.conf
+++ b/t/MultiTestDB.conf
@@ -1,7 +1,0 @@
-{
-  'port'   => '4606',
-  'driver' => 'mysql',
-  'user'   => 'ensadmin',
-  'pass'   => 'ensembl',
-  'host'   => 'mysql-ens-var-prod-3'
-}

--- a/t/MultiTestDB.conf
+++ b/t/MultiTestDB.conf
@@ -1,0 +1,7 @@
+{
+  'port'   => '4606',
+  'driver' => 'mysql',
+  'user'   => 'ensadmin',
+  'pass'   => 'ensembl',
+  'host'   => 'mysql-ens-var-prod-3'
+}


### PR DESCRIPTION
1. If the `output_dir` is a channel current workflows errors out. We need to allow `output_dir` to be a channel in which case we do not do any processing on it (similar to other input arguments).

- renamed `toAbsolute` function to `createOutputChannel` and put the logic for `output_dir` channel there
- renamed `createChannels` to `createInputChannels` to have consistent naming

2. `generate_splits.nf` does not allow 26^2 = 676 splits and not enough for source like dbSNP. Allowing 26^3=17.576 splits which should be enough for any job.