### PR TITLE
Report consequences for each breakend (e112)

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
@@ -247,7 +247,7 @@ sub get_all_regions_by_InputBuffer {
     $min_max->{$chr} = [$min, $max];
 
     # process alternative alleles from breakend structural variants
-    next unless $vf->can('get_breakends');
+    next unless Scalar::Util::blessed($vf) and $vf->can('get_breakends');
     foreach my $alt (@{$vf->get_breakends}) {
       ($chr, $min, $max, $seen, @new_regions) = $self->get_regions_from_coords(
         $alt->{chr}, $alt->{pos}, $alt->{pos},

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
@@ -247,7 +247,7 @@ sub get_all_regions_by_InputBuffer {
     $min_max->{$chr} = [$min, $max];
 
     # process alternative alleles from breakend structural variants
-    foreach my $alt (@{$vf->{_parsed_allele}}) {
+    foreach my $alt (@{$vf->get_breakends}) {
       ($chr, $min, $max, $seen, @new_regions) = $self->get_regions_from_coords(
         $alt->{chr}, $alt->{pos}, $alt->{pos},
         $min_max, $cache_region_size, $up_down_size, $seen);

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
@@ -247,6 +247,7 @@ sub get_all_regions_by_InputBuffer {
     $min_max->{$chr} = [$min, $max];
 
     # process alternative alleles from breakend structural variants
+    next unless $vf->can('get_breakends');
     foreach my $alt (@{$vf->get_breakends}) {
       ($chr, $min, $max, $seen, @new_regions) = $self->get_regions_from_coords(
         $alt->{chr}, $alt->{pos}, $alt->{pos},

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -317,6 +317,7 @@ sub get_overlapping_vfs {
     }
 
     # check overlap with complex alternative alleles (such as breakend structural variants)
+    next unless $vf->can('get_breakends');
     for my $alt (@{ $vf->get_breakends }) {
       push(@vfs, $vf) if overlap($alt->{pos}, $alt->{pos}, $start, $end);
     }
@@ -352,6 +353,7 @@ sub interval_tree {
       $tree->insert($vf, $s - 1, $e);
 
       # breakends: add same variation feature to alternative allele coordinates
+      next unless $vf->can('get_breakends');
       for my $alt (@{ $vf->get_breakends }) {
         $s = $e = $alt->{pos};
         $tree->insert($vf, $s - 1, $e);

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -317,7 +317,7 @@ sub get_overlapping_vfs {
     }
 
     # check overlap with complex alternative alleles (such as breakend structural variants)
-    next unless $vf->can('get_breakends');
+    next unless Scalar::Util::blessed($vf) and $vf->can('get_breakends');
     for my $alt (@{ $vf->get_breakends }) {
       push(@vfs, $vf) if overlap($alt->{pos}, $alt->{pos}, $start, $end);
     }
@@ -353,7 +353,7 @@ sub interval_tree {
       $tree->insert($vf, $s - 1, $e);
 
       # breakends: add same variation feature to alternative allele coordinates
-      next unless $vf->can('get_breakends');
+      next unless Scalar::Util::blessed($vf) and $vf->can('get_breakends');
       for my $alt (@{ $vf->get_breakends }) {
         $s = $e = $alt->{pos};
         $tree->insert($vf, $s - 1, $e);

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -317,7 +317,7 @@ sub get_overlapping_vfs {
     }
 
     # check overlap with complex alternative alleles (such as breakend structural variants)
-    for my $alt (@{ $vf->{_parsed_allele} }) {
+    for my $alt (@{ $vf->get_breakends }) {
       push(@vfs, $vf) if overlap($alt->{pos}, $alt->{pos}, $start, $end);
     }
   }
@@ -351,9 +351,8 @@ sub interval_tree {
       ($s, $e) = ($e, $s) if $s > $e;
       $tree->insert($vf, $s - 1, $e);
 
-      # add same variation feature to alternative allele coordinates
-      # (such as breakend structural variants)
-      for my $alt (@{ $vf->{_parsed_allele} }) {
+      # breakends: add same variation feature to alternative allele coordinates
+      for my $alt (@{ $vf->get_breakends }) {
         $s = $e = $alt->{pos};
         $tree->insert($vf, $s - 1, $e);
       }

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -382,7 +382,6 @@ sub get_all_VariationFeatureOverlapAllele_output_hashes {
   return $self->summary_only($vf, $hash, $vfoas) if $self->{summary} || $self->{most_severe};
 
   foreach my $vfoa(@$vfoas) {
-
     # copy the initial VF-based hash so we're not overwriting
     my %copy = %$hash;
 
@@ -1898,7 +1897,7 @@ sub BaseStructuralVariationOverlapAllele_to_output_hash {
 
   my $svf = $vfoa->base_variation_feature;
 
-  $hash->{Allele} = $svf->{allele_string} || $svf->class_SO_term;
+  $hash->{Allele} = $vfoa->{breakend}->{string} || $svf->class_SO_term;
 
   # allele number
   $hash->{ALLELE_NUM} = $vfoa->allele_number if $self->{allele_number};

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -842,9 +842,10 @@ sub post_process_vfs {
   foreach my $vf(@$vfs) {
     $vf->seq_region_start($vf->{start});
     $vf->seq_region_end($vf->{end});
-  
+
     # Checks if the allele string is insertion or/and deletion
-    if(defined($vf->{allele_string}) && $vf->{allele_string} =~ /\//){
+    my $is_sv = ref($vf) eq 'Bio::EnsEMBL::Variation::StructuralVariationFeature';
+    if(!$is_sv && defined($vf->{allele_string}) && $vf->{allele_string} =~ /\//){
       my $is_indel = 0;
       my ($ref_allele_string,$alt_allele_string) = split(/\//, $vf->{allele_string});
       $is_indel = 1 unless length($ref_allele_string) == length($alt_allele_string) or $vf->{allele_string} =~ /-/;

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -694,7 +694,7 @@ sub get_SO_term {
     $abbrev = "CNV";
     $abbrev = "DEL" if $type =~ /\<CN=?0\>/;
     $abbrev = "DUP" if $type =~ /\<CN=?2\>/;
-  } elsif ($type =~ /[\[\]]/) {
+  } elsif ($type =~ /[\[\]]|^\.|\.$/) {
     $abbrev = "BND";
   } elsif ($type =~ /^\<|\>$/) {
     $abbrev = $type;

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -217,7 +217,7 @@ sub next {
 
   my $vf = shift @$cache;
   return $vf unless $vf;
-  
+
   unless($self->validate_vf($vf) || $self->{dont_skip}) {
     return $self->next();
   }

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -417,10 +417,11 @@ sub create_StructuralVariationFeatures {
   my $record = $parser->{record};
 
   # get relevant data
-  my ($chr, $start, $end, $alts, $info, $ids) = (
+  my ($chr, $start, $end, $ref, $alts, $info, $ids) = (
     $parser->get_seqname,
     $parser->get_start,
     $parser->get_end,
+    $parser->get_reference,
     $parser->get_alternatives,
     $parser->get_info,
     $parser->get_IDs,
@@ -447,6 +448,7 @@ sub create_StructuralVariationFeatures {
         $alt = sprintf('%s[%s:%s[', $alt, $breakend_chr, $breakend_pos);
       }
     }
+    $alt = $ref . "./$alt" unless $alt =~ /^\.|\.$/;
   }
 
   ## check against size upperlimit to avoid memory problems

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -260,7 +260,7 @@ sub create_VariationFeatures {
     join("", $ref, @$alts) !~ /^[ACGT]+$/ &&
     (
       $info->{SVTYPE} ||
-      join(",", @$alts) =~ /[<\[\]][^\*]+[>\]\[]/
+      join(",", @$alts) =~ /[<\[\]][^\*]+[>\]\[]|^.|.$/
     )
   ) {
     return $self->create_StructuralVariationFeatures();

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -260,7 +260,7 @@ sub create_VariationFeatures {
     join("", $ref, @$alts) !~ /^[ACGT]+$/ &&
     (
       $info->{SVTYPE} ||
-      join(",", @$alts) =~ /[<\[\]][^\*]+[>\]\[]|^.|.$/
+      join(",", @$alts) =~ /[<\[\]][^\*]+[>\]\[]|^\.\w+|\w+\.$/
     )
   ) {
     return $self->create_StructuralVariationFeatures();
@@ -448,7 +448,7 @@ sub create_StructuralVariationFeatures {
         $alt = sprintf('%s[%s:%s[', $alt, $breakend_chr, $breakend_pos);
       }
     }
-    $alt = $ref . "./$alt" unless $alt =~ /^\.|\.$/;
+    $alt = $ref . "/$alt" unless $alt =~ /^\.|\.$/;
   }
 
   ## check against size upperlimit to avoid memory problems

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -398,93 +398,6 @@ sub create_VariationFeatures {
 }
 
 
-=head2 _parse_breakend_alt_alleles
-
-  Arg 1      : string $alt (ALT field from VCF)
-  Arg 2      : hashref $info (INFO field from VCF)
-  Example    : $parsed_alleles = $self->_parse_breakend_alt_alleles($alt, $info);
-  Description: Parse alternative alleles from breakend structural variants
-  Returntype : Arrayref of hashrefs containing information of the parsed alleles
-  Exceptions : none
-  Caller     : create_StructuralVariationFeatures()
-  Status     : Stable
-
-=cut
-
-sub _parse_breakend_alt_alleles {
-  my $self = shift;
-  my $alt = shift;
-  my $info = shift;
-
-  my $parsed_allele = [];
-
-  # Support multiple breakends from ALT in the format C[2:321682[,]17:198982]G
-  for my $alt_string (split ",", $alt) {
-    my ($alt_allele) = ($alt_string =~ '[\[\]]?([A-Za-z]+)[\[\]]?');
-    my ($alt_chr, $alt_pos) = ($alt_string =~ '([A-Za-z0-9]+) ?: ?([0-9]+)');
-
-    next if !defined $alt_allele or !defined $alt_chr or !defined $alt_pos;
-    $alt_chr = $self->get_source_chr_name($alt_chr);
-
-    # Mate orientation:
-    #   C[2:321682[  - normal
-    #   G]17:198982] - inverted
-    #   ]13:123456]T - normal
-    #   [17:198983[A - inverted
-    my $inverted = ($alt_string =~ '^\[|\]$') || 0;
-
-    # Mate placement:
-    #   C[2:321682[  - left
-    #   [17:198983[A - right
-    my $placement = ($alt_string =~ '^(\[|\])') ? 'left' : 'right';
-
-    my $slice = Bio::EnsEMBL::Slice->new_fast({
-      seq_region_name => $alt_chr,
-      start => $alt_pos,
-      end => $alt_pos,
-    });
-
-    push @$parsed_allele, {
-      string    => $alt_string,
-      allele    => $alt_allele,
-      pos       => $alt_pos,
-      start     => $alt_pos,
-      end       => $alt_pos,
-      chr       => $alt_chr,
-      inverted  => $inverted,
-      placement => $placement,
-      slice     => $slice
-    };
-  }
-
-  # Support breakend described in INFO field
-  if (defined $info->{CHR2} && scalar @$parsed_allele == 0) {
-    my $alt_chr = $self->get_source_chr_name($info->{CHR2});
-    my $alt_pos = $info->{END2};
-
-    if (defined $alt_chr && defined $alt_pos) {
-      my $slice = Bio::EnsEMBL::Slice->new_fast({
-        seq_region_name => $alt_chr,
-        start => $alt_pos,
-        end => $alt_pos,
-      });
-
-      push @$parsed_allele, {
-        string    => $alt,
-        allele    => $alt,
-        pos       => $alt_pos,
-        start     => $alt_pos,
-        end       => $alt_pos,
-        chr       => $alt_chr,
-        slice     => $slice
-      };
-    }
-  }
-
-  return $parsed_allele;
-}
-
-
 =head2 create_StructuralVariationFeatures
 
   Example    : $vfs = $parser->create_StructuralVariationFeatures();
@@ -541,14 +454,6 @@ sub create_StructuralVariationFeatures {
     $parser->get_outer_end,
   );
 
-  # parse alternative alleles from breakends
-  my $parsed_allele;
-  my $allele_string;
-  if ($so_term =~ /break/ ){
-    $parsed_allele = $self->_parse_breakend_alt_alleles($alt, $info);
-    $allele_string = $alt;
-  }
-
   if($start >= $end && $so_term =~ /del/i) {
     $self->skipped_variant_msg("deletion looks incomplete");
   }
@@ -565,13 +470,12 @@ sub create_StructuralVariationFeatures {
     variation_name => @$ids ? $ids->[0] : undef,
     chr            => $self->get_source_chr_name($chr),
     class_SO_term  => $so_term,
+    allele_string  => $alt,
     _line          => $record
   });
-  $svf->{allele_string}  = $allele_string if defined $allele_string;
-  $svf->{_parsed_allele} = $parsed_allele if defined $parsed_allele;
-  $svf->{vep_skip}       = $self->{skip_line} if defined $self->{skip_line};
+  $svf->{vep_skip} = $self->{skip_line} if defined $self->{skip_line};
 
-  return $self->post_process_vfs([$svf]);
+  return $self->post_process_vfs([$svf]);;
 }
 
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -443,7 +443,7 @@ sub create_StructuralVariationFeatures {
       my $breakend_chr = $self->get_source_chr_name($info->{CHR2});
       my $breakend_pos = $info->{END2} || $incorrect_end;
       if (defined $breakend_chr and defined $breakend_pos) {
-        $alt = 'N' if $alt =~ /<?BND>?/i;
+        $alt = $alt =~ /^<?BND>?$/i ? "N" : "$alt/N";
         $alt = sprintf('%s[%s:%s[', $alt, $breakend_chr, $breakend_pos);
       }
     }

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -514,7 +514,7 @@ sub create_StructuralVariationFeatures {
   );
   
   ## get structural variant type from SVTYPE tag (deprecated in VCF 4.4) or ALT
-  my $alt = join(",", @$alts);
+  my $alt = join("/", @$alts);
   my $type = $info->{SVTYPE} || $alt;
   my $so_term = $self->get_SO_term($type) || $type;
 

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -685,7 +685,7 @@ is_deeply($cnv_vf, bless( {
 ## test breakend variant with unsupported END information in INFO field
 my $bnd_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
-  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A	.	PASS	SVTYPE=BND;END=37938377   )]),
+  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	TCA	]1:37938377]A	.	PASS	SVTYPE=BND;END=37938377   )]),
   valid_chromosomes => [1,2]
 })->next();
 
@@ -695,15 +695,15 @@ is_deeply($bnd_vf, bless( {
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
                  'class_SO_term' => 'chromosome_breakpoint',
-                 'allele_string' => ']1:37938377]A',
+                 'allele_string' => 'TCA/]1:37938377]A',
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
-                 'end' => 68914093,
-                 'inner_end' => 68914093,
-                 'outer_end' => 68914093,
+                 'end' => 68914095,
+                 'inner_end' => 68914095,
+                 'outer_end' => 68914095,
                  'seq_region_start' => 68914093,
-                 'seq_region_end' => 68914093
+                 'seq_region_end' => 68914095
                },
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with unsupported INFO/END field');
@@ -721,7 +721,7 @@ is_deeply($bnd2_vf, bless( {
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
                  'class_SO_term' => 'chromosome_breakpoint',
-                 'allele_string' => ']1:37938377]A/C]2:68920000]',
+                 'allele_string' => 'A/]1:37938377]A/C]2:68920000]',
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
@@ -737,7 +737,7 @@ is_deeply($bnd2_vf, bless( {
 ## test breakend variant with information in INFO field
 my $bnd3_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
-  file => $test_cfg->create_input_file([qw(2    68914092     BND00001121     A       <BND>    .   PASS    SVTYPE=BND;CHR2=2;END2=68920000)]),
+  file => $test_cfg->create_input_file([qw(2    68914092     BND00001121     G       <BND>    .   PASS    SVTYPE=BND;CHR2=2;END2=68920000)]),
   valid_chromosomes => [1,2]
 })->next();
 delete($bnd3_vf->{adaptor}); delete($bnd3_vf->{_line});
@@ -746,7 +746,7 @@ is_deeply($bnd3_vf, bless( {
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
                  'class_SO_term' => 'chromosome_breakpoint',
-                 'allele_string' => 'N[2:68920000[',
+                 'allele_string' => 'G/N[2:68920000[',
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
@@ -771,7 +771,7 @@ is_deeply($bnd4_vf, bless( {
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
                  'class_SO_term' => 'chromosome_breakpoint',
-                 'allele_string' => 'N[2:68920000[',
+                 'allele_string' => 'A/N[2:68920000[',
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
@@ -784,6 +784,31 @@ is_deeply($bnd4_vf, bless( {
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with incorrect INFO/END field');
 
+## test single breakend variant
+my $bnd5_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(2	68914092	single_BND	TCA	TCA.	.	PASS	.   )]),
+  valid_chromosomes => [1,2]
+})->next();
+
+delete($bnd5_vf->{adaptor}); delete($bnd5_vf->{_line});
+is_deeply($bnd5_vf, bless( {
+                 'chr' => '2',
+                 'strand' => '1',
+                 'variation_name' => 'single_BND',
+                 'class_SO_term' => 'chromosome_breakpoint',
+                 'allele_string' => 'TCA.',
+                 'start' => 68914093,
+                 'inner_start' => 68914093,
+                 'outer_start' => 68914093,
+                 'end' => 68914095,
+                 'inner_end' => 68914095,
+                 'outer_end' => 68914095,
+                 'seq_region_start' => 68914093,
+                 'seq_region_end' => 68914095
+               },
+               'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
+               'StructuralVariationFeature - BND with unsupported INFO/END field');
 
 ## OTHER TESTS
 ##############

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -403,6 +403,7 @@ is_deeply($vf, bless( {
 $expected = bless( {
   'outer_end' => 25587769,
   'chr' => '21',
+  'allele_string' => '<DUP>',
   'inner_end' => 25587769,
   'outer_start' => 25587759,
   'end' => 25587769,
@@ -429,6 +430,7 @@ $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   valid_chromosomes => [21]
 })->next();
 delete($vf->{adaptor}); delete($vf->{_line});
+$expected->{allele_string} = '.';
 is_deeply($vf, $expected, 'StructuralVariationFeature 2');
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
@@ -437,6 +439,7 @@ $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   valid_chromosomes => [21]
 })->next();
 delete($vf->{adaptor}); delete($vf->{_line});
+$expected->{allele_string} = '<DUP>';
 is_deeply($vf, $expected , 'StructuralVariationFeature no SVTYPE');
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
@@ -445,7 +448,7 @@ $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   valid_chromosomes => [21]
 })->next();
 delete($vf->{adaptor}); delete($vf->{_line});
-is_deeply($vf, $expected , 'StructuralVariationFeature SVLEN');
+is_deeply($vf, $expected, 'StructuralVariationFeature SVLEN');
 
 $vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => $cfg,
@@ -456,6 +459,7 @@ delete($vf->{adaptor}); delete($vf->{_line});
 is_deeply($vf, bless( {
   'outer_end' => 25587774,
   'chr' => '21',
+  'allele_string' => '<DUP>',
   'inner_end' => 25587765,
   'outer_start' => 25587756,
   'end' => 25587769,
@@ -479,6 +483,7 @@ delete($vf->{adaptor}); delete($vf->{_line});
 is_deeply($vf, bless( {
   'outer_end' => 25587769,
   'chr' => '21',
+  'allele_string' => '<DEL>',
   'inner_end' => 25587769,
   'outer_start' => 25587759,
   'end' => 25587769,
@@ -529,6 +534,7 @@ delete($sv->{_line});
 is_deeply($sv, bless( {
   'outer_end' => 25587759,
   'chr' => '21',
+  'allele_string' => '<DEL>',
   'inner_end' => 25587759,
   'outer_start' => 25587759,
   'end' => 25587759,
@@ -574,6 +580,7 @@ delete($lvf->{adaptor}); delete($lvf->{_line});
 is_deeply($lvf, bless( {
   'outer_end' => 25597764,
   'chr' => '21',
+  'allele_string' => '<DUP>',
   'inner_end' => 25597755,
   'outer_start' => 25587756,
   'end' => 25597759,
@@ -605,6 +612,7 @@ delete($cvf->{adaptor}); delete($cvf->{_line});
 is_deeply($cvf, bless( {
                  'outer_end' => '828435',
                  'chr' => '1',
+                 'allele_string' => '<CPX>',
                  'inner_end' => '828435',
                  'outer_start' => '774570',
                  'end' => 828435,
@@ -636,6 +644,7 @@ delete($cnv_vf->{adaptor}); delete($cnv_vf->{_line});
 is_deeply($cnv_vf, bless( {
                  'outer_end' => '828435',
                  'chr' => '1',
+                 'allele_string' => '<CN0>',
                  'inner_end' => '828435',
                  'outer_start' => '774570',
                  'end' => 828435,
@@ -659,6 +668,7 @@ delete($cnv_vf->{adaptor}); delete($cnv_vf->{_line});
 is_deeply($cnv_vf, bless( {
                  'outer_end' => '828435',
                  'chr' => '1',
+                 'allele_string' => '<CN0>/<CN2>',
                  'inner_end' => '828435',
                  'outer_start' => '774570',
                  'end' => 828435,
@@ -675,7 +685,7 @@ is_deeply($cnv_vf, bless( {
 ## test breakend variant with unsupported END information in INFO field
 my $bnd_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
-  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A	.	PASS	SVTYPE=BND;CHR2=1;END=37938377   )]),
+  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A	.	PASS	SVTYPE=BND;END=37938377   )]),
   valid_chromosomes => [1,2]
 })->next();
 
@@ -693,22 +703,7 @@ is_deeply($bnd_vf, bless( {
                  'inner_end' => 68914093,
                  'outer_end' => 68914093,
                  'seq_region_start' => 68914093,
-                 'seq_region_end' => 68914093,
-                 '_parsed_allele' => [{
-                   'placement' => 'left',
-                   'string' => ']1:37938377]A',
-                   'chr' => '1',
-                   'pos' => 37938377,
-                   'start' => 37938377,
-                   'end' => 37938377,
-                   'allele' => 'A',
-                   'inverted' => 0,
-                   'slice' => Bio::EnsEMBL::Slice->new_fast({
-                     seq_region_name => '1',
-                     start => 37938377,
-                     end => 37938377
-                    })
-                  }]
+                 'seq_region_end' => 68914093
                },
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with unsupported INFO/END field');
@@ -716,7 +711,7 @@ is_deeply($bnd_vf, bless( {
 ## test breakend variant with multiple mates and information in ALT field
 my $bnd2_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
-  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A,C]2:68920000]	.	PASS	SVTYPE=BND;CHR2=1;END2=37938377   )]),
+  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A,C]2:68920000]	.	PASS	SVTYPE=BND   )]),
   valid_chromosomes => [1,2]
 })->next();
 
@@ -726,7 +721,7 @@ is_deeply($bnd2_vf, bless( {
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
                  'class_SO_term' => 'chromosome_breakpoint',
-                 'allele_string' => ']1:37938377]A,C]2:68920000]',
+                 'allele_string' => ']1:37938377]A/C]2:68920000]',
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
@@ -735,35 +730,6 @@ is_deeply($bnd2_vf, bless( {
                  'outer_end' => 68914093,
                  'seq_region_start' => 68914093,
                  'seq_region_end' => 68914093,
-                 '_parsed_allele' => [{
-                   'placement' => 'left',
-                   'string' => ']1:37938377]A',
-                   'chr' => '1',
-                   'pos' => 37938377,
-                   'start' => 37938377,
-                   'end' => 37938377,
-                   'allele' => 'A',
-                   'inverted' => 0,
-                   'slice' => Bio::EnsEMBL::Slice->new_fast({
-                     seq_region_name => '1',
-                     start => 37938377,
-                     end => 37938377
-                    })
-                  }, {
-                   'string' => 'C]2:68920000]',
-                   'placement' => 'right',
-                   'chr' => '2',
-                   'pos' => 68920000,
-                   'start' => 68920000,
-                   'end' => 68920000,
-                   'allele' => 'C',
-                   'inverted' => 1,
-                   'slice' => Bio::EnsEMBL::Slice->new_fast({
-                     seq_region_name => '2',
-                     start => 68920000,
-                     end => 68920000
-                    })
-                  }]
                },
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with information in ALT field');
@@ -780,7 +746,7 @@ is_deeply($bnd3_vf, bless( {
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
                  'class_SO_term' => 'chromosome_breakpoint',
-                 'allele_string' => '<BND>',
+                 'allele_string' => 'N[2:68920000[',
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
@@ -789,19 +755,6 @@ is_deeply($bnd3_vf, bless( {
                  'outer_end' => 68914093,
                  'seq_region_start' => 68914093,
                  'seq_region_end' => 68914093,
-                 '_parsed_allele' => [{
-                   'string' => '<BND>',
-                   'chr' => '2',
-                   'pos' => 68920000,
-                   'start' => 68920000,
-                   'end' => 68920000,
-                   'allele' => '<BND>',
-                   'slice' => Bio::EnsEMBL::Slice->new_fast({
-                     seq_region_name => '2',
-                     start => 68920000,
-                     end => 68920000
-                    })
-                  }]
                },
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with information in INFO field');
@@ -818,7 +771,7 @@ is_deeply($bnd4_vf, bless( {
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
                  'class_SO_term' => 'chromosome_breakpoint',
-                 'allele_string' => '<BND>',
+                 'allele_string' => 'N[2:68920000[',
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
@@ -827,19 +780,6 @@ is_deeply($bnd4_vf, bless( {
                  'outer_end' => 68914093,
                  'seq_region_start' => 68914093,
                  'seq_region_end' => 68914093,
-                 '_parsed_allele' => [{
-                   'string' => '<BND>',
-                   'chr' => '2',
-                   'pos' => 68920000,
-                   'start' => 68920000,
-                   'end' => 68920000,
-                   'allele' => '<BND>',
-                   'slice' => Bio::EnsEMBL::Slice->new_fast({
-                     seq_region_name => '2',
-                     start => 68920000,
-                     end => 68920000
-                    })
-                  }]
                },
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with incorrect INFO/END field');

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -672,15 +672,56 @@ is_deeply($cnv_vf, bless( {
                },
                 'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) , 'StructuralVariationFeature - CNV with multiple alleles');
 
-## test breakend variant with multiple mates and information in ALT field
+## test breakend variant with unsupported END information in INFO field
 my $bnd_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
-  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A,C]2:68920000]	.	PASS	SVTYPE=BND;CHR2=1;END2=37938377   )]),
+  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A	.	PASS	SVTYPE=BND;CHR2=1;END=37938377   )]),
   valid_chromosomes => [1,2]
 })->next();
 
 delete($bnd_vf->{adaptor}); delete($bnd_vf->{_line});
 is_deeply($bnd_vf, bless( {
+                 'chr' => '2',
+                 'strand' => '1',
+                 'variation_name' => 'BND00001121',
+                 'class_SO_term' => 'chromosome_breakpoint',
+                 'allele_string' => ']1:37938377]A',
+                 'start' => 68914093,
+                 'inner_start' => 68914093,
+                 'outer_start' => 68914093,
+                 'end' => 68914093,
+                 'inner_end' => 68914093,
+                 'outer_end' => 68914093,
+                 'seq_region_start' => 68914093,
+                 'seq_region_end' => 68914093,
+                 '_parsed_allele' => [{
+                   'placement' => 'left',
+                   'string' => ']1:37938377]A',
+                   'chr' => '1',
+                   'pos' => 37938377,
+                   'start' => 37938377,
+                   'end' => 37938377,
+                   'allele' => 'A',
+                   'inverted' => 0,
+                   'slice' => Bio::EnsEMBL::Slice->new_fast({
+                     seq_region_name => '1',
+                     start => 37938377,
+                     end => 37938377
+                    })
+                  }]
+               },
+               'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
+               'StructuralVariationFeature - BND with unsupported INFO/END field');
+
+## test breakend variant with multiple mates and information in ALT field
+my $bnd2_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(2	68914092	BND00001121	A	]1:37938377]A,C]2:68920000]	.	PASS	SVTYPE=BND;CHR2=1;END2=37938377   )]),
+  valid_chromosomes => [1,2]
+})->next();
+
+delete($bnd2_vf->{adaptor}); delete($bnd2_vf->{_line});
+is_deeply($bnd2_vf, bless( {
                  'chr' => '2',
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
@@ -728,13 +769,13 @@ is_deeply($bnd_vf, bless( {
                'StructuralVariationFeature - BND with information in ALT field');
 
 ## test breakend variant with information in INFO field
-my $bnd2_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+my $bnd3_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
   config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
   file => $test_cfg->create_input_file([qw(2    68914092     BND00001121     A       <BND>    .   PASS    SVTYPE=BND;CHR2=2;END2=68920000)]),
   valid_chromosomes => [1,2]
 })->next();
-delete($bnd2_vf->{adaptor}); delete($bnd2_vf->{_line});
-is_deeply($bnd2_vf, bless( {
+delete($bnd3_vf->{adaptor}); delete($bnd3_vf->{_line});
+is_deeply($bnd3_vf, bless( {
                  'chr' => '2',
                  'strand' => '1',
                  'variation_name' => 'BND00001121',
@@ -765,7 +806,43 @@ is_deeply($bnd2_vf, bless( {
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with information in INFO field');
 
-
+## test breakend variant with incorrect information in INFO field
+my $bnd4_vf = Bio::EnsEMBL::VEP::Parser::VCF->new({
+  config => Bio::EnsEMBL::VEP::Config->new({%$base_testing_cfg, gp => 1,  warning_file => 'STDERR'}),
+  file => $test_cfg->create_input_file([qw(2    68914092     BND00001121     A       <BND>    .   PASS    SVTYPE=BND;CHR2=2;END=68920000)]),
+  valid_chromosomes => [1,2]
+})->next();
+delete($bnd4_vf->{adaptor}); delete($bnd4_vf->{_line});
+is_deeply($bnd4_vf, bless( {
+                 'chr' => '2',
+                 'strand' => '1',
+                 'variation_name' => 'BND00001121',
+                 'class_SO_term' => 'chromosome_breakpoint',
+                 'allele_string' => '<BND>',
+                 'start' => 68914093,
+                 'inner_start' => 68914093,
+                 'outer_start' => 68914093,
+                 'end' => 68914093,
+                 'inner_end' => 68914093,
+                 'outer_end' => 68914093,
+                 'seq_region_start' => 68914093,
+                 'seq_region_end' => 68914093,
+                 '_parsed_allele' => [{
+                   'string' => '<BND>',
+                   'chr' => '2',
+                   'pos' => 68920000,
+                   'start' => 68920000,
+                   'end' => 68920000,
+                   'allele' => '<BND>',
+                   'slice' => Bio::EnsEMBL::Slice->new_fast({
+                     seq_region_name => '2',
+                     start => 68920000,
+                     end => 68920000
+                    })
+                  }]
+               },
+               'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
+               'StructuralVariationFeature - BND with incorrect INFO/END field');
 
 
 ## OTHER TESTS


### PR DESCRIPTION
ENSVAR-5962: Report consequences for each breakend

### Changelog

- Parse multiple breakends like multiple alternative alleles
- Move breakend parsing code to ensembl-variation: https://github.com/Ensembl/ensembl-variation/pull/1040
- Manta breakends (`CHR2=8;END2=4654454`) are now converted to VCF breakend format (such as `[8:4654454[N`) before being parsed in ensembl-variation

Fixes https://github.com/Ensembl/ensembl-vep/issues/1492

### Testing

Run multiple types of variants, such as:

```
1       713044  DUP     C       <CN=2>  .       .       END=755966
1       7936271 .       N       N[12:58877476[,N[8:56445865[    .      .      .
1       7936271 .       N       <BND>    CHR2=8;END2= 4654454      .      .
2       227032111    BND00000186    A    [1:106864407[A   .   LowQual   IMPRECISE;SVTYPE=BND;SVMETHOD=EMBL.DELLYv0.7.8;CHR2=1;END=106864407;PE=2;MAPQ=60;CT=5to5;CIPOS=-231,231;CIEND=-231,231 GT:GL:GQ:FT:RCL:RC:RCR:CN:DR:DV:RR:RV    0/0:0,-19.006,-594:10000:PASS:8:5259:1:1169:101:2:0:0
20     17330   .         T      A       3    q10    NS=3;DP=11;AF=0.017               GT:GQ:DP:HQ 0|0:49:3:58,50 0|1:3:5:65,3   0/0:41:3
```

Check if everything looks fine in different output formats (default output, VCF, JSON, TSV).