### PR TITLE
Export newly moved function to different module

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseVEP.pm
@@ -69,6 +69,9 @@ use Bio::EnsEMBL::VEP::Stats;
 use File::Spec;
 use FileHandle;
 
+use base qw(Exporter);
+
+our @EXPORT_OK = qw(_fetch_chr_synonyms);
 
 =head2 new
 


### PR DESCRIPTION
Related to - https://github.com/Ensembl/ensembl-vep/pull/1589

the function `_fetch_chr_synonyms` into a different module but did not get exported