### PR TITLE
Avert cross species contamination in VEP cache dump

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/Dumper/Variation.pm
@@ -429,68 +429,58 @@ sub pubmed {
   my $self = shift;
   my $as = shift;
 
-  if(!exists($self->{_pubmed})) {
-
-    my %pm;
-    my $file = sprintf(
-      '%s/pubmed_%s_%s_%s.txt',
-      $self->required_param('pipeline_dir'),
-      $self->required_param('species'),
-      $self->required_param('ensembl_release'),
-      $self->required_param('assembly')
-    );
-    
-    if(-e $file) {
-      open IN, $file or die "Could not write to pubmed file $file $!";
-      while(<IN>) {
-        chomp;
-        my @split = split;
-        $pm{$split[0]} = $split[1];
-      }
-      close IN;
+  my %pm;
+  my $file = sprintf(
+    '%s/pubmed_%s_%s_%s.txt',
+    $self->required_param('pipeline_dir'),
+    $self->required_param('species'),
+    $self->required_param('ensembl_release'),
+    $self->required_param('assembly')
+  );
+  
+  if(-e $file) {
+    open IN, $file or die "Could not write to pubmed file $file $!";
+    while(<IN>) {
+      chomp;
+      my @split = split;
+      $pm{$split[0]} = $split[1];
     }
-    else{
-      $self->warning('Unable to find PUBMED file: ' . $file);
-    }
-
-    $self->{_pubmed} = \%pm;
+    close IN;
+  }
+  else{
+    $self->warning('Unable to find PUBMED file: ' . $file);
   }
 
-  return $self->{_pubmed};
+  return \%pm;
 }
 
 sub var_synonyms {
   my $self = shift;
   my $as = shift;
 
-  if(!exists($self->{_var_synonyms})) {
+  my %pm;
+  my $file = sprintf(
+    '%s/var_synonyms_%s_%s_%s.txt',
+    $self->required_param('pipeline_dir'),
+    $self->required_param('species'),
+    $self->required_param('ensembl_release'),
+    $self->required_param('assembly')
+  );
 
-    my %pm;
-    my $file = sprintf(
-      '%s/var_synonyms_%s_%s_%s.txt',
-      $self->required_param('pipeline_dir'),
-      $self->required_param('species'),
-      $self->required_param('ensembl_release'),
-      $self->required_param('assembly')
-    );
-
-    if(-e $file) {
-      open IN, $file or die "Could not write to var synonyms file $file $!";
-      while(<IN>) {
-        chomp;
-        my @split = split(/\t/);
-        $pm{$split[0]} = $split[1];
-      }
-      close IN;
+  if(-e $file) {
+    open IN, $file or die "Could not write to var synonyms file $file $!";
+    while(<IN>) {
+      chomp;
+      my @split = split(/\t/);
+      $pm{$split[0]} = $split[1];
     }
-    else{
-      $self->warning('Unable to find Variation Synonyms file: ' . $file);
-    }
-
-    $self->{_var_synonyms} = \%pm;
+    close IN;
+  }
+  else{
+    $self->warning('Unable to find Variation Synonyms file: ' . $file);
   }
 
-  return $self->{_var_synonyms};
+  return \%pm;
 }
 
 


### PR DESCRIPTION
[ENSVAR-6087](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6087)

#### Problem
In VEP cache we generally have `pubmed` and `var_synonyms` data from the database. For past couple of release we are getting erratically missing data from them. Note that these two are the only field that are queried from the database and dumped into files and read back again from those dump file when creating the cache.

#### Cause
After adding some debug data (the contents of the dump files read in each job), the cause behind these missing data is found out. We generally keep the data loaded from the dump files in-memory for a species between jobs. But it seems that somehow these objects is persisting jobs between different species and hence one species is getting data from another species.

### Solution
Simply do not keep in-memory objects. 

#### Test
Tested with fix and compared the result between different species. The result can be viewed in above JIRA ticket. 