### PR TITLE
Fix Singularity: create home dir with expected permissions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,8 +119,8 @@ ENV LANG_VAR en_US.UTF-8
 ARG BRANCH
 
 # Create vep user
-RUN mkdir -p $OPT && \
-    useradd -r -m -U -d "$OPT" -s /bin/bash -c "VEP User" -p '' vep && \
+RUN useradd -r -m -U -d "$OPT" -s /bin/bash -c "VEP User" -p '' vep && \
+    chmod a+rx $OPT && \
     usermod -a -G sudo vep && \
     mkdir -p $OPT_SRC
 USER vep
@@ -198,7 +198,7 @@ RUN curl -O "$PLUGIN_DEPS/ubuntu-packages.txt" && \
     rm -rf /var/lib/apt/lists/* ubuntu-packages.txt
 #   - Symlink python to python2
 RUN ln -s /usr/bin/python2 /usr/bin/python
-#   - Perl modules
+#   - Perl modules
 RUN curl -O "$PLUGIN_DEPS/cpanfile" && \
     cpanm --installdeps --with-recommends . && \
     rm -rf /root/.cpanm cpanfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,10 @@ ENV LANG_VAR en_US.UTF-8
 ARG BRANCH
 
 # Create vep user
-RUN useradd -r -m -U -d "$OPT" -s /bin/bash -c "VEP User" -p '' vep && usermod -a -G sudo vep && mkdir -p $OPT_SRC
+RUN mkdir -p $OPT && \
+    useradd -r -m -U -d "$OPT" -s /bin/bash -c "VEP User" -p '' vep && \
+    usermod -a -G sudo vep && \
+    mkdir -p $OPT_SRC
 USER vep
 
 # Copy downloaded libraries (stage 1) to this image (stage 2)


### PR DESCRIPTION
Fixes #1584: Singularity VEP is currently not working because of permission changes to the `/opt/vep` user folder. This PR fixes the folder permissions.

## Logic

When adding the VEP user, the `/opt/vep` user folder is being created with permissions `750` (`rwxr-w---`) instead of the expected `755` (`rwxr-wr-w`). These permissions come from the file `/etc/adduser.conf` (`DIR_MODE` flag) that was changed in **Ubuntu 22.04**[^1].

[^1]: Previous VEP Docker images based on Ubuntu 18.04 have the correct permissions for the `/opt/vep` user folder.

The solution is simply to change the folder permissions after creating the folder.

## Testing

Test the Docker image [`nunoagostinho/vep:test3`](https://hub.docker.com/r/nunoagostinho/vep/tags)