### PR TITLE
Improve `--registry` and `--db_version`

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -66,6 +66,7 @@ use Bio::EnsEMBL::VEP::Utils qw(get_time);
 use Bio::EnsEMBL::Slice;
 use Bio::EnsEMBL::CoordSystem;
 use Bio::EnsEMBL::VEP::Stats;
+use File::Spec;
 use FileHandle;
 
 
@@ -259,6 +260,8 @@ sub registry {
 
       # load DB options from registry file if given
       if(my $registry_file = $self->param('registry')) {
+        $registry_file = File::Spec->rel2abs($registry_file);
+        throw("ERROR: Registry file $registry_file not found") unless -e $registry_file;
         $self->status_msg("Loading DB self from registry file ", $registry_file) if $self->param('verbose');
         
         $reg->load_all(


### PR DESCRIPTION
## Changelog

- [Improvements to `--registry`](https://github.com/Ensembl/ensembl-vep/commit/1a6ac067bd97611e948c92123f9d32c3cbc93937)
    - Allow using a relative filename for `--registry`
    - Throw error when the registry file is not found
- [Warn when selected `--db_version` is not found in any database names](https://github.com/Ensembl/ensembl-vep/commit/4c7a82539fed2a0789f37d10fa6e737c0f1c5db0)
    - Instead of simply returning the warning `MSG: human is not a valid species name (check DB and API version)`, also return a VEP warning stating:

```
WARNING: No database names in ensembldb.ensembl.org:3306 contain version 112

-------------------- WARNING ----------------------
MSG: human is not a valid species name (check DB and API version)
FILE: Bio/EnsEMBL/Registry.pm LINE: 1334
CALLED BY: Bio/EnsEMBL/Registry.pm  LINE: 1109
Date (localtime)    = Fri Jan 19 12:28:53 2024
Ensembl API version = 112
---------------------------------------------------

-------------------- EXCEPTION --------------------
MSG: Can not find internal name for species 'human'
STACK Bio::EnsEMBL::Registry::get_adaptor /hps/software/users/ensembl/repositories/nuno/ensembl/modules/Bio/EnsEMBL/Registry.pm:1111
STACK Bio::EnsEMBL::VEP::BaseVEP::get_adaptor /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/BaseVEP.pm:351
STACK Bio::EnsEMBL::VEP::BaseVEP::get_database_assembly /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/BaseVEP.pm:462
STACK Bio::EnsEMBL::VEP::BaseRunner::setup_db_connection /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/BaseRunner.pm:123
STACK Bio::EnsEMBL::VEP::Runner::init /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/Runner.pm:123
STACK Bio::EnsEMBL::VEP::Runner::run /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/Runner.pm:200
STACK toplevel /hps/software/users/ensembl/repositories/nuno/ensembl-vep/vep:46
Date (localtime)    = Fri Jan 19 12:28:53 2024
Ensembl API version = 112
---------------------------------------------------
```

## Testing

- Run VEP with a registry file
    - Use a relative filename in `--registry`: VEP should use the registry file from relative file path
    - Use an incorrect filename in `--registry`: VEP should throw an error stating the registry file does not exist
- Run VEP with `--db_version`
    - Use a current `--db_version` like `109`: VEP should run without any warnings
    - Use a future `--db_version` like `112`: VEP should warn that the `--db_version` was not found in any database names before erroring out