### PR TITLE
Fix SV warnings for short variants in `region` format

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/Region.pm
@@ -184,22 +184,8 @@ sub create_VariationFeatures {
 
   my $vf;
   
-  # sv?
-  my $so_term = $self->get_SO_term($allele);
-  if(defined($so_term)) {
-    $vf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new_fast({
-      start          => $start,
-      end            => $end,
-      strand         => $strand,
-      adaptor        => $self->get_adaptor('variation', 'StructuralVariationFeature'),
-      variation_name => $region,
-      chr            => $chr,
-      class_SO_term  => $so_term,
-    });
-  }
-
   # normal vf
-  else {
+  if ($allele =~ /^[ACGTN-]+$/) {
     my $ref = ('N' x (($end - $start) + 1)) || '-';
 
     $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
@@ -211,6 +197,22 @@ sub create_VariationFeatures {
       adaptor        => $self->get_adaptor('variation', 'VariationFeature'),
       variation_name => $region,
       chr            => $chr,
+    });
+  }
+
+  # sv
+  else {
+    my $so_term = $self->get_SO_term($allele);
+    return [] unless defined $so_term;
+
+    $vf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new_fast({
+      start          => $start,
+      end            => $end,
+      strand         => $strand,
+      adaptor        => $self->get_adaptor('variation', 'StructuralVariationFeature'),
+      variation_name => $region,
+      chr            => $chr,
+      class_SO_term  => $so_term,
     });
   }
 


### PR DESCRIPTION
Fixes #1617: when inputting short variants in `region` format, VEP prints a warning message:
```
WARNING: line 1 skipped (12:9079672-9079672:C): C type is not supported
```

Also, unknown SV types in `region` format are incorrectly returned with no warning.

## Changelog

This PR does the following:
- Remove the nonsense warning for short variants in `region` format
- Throw warning (and do not return output) when using SVs whose type is not supported

## Testing

Ensure that running VEP with the following variants works without warnings[^1]:

```
12:9079672-9079672:C
12:9079672-9079672:DUP
12:9079672-9079672:INS:ME
12:9079672-9079672:INS:ME:LINE1
```

Ensure that running VEP with the following variants does not print output (only warnings):

```
12:9079672-9079672:RANDOM
12:9079672-9079672:DELTEST
```

[^1]: The last two examples require https://github.com/Ensembl/ensembl-variation/pull/1071