### PR TITLE
Fix plugin path in command line output

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -710,12 +710,9 @@ sub new {
 
     $value = join(" --$flag ", @{$value}) if ref($value) eq "ARRAY";
 
-    if ($^O eq "MSWin32"){
-      $value =~ s|[^,=]+\\(?!$)(?! )(?!,)|[PATH]\\|g;
-    }
-    else {
-      $value =~ s|[^,=]+\/(?!$)(?! )(?!,)|[PATH]\/|g;
-    }
+    # replace most of the provided path with [PATH]/
+    my $delim = $^O eq "MSWin32" ? '\\' : '/';
+    $value =~ s|[^,=]+$delim(?! )(?!,)(?!$)|[PATH]$delim|g;
 
     $config_command .= $value eq 1? "--$flag "  : "--$flag $value ";
   }

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -711,10 +711,10 @@ sub new {
     $value = join(" --$flag ", @{$value}) if ref($value) eq "ARRAY";
     
     if ($^O eq "MSWin32"){
-      $value =~ s/.+(?=\\)/\[PATH\]/g;
+      $value =~ s/[^,=]+(?=\\)/\[PATH\]/g;
     }
     else {
-      $value =~ s/.+(?=\/)/\[PATH\]/g;
+      $value =~ s/[^,=]+(?=\/)/\[PATH\]/g;
     }
     
     $config_command .= $value eq 1? "--$flag "  : "--$flag $value ";

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -709,14 +709,14 @@ sub new {
     next if !defined($value) || (ref($value) eq "ARRAY" && @{$value} == 0) || grep { /$flag/ } @skip_opts;
 
     $value = join(" --$flag ", @{$value}) if ref($value) eq "ARRAY";
-    
+
     if ($^O eq "MSWin32"){
-      $value =~ s/[^,=]+(?=\\)/\[PATH\]/g;
+      $value =~ s|[^,=]+\\(?!$)(?! )(?!,)|[PATH]\\|g;
     }
     else {
-      $value =~ s/[^,=]+(?=\/)/\[PATH\]/g;
+      $value =~ s|[^,=]+\/(?!$)(?! )(?!,)|[PATH]\/|g;
     }
-    
+
     $config_command .= $value eq 1? "--$flag "  : "--$flag $value ";
   }
 


### PR DESCRIPTION
Currently, the VEP command-line in output is hiding all plugin parameters preceding a path delimiter (`/` or `\`).

For instance, if we run multiple plugins with a command like:
```
./vep --i $vcf \
      --cache homo_sapiens/tabixconverted/ \
      --plugin dbNSFP,dbNSFP/4.4a/dbNSFP4.4a_grch38.gz,rs_dbSNP \
      --plugin GO,plugin_data/GO_data_files/ \
      --plugin DisGeNET,file=DisGeNET/May_2020/all_variant_disease_pmid_associations_final.tsv.gz
```

The output will be:

`## VEP command-line: vep --cache [PATH]/ --input_file [PATH]/A530_small.vcf --offline --output_file [PATH]/vep-output.txt --plugin [PATH]/all_variant_disease_pmid_associations_final.tsv.gz`

## Change log

- Fix command plugin path hiding parameters for multiple plugins
- [Use lookahead to avoid stripping the directory path if finishing with `/`](https://github.com/Ensembl/ensembl-vep/commit/05b7288616312f3b27242871243e9a2d7d463398): for instance, `homo_sapiens/tabixconverted/` will become `[PATH]/tabixconverted/`
- Simplify code

## Testing

The output should be similar to:

`## VEP command-line: vep --dir_cache [PATH]/tabixconverted/ --fasta [PATH]/Homo_sapiens.GRCh38.dna.toplevel.fa.gz --force_overwrite --input_file [PATH]/A530_small.vcf --offline --output_file [PATH]/vep-output.txt --plugin dbNSFP,[PATH]/dbNSFP4.4a_grch38.gz,rs_dbSNP --plugin GO,[PATH]/GO_data_files/ --plugin DisGeNET,file=[PATH]/all_variant_disease_pmid_associations_final.tsv.gz`