### PR TITLE
Restrain using latest DBD::mysql version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'DBI';
 requires 'Set::IntervalTree';
 requires 'JSON';
 requires 'Text::CSV';
-recommends 'DBD::mysql';
+recommends 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 recommends 'PerlIO::gzip';
 recommends 'IO::Uncompress::Gunzip';
 recommends 'Bio::DB::BigFile';


### PR DESCRIPTION
DBD::mysql have released new version (5.001) on Oct 4, 2023. This version removes support for MySQL 5 -
https://metacpan.org/dist/DBD-mysql/changes

Hence we need to use lower version than that.

Ensembl repo already have similar PR merged - https://github.com/Ensembl/ensembl/pull/666