### PR TITLE
Avoid messages of uninitialized value `$db_version` in unit tests

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -300,7 +300,7 @@ sub registry {
         my @db_names = map { $_->dbc->dbname } @{ $reg->get_all_DBAdaptors };
         my $hostname = ($user eq 'anonymous' ? '' : $user . '@') . "$host:$port";
         $self->warning_msg("No database names in $hostname contain version $db_version")
-          unless grep { /$db_version/ } @db_names;
+          if defined $db_version and not grep { /$db_version/ } @db_names;
       }
 
       eval { $reg->set_reconnect_when_lost() };


### PR DESCRIPTION
Unit tests ([example](https://app.travis-ci.com/github/Ensembl/ensembl-vep/jobs/616556185)) are printing the following line multiple times:

```
Use of uninitialized value $db_version in regexp compilation at /home/travis/build/Ensembl/ensembl-vep/modules/Bio/EnsEMBL/VEP/BaseVEP.pm line 302, <$__ANONIO__> line 139.
```

This PR fixes the issue brought by #1588 

## Testing

Unit tests should not print the line above no more. For instance, run unit test for `t/BaseVEP.t`