### PR TITLE
Fix required version of `DBD::mysql`

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'DBI';
 requires 'Set::IntervalTree';
 requires 'JSON';
 requires 'Text::CSV';
-recommends 'DBD::mysql';
+recommends 'DBD::mysql', '< 5.0'; # newer versions do not support MySQL 5
 recommends 'PerlIO::gzip';
 recommends 'IO::Uncompress::Gunzip';
 recommends 'Bio::DB::BigFile';


### PR DESCRIPTION
The latest version of `DBD::mysql` (5.001) deprecates support for MySQL 5: https://metacpan.org/dist/DBD-mysql/changes

As such, we need to request a prior version of `DBD::mysql`.