### PR TITLE
Fix custom annotation of breakends and non-supported SVs (exact mode)

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -462,12 +462,18 @@ sub _record_overlaps_VF {
   my $reciprocal = $self->{reciprocal};
   my ($ref_start, $ref_end) = ($parser->get_start, $parser->get_end);
 
-  # match on variant class (if enabled)
-  # confounded by different descriptions for the same event
-  if ($same_type) {
-    my $vf_class = $vf->class_SO_term;
-    my $ref_class = get_SO_term($parser);
+  # match based on variant class (if enabled)
+  my $vf_class  = $vf->class_SO_term;
+  my $ref_class = get_SO_term($parser);
 
+  # avoid matching breakpoints (start == end) with SNPs in exact mode
+  my $is_exact_breakpoint = $type eq 'exact' && defined $vf_class && $vf_class =~ /breakpoint/;
+
+  if ($same_type || $is_exact_breakpoint) {
+    # do not match if only one of the types is defined
+    return 0 if defined $ref_class xor defined $vf_class;
+
+    # do not match if both types are not the same
     return 0 if defined $ref_class && defined $vf_class && $ref_class ne $vf_class;
   }
 

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -93,8 +93,6 @@ BEGIN {
   }
 }
 
-use Bio::EnsEMBL::VEP::Parser qw(get_SO_term);
-
 my %FORMAT_MAP = (
   'vcf'     => 'VCF',
   'gff'     => 'GFF',
@@ -458,24 +456,8 @@ sub _record_overlaps_VF {
   my $type = $self->type();
   my $overlap_cutoff = $self->{overlap_cutoff};
   my $distance = $self->{distance};
-  my $same_type = $self->{same_type};
   my $reciprocal = $self->{reciprocal};
   my ($ref_start, $ref_end) = ($parser->get_start, $parser->get_end);
-
-  # match based on variant class (if enabled)
-  my $vf_class  = $vf->class_SO_term;
-  my $ref_class = get_SO_term($parser);
-
-  # avoid matching breakpoints (start == end) with SNPs in exact mode
-  my $is_exact_breakpoint = $type eq 'exact' && defined $vf_class && $vf_class =~ /breakpoint/;
-
-  if ($same_type || $is_exact_breakpoint) {
-    # do not match if only one of the types is defined
-    return 0 if defined $ref_class xor defined $vf_class;
-
-    # do not match if both types are not the same
-    return 0 if defined $ref_class && defined $vf_class && $ref_class ne $vf_class;
-  }
 
   if($type eq 'overlap' || $type eq 'within' || $type eq 'surrounding') {
     # account for insertions in Ensembl world where s = e+1

--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -787,7 +787,7 @@ sub skipped_variant_msg {
   my $line = $self->{parser}->{current_block} if defined $self->{parser};
   if (defined $line) {
     my $maxChar = 50;
-    $line =~ s/\t/ /g; # replace tabs with spaces to improve readability
+    $line =~ s/\s+/ /g; # trim tabs and extra spaces to improve readability
     $line = substr($line, 0, $maxChar - 4) . "..." if length($line) > $maxChar;
     $msg = "(" . $line . "): " . $msg;
   }

--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -794,7 +794,6 @@ sub skipped_variant_msg {
 
   $msg = "Line $line_number skipped " . $msg if defined $line_number;
   $self->warning_msg("WARNING: " . $msg . "\n");
-  $self->{skip_line} = 1;
 
   $self->skipped_variants({
     line => $line,

--- a/modules/Bio/EnsEMBL/VEP/Parser.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser.pm
@@ -672,9 +672,6 @@ sub get_SO_term {
     $abbrev = $type;
   }
 
-  ## unsupported SV types
-  $self->skipped_variant_msg("$abbrev type is not supported") if $abbrev eq "CPX";
-
   my %terms = (
     INS  => 'insertion',
     DEL  => 'deletion',
@@ -685,7 +682,12 @@ sub get_SO_term {
     BND  => 'chromosome_breakpoint'
   );
 
-  return $terms{$abbrev};
+  my $res = $terms{$abbrev};
+  ## unsupported SV types
+  if ($self->isa('Bio::EnsEMBL::VEP::Parser')) {
+    $self->skipped_variant_msg("$abbrev type is not supported") unless $res;
+  }
+  return $res;
 }
 
 


### PR DESCRIPTION
ENSVAR-5610, fixes #1397

### Changelog

- Custom exact matching improvements:
  - Avoid matching breakpoints with SNPs when using custom annotation in exact mode
  - Only perform this check when using custom annotation in VCF format (other formats do not contain variant type information in a standardised way)
- Bug fix: avoid skipping all subsequent SVs after skipping one
- Improvements to warning messages thrown when skipping variants:
  - Warn when skipping any non-supported SV type
  - Trim input whitespaces to improve readability of messages
  - Bug fix: avoid calling `skipped_variant_msg()` with ensembl-io's parser

### Documentation

- Updates to public documentation: https://github.com/Ensembl/public-plugins/pull/722

### Testing

Run VEP with custom annotation in exact mode containing breakends and `NON_REF` SVs, such as:

```
1   2642609        .                               G  A  .  .  .  .  .
1 2642609   nonREF  G  <NON_REF>  892  PASS  AN=6  GT  0/1
chr11   99819752        nonREF       C       <NON_REF>        892     PASS    AN=6       GT    0/1
1       713044  DUP1     C       <CN=2>  .       .       END=755966
1       713044  DUP2     C       <CN2>  .       .       END=755966
1       713044  DUP2     C       <INS:FHJDSJH>  .       .       END=755966
chr11   99819752        MantaBND:2716:0:1:0:0:0:0       C       CAACTGAG]chr11:99820576]        892     PASS    SVTYPE=BND;MATEID=MantaBND:2716:0:1:0:0:0:1;SVINSLEN=7;SVINSSEQ=AACTGAG;BND_DEPTH=266;MATE_BND_DEPTH=24;AC=3;AN=6       GT    0/1
chr11   99820576        MantaBND:2716:0:1:0:0:0:1       C       CCTCAGTT]chr11:99819752]        892     PASS    SVTYPE=BND;MATEID=MantaBND:2716:0:1:0:0:0:0;SVINSLEN=7;SVINSSEQ=CTCAGTT;BND_DEPTH=24;MATE_BND_DEPTH=266;AC=3;AN=6       GT    0/1
```

Run VEP using a command such as:
```
gnomAD=input/gnomad.genomes.v3.1.2.sites.stripped.vcf.gz
vep --i $vcf --vcf --database --custom $gnomAD,gnomAD,vcf,exact,0,AF,HN
```

Output should not contain custom annotation for NON_REF and breakend variants.