### PR TITLE
Improve summary stats and VCF output

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -204,8 +204,9 @@ sub headers {
 
   # add VEP version string
   push @headers, sprintf(
-    '##VEP="v%i" time="%s"%s%s',
+    '##VEP="v%s" API="v%s" time="%s"%s%s',
     $info->{vep_version},
+    $info->{api_version},
     $info->{time},
     $info->{cache_dir} ? ' cache="'.$info->{cache_dir}.'"' : '',
     $info->{db_name} ? ' db="'.$info->{db_name}.'@'.$info->{db_host}.'"' : ''

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -685,7 +685,7 @@ sub generate_run_stats {
 sub generate_data_version {
   my $self = shift;
   my %version_data = %{ $self->{info}->{version_data} };
-  my @return = map { [ $version_data{$_} ] } sort keys %version_data;
+  my @return = map { [ $_, $version_data{$_} ] } sort keys %version_data;
   return \@return;
 }
 

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -665,7 +665,7 @@ sub generate_run_stats {
   }
 
   unshift @return, ['Annotation sources', join("; ", @cache_db_strings)];
-  unshift @return, ['VEP version (API)', sprintf(' %i (%i)', $info->{vep_version}, $info->{api_version})];
+  unshift @return, ['VEP version (API)', sprintf(' %s (%s)', $info->{vep_version}, $info->{api_version})];
 
   return \@return;
 }

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -685,7 +685,7 @@ sub generate_run_stats {
 sub generate_data_version {
   my $self = shift;
   my %version_data = %{ $self->{info}->{version_data} };
-  my @return = map { [ %version_data{$_} ] } sort keys %version_data;
+  my @return = map { [ $version_data{$_} ] } sort keys %version_data;
   return \@return;
 }
 

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -675,6 +675,25 @@ sub generate_run_stats {
 }
 
 
+=head2 generate_data_version
+
+  Example    : $run_stats = $stats->generate_data_version();
+  Description: Generates data version information.
+  Returntype : arrayref
+  Exceptions : none
+  Caller     : finished_stats()
+  Status     : Stable
+
+=cut
+
+sub generate_data_version {
+  my $self = shift;
+  my %version_data = %{ $self->{info}->{version_data} };
+  my @return = map { [ %version_data{$_} ] } sort keys %version_data;
+  return \@return;
+}
+
+
 =head2 generate_general_stats
 
   Arg 1      : hashref $stats
@@ -786,7 +805,10 @@ sub dump_text {
 
   print $fh "[VEP run statistics]\n";
   print $fh join("\t", map {s/\<.+?\>//g; $_} @{$_})."\n" for @{$finished_stats->{run_stats}};
-  
+
+  print $fh "[Data version]\n";
+  print $fh join("\t", map {s/\<.+?\>//g; $_} @{$_})."\n" for @{$finished_stats->{data_version}};
+
   print $fh "\n[General statistics]\n";
   print $fh join("\t", map {s/\<.+?\>//g; $_} grep {defined($_)} @{$_})."\n" for @{$finished_stats->{general_stats}};
   
@@ -828,6 +850,7 @@ sub dump_html {
           join('', map {sprintf('<li><a href="#%s">%s</a></li>', $_->[0], $_->[1])} (
             ['masthead', 'Top of page'],
             ['run_stats', 'VEP run statistics'],
+            ['data_version', 'Data version'],
             ['gen_stats', 'General statistics'],
             map {
               [$_->{id}, $_->{title}]
@@ -844,7 +867,13 @@ sub dump_html {
     '<table class="stats_table">'.
       join('', map {'<tr>'.join('', map {'<td>'.$_.'</td>'} @$_).'</tr>'} @{$finished_stats->{run_stats}}).
     '</table>';
-  
+
+  print $fh
+    '<h3 id="data_version">Data version</h3>'.
+    '<table class="stats_table">'.
+      join('', map {'<tr>'.join('', map {'<td>'.$_.'</td>'} @$_).'</tr>'} @{$finished_stats->{data_version}}).
+    '</table>';
+
   # vars in/out stats
   print $fh
     '<h3 id="gen_stats">General statistics</h3>'.

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -1036,10 +1036,22 @@ sub stats_html_head {
     
     .stats_table {
       margin: 5px;
+      table-layout: fixed;
+      width: 100%;
     }
-    
+
+    pre {
+      white-space: normal;
+      word-break: keep-all;
+    }
+
     td {
       padding: 5px;
+      word-break: break-word;
+    }
+
+    td:nth-child(2) {
+      width: 80%;
     }
 
     th.gradient {

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -478,8 +478,9 @@ sub finished_stats {
     }
 
     $self->{finished_stats} = {
-      charts => $self->generate_chart_data($stats),
-      run_stats => $self->generate_run_stats($stats),
+      charts        => $self->generate_chart_data($stats),
+      run_stats     => $self->generate_run_stats($stats),
+      data_version  => $self->generate_data_version(),
       general_stats => $self->generate_general_stats($stats),
     }
   }
@@ -648,18 +649,13 @@ sub generate_run_stats {
     ['Start time', $self->start_time],
     ['End time', $self->end_time],
     ['Run time', $self->run_time." seconds"],
-    ['Input file', $self->param('input_file')],
-    [
-      'Output file',
-      $self->param('output_file')#.
-      # (defined($config->{html}) ? ' '.a({href => $config->{output_file}.'.html'}, '[HTML]') : '').
-      # ' '.a({href => $config->{output_file}}, '[text]')
-    ],
+    ['Input file', "<pre>".$self->param('input_file')."</pre>"],
+    ['Output file', "<pre>".$self->param('output_file')."</pre>"],
   );
 
   my @cache_db_strings;
   if($info->{cache_dir}) {
-    push @cache_db_strings, "Cache: ".$info->{cache_dir};
+    push @cache_db_strings, "Cache: <kbd>".$info->{cache_dir}."</kbd>";
   }
   if($self->param('database') or ($self->param('cache') && !$self->param('offline'))) {
     push @cache_db_strings, sprintf('%s on %s', $info->{db_name}, $info->{db_host});

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -2035,8 +2035,8 @@ $ib = get_annotated_buffer({
 });
 
 $of->{individual_zyg} = ['dave,barry'];
-my $result = $of->VariationFeature_to_output_hash($ib->buffer->[0]);
-my $genotype = join ',', sort(@{$result->{ZYG}});
+$result = $of->VariationFeature_to_output_hash($ib->buffer->[0]);
+$genotype = join ',', sort(@{$result->{ZYG}});
 
 is($genotype, 'barry:HOM,dave:HET', 'VariationFeature_to_output_hash - individual_zyg correct sample name');
 delete($of->{individual_zyg});

--- a/t/OutputFactory_VCF.t
+++ b/t/OutputFactory_VCF.t
@@ -52,7 +52,7 @@ cmp_deeply(
   $of->headers,
   [
     '##fileformat=VCFv4.1',
-    '##VEP="v1" time="test"',
+    '##VEP="v1" API="v1" time="test"',
     '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|custom_test">',
     '##INFO=<ID=custom_test,Number=.,Type=String,Description="test.vcf.gz">',
     re('\#\#VEP-command-line=\'vep'),


### PR DESCRIPTION
## Changelog

### Summary statistics

- [Add table with data version](https://github.com/Ensembl/ensembl-vep/commit/8e21af1a9b6a5641f06da9613cbfda326120f3a4), such as COSMIC, ClinVar, dbSNP and SIFT
- [Fix table layout](https://github.com/Ensembl/ensembl-vep/commit/b3b85c1b2ce8bb9e1916ccc70ceca792a1c015e9)
- [Format paths to files/folders as code](https://github.com/Ensembl/ensembl-vep/commit/960d02212fa7acb80701b8a0e09d04f9042c4747)

### Summary statistics + VCF output

- [Fix VEP subversion and show API version in VCF output](https://github.com/Ensembl/ensembl-vep/commit/4c188cc53c07fff6c66a1f01b4f26d71e34bf45e)
    - Add VEP subversion to VCF output and summary statistics (before, only the VEP major version was displayed)
    - API version is now displayed in the VCF output

## Testing

Run VEP to return:
- VCF output
- Summary statistics in both HTML and text formats