### PR TITLE
ignore blank lines in the config.ini

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -1027,6 +1027,7 @@ sub read_config_from_file {
 
   while(<CONFIG>) {
     next if /^\#/;
+    next if /^\s*$/;
 
     # preserve spaces between quotes
     s/\s+(?=(?:(?:[^"]*"){2})*[^"]*"[^"]*$)/___SPACE___/g;


### PR DESCRIPTION
currently these generate ugly warnings. I use space and comments in the config file for readability