### PR TITLE
Fix `MYSQL_OPT_RECONNECT` deprecation warning in docker/singularity

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BRANCH=main
+ARG BRANCH=release/111
 
 ###################################################
 # Stage 1 - docker container to build ensembl-vep #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,6 +91,7 @@ RUN apt-get update && apt-get -y install \
     cpanminus \
     curl \
     libmysqlclient-dev \
+    libdbd-mysql-perl \
     libpng-dev \
     libssl-dev \
     zlib1g-dev \


### PR DESCRIPTION
In docker/singularity we are seeing the following warning -
```
WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
```

This warning originates from linux library `libmysqlclient21` when they rolled out version `8.0.34-0ubuntu0.22.04.1`. Because MYSQL  8.034 deprecates the use of `MYSQL_OPT_RECONNECT` in this version and `DBD::mysql` always sets this flag (to false anyway). See - 
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html#mysqld-8-0-34-deprecation-removal
https://github.com/perl5-dbi/DBD-mysql/issues/354

Ubuntu later released a new library that solves the issue for DBD::mysql `libdbd-mysql-perl`. See -
https://bugs.launchpad.net/ubuntu/+source/mysql-8.0/+bug/2031548

Adding this library removes this unwanted warning.