### PR TITLE
Fix chromosome comparison in custom annotation and breakends

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource.pm
@@ -176,7 +176,7 @@ sub get_regions_from_coords {
   my $seen              = shift;
 
   # find actual chromosome name used by AnnotationSource
-  my $source_chr = $self->get_source_chr_name($chr);
+  my $source_chr = $self->get_standard_chr_name($chr);
 
   # allow for indels
   ($start, $end) = ($end, $start) if $start > $end;
@@ -294,7 +294,7 @@ sub _check_overlap {
 
   # if there is no chromosome info, return first key of $min_max
   my $chr = exists $elem->{slice} ? $elem->{slice}->{seq_region_name} : $elem->{chr};
-  $chr = defined $chr ? $self->get_source_chr_name($chr) : (keys %$min_max)[0];
+  $chr = defined $chr ? $self->get_standard_chr_name($chr) : (keys %$min_max)[0];
 
   my $check = exists $min_max->{$chr} &&
     overlap($elem->{start}, $elem->{end},

--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -395,7 +395,7 @@ sub get_slice {
   my $self = shift;
   my $orig_chr = shift;
 
-  my $chr = $self->get_source_chr_name($orig_chr, 'slices', [keys %{$self->chr_lengths}]);
+  my $chr = $self->get_standard_chr_name($orig_chr);
 
   my $cache = $self->{_slice_cache} ||= {};
 
@@ -676,6 +676,27 @@ sub get_source_chr_name {
   }
 
   return $chr_name_map->{$chr};
+}
+
+
+=head2 get_standard_chr_name
+
+  Arg 1      : string $chr
+  Example    : $syns = $obj->get_standard_chr_name('NC_000012.12')
+  Description: Attempts to get the standard chromosome name based on the keys of
+               $self->chr_lengths. If no valid match is found, returns $chr as
+               given.
+  Returntype : string
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub get_standard_chr_name {
+  my ($self, $chr) = @_;
+  my @names = keys %{$self->chr_lengths};
+  return $self->get_source_chr_name($chr, 'slices', \@names);
 }
 
 

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -424,7 +424,7 @@ sub create_StructuralVariationFeatures {
     $end = $parser->get_end if $incorrect_end;
 
     if (defined $info->{CHR2}) {
-      my $breakend_chr = $self->get_source_chr_name($info->{CHR2});
+      my $breakend_chr = $self->get_standard_chr_name($info->{CHR2});
       my $breakend_pos = $info->{END2} || $incorrect_end;
       if (defined $breakend_chr and defined $breakend_pos) {
         $alt = $alt =~ /^<?BND>?$/i ? "N" : "$alt/N";
@@ -457,7 +457,7 @@ sub create_StructuralVariationFeatures {
     strand         => 1,
     adaptor        => $self->get_adaptor('variation', 'StructuralVariationFeature'),
     variation_name => @$ids ? $ids->[0] : undef,
-    chr            => $self->get_source_chr_name($chr),
+    chr            => $self->get_standard_chr_name($chr),
     class_SO_term  => $so_term,
     allele_string  => $alt,
     _line          => $record


### PR DESCRIPTION
Fixes:
- #1570 (no data when using custom annotation)
- ENSVAR-5967 (no support for chromosome synonyms in breakends)

## Motivation

When using chromosome synonyms (such as `chr12` and `NC_000012.12`) with custom annotation or breakends, the comparison fails because they are not exactly the same.

This PR solves the issue by creating a function to get standard chromosome names based on the following line: https://github.com/Ensembl/ensembl-vep/blob/42ec839818b8f85e435669ab48c309eb85e8be54/modules/Bio/EnsEMBL/VEP/BaseVEP.pm#L398

## Testing

Run VEP with:
- a custom annotation containing chromosome synonyms ([example](https://github.com/Ensembl/ensembl-vep/files/13864178/off_menu_transcripts.hg38.gff.gz))
- breakend variants containing chromosome synonyms