### PR TITLE
Custom GFF/GTF: add filename to skip `feature_type` warning

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
@@ -237,7 +237,9 @@ sub _get_records_by_coords {
       push @records, $self->_record_to_hash();
     }
     else {
-      $self->warning_msg("The feature_type ".$parser->get_type." is being skipped\n");
+      my $type = $parser->get_type;
+      my $file = $self->{file};
+      $self->warning_msg("Ignoring non-supported '$type' feature_type from $file\n");
     }
 
     $parser->next();

--- a/t/AnnotationSource_File_GFF.t
+++ b/t/AnnotationSource_File_GFF.t
@@ -17,6 +17,7 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
+use Test::Warnings qw(warning :no_end_test);
 use FindBin qw($Bin);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap);
 
@@ -64,7 +65,8 @@ SKIP: {
   ###############
 
   # _get_records_by_coords
-  my $records = $as->_get_records_by_coords(21, 25585733, 25585733);
+  my $records;
+  warning { $records = $as->_get_records_by_coords(21, 25585733, 25585733) };
   is(scalar @$records, 75, '_get_records_by_coords - count');
 
   is_deeply(
@@ -322,7 +324,7 @@ SKIP: {
   $ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $as->config, parser => $p});
   $ib->next();
 
-  $as->annotate_InputBuffer($ib);
+  warning { $as->annotate_InputBuffer($ib) };
   my $vf = $ib->buffer->[0];
   $vf->_finish_annotation;
   is(scalar (grep {$_->transcript->stable_id eq 'ENST00000352957'} @{$vf->get_all_TranscriptVariations}), 0, 'with filter - filtered transcript absent');
@@ -350,7 +352,7 @@ SKIP: {
   ok($as->chromosome_synonyms($test_cfg->{chr_synonyms}), 'load synonyms');
 
   # _get_records_by_coords
-  $records = $as->_get_records_by_coords('NC_000021.9', 25585733, 25585733);
+  warning { $records = $as->_get_records_by_coords('NC_000021.9', 25585733, 25585733) };
   is(scalar @$records, 104, '_get_records_by_coords - refseq - count');
 
   is_deeply(

--- a/t/AnnotationSource_File_GTF.t
+++ b/t/AnnotationSource_File_GTF.t
@@ -17,6 +17,7 @@ use warnings;
 
 use Test::More;
 use Test::Exception;
+use Test::Warnings qw(warning :no_end_test);
 use FindBin qw($Bin);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap);
 
@@ -60,7 +61,8 @@ SKIP: {
   ###############
 
   # _get_records_by_coords
-  my $records = $as->_get_records_by_coords(21, 25585733, 25585733);
+  my $records;
+  warning { $records = $as->_get_records_by_coords(21, 25585733, 25585733) };
   is(scalar @$records, 77, '_get_records_by_coords - count');
 
   is_deeply(
@@ -223,7 +225,7 @@ SKIP: {
   my $ib_mt = Bio::EnsEMBL::VEP::InputBuffer->new({config => $runner_mt->config, parser => $p_mt});
   is(ref($ib_mt->next()), 'ARRAY', 'check buffer next (MT)');
 
-  $gtf_mt->annotate_InputBuffer($ib_mt);
+  warning { $gtf_mt->annotate_InputBuffer($ib_mt) };
   $ib_mt->finish_annotation();
   is ($ib_mt->buffer->[0]->get_all_TranscriptVariations->[0]->_codon_table, 2, 'codon table for MT chromosome is correct');
   is ($ib_mt->buffer->[0]->get_all_TranscriptVariations->[0]->pep_allele_string, 'I/M', 'codon table for MT chromosome - check allele');


### PR DESCRIPTION
Related with #1506.

Make custom GTF/GFF warnings easier to understand by printing the corresponding filename when skipping features.

Before:

```
WARNING: The feature_type start_codon is being skipped
```

After:

```
WARNING: Ignoring non-supported 'start_codon' feature_type from refseq.gtf.gz
```

## Testing

You can test with file [t/testdata/custom/refseq.gff.gz](https://github.com/Ensembl/ensembl-vep/blob/release/110/t/testdata/custom/refseq.gff.gz):

```
perl vep --id "NC_000021.9 24993056 . . A" --database --force --gff t/testdata/custom/refseq.gff.gz
```