### PR TITLE
VEP Docker: include GeneSplicer binary

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -206,6 +206,18 @@ RUN curl -O "$PLUGIN_DEPS/requirements.txt" && \
     python2 -m pip install --no-cache-dir -r requirements.txt && \
     rm requirements.txt
 
+# Install GeneSplicer binary
+USER vep
+WORKDIR $VEP_DIR_PLUGINS
+RUN curl -O ftp://ftp.ccb.jhu.edu/pub/software/genesplicer/GeneSplicer.tar.gz && \
+    tar -xzf GeneSplicer.tar.gz && \
+    rm GeneSplicer.tar.gz && \
+    cd GeneSplicer/sources && \
+    make && \
+    mv genesplicer .. && \
+    rm -rf GeneSplicer/*/
+ENV PATH $VEP_DIR_PLUGINS/GeneSplicer:$PATH
+
 # Set working directory as symlink to $OPT/.vep (containing VEP cache and data)
 USER root
 RUN ln -s $OPT/.vep /data


### PR DESCRIPTION
Fixes #1590: compile `genesplicer` command for use in VEP Docker/Singularity

This only includes the compiled binary and **not** the associated training data (because of its size). The data still needs to be mounted by the user as usual for a Docker container.

## Usage example

Build the Docker image from this modified Dockerfile and run this command inside Docker:
```
vep --id rs1348242192 --database --force \
    --plugin GeneSplicer,/plugins/GeneSplicer/genesplicer,${human_data}
```

https://github.com/Ensembl/VEP_plugins/pull/689: Future improvements to [GeneSplicer.pm](https://github.com/Ensembl/VEP_plugins/blob/main/GeneSplicer.pm) could make this command easier to use.