### PR TITLE
Improve statistics output

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -643,13 +643,23 @@ sub generate_run_stats {
     }
   }
 
+  # Distinguish input source
+  my ($input, $input_label);
+  if ($self->param('input_file') eq *Bio::EnsEMBL::VEP::Runner::IN) {
+    $input = $self->param('input_data');
+    $input_label = 'Input data';
+  } else {
+    $input = $self->param('input_file');
+    $input_label = 'Input file';
+  }
+
   my @return = (
     ['Species', $self->species],
     ['Command line options', '<pre>'.join(" ", @opts).'</pre>'],
     ['Start time', $self->start_time],
     ['End time', $self->end_time],
     ['Run time', $self->run_time." seconds"],
-    ['Input file', "<pre>".$self->param('input_file')."</pre>"],
+    [$input_label, "<pre>".$input."</pre>"],
     ['Output file', "<pre>".$self->param('output_file')."</pre>"],
   );
 
@@ -802,8 +812,12 @@ sub dump_text {
   print $fh "[VEP run statistics]\n";
   print $fh join("\t", map {s/\<.+?\>//g; $_} @{$_})."\n" for @{$finished_stats->{run_stats}};
 
-  print $fh "[Data version]\n";
-  print $fh join("\t", map {s/\<.+?\>//g; $_} @{$_})."\n" for @{$finished_stats->{data_version}};
+  print $fh "\n[Data version]\n";
+  if (@{$finished_stats->{data_version}}) {
+    print $fh join("\t", map {s/\<.+?\>//g; $_} @{$_})."\n" for @{$finished_stats->{data_version}};
+  } else {
+    print $fh "No data version information available.\n";
+  }
 
   print $fh "\n[General statistics]\n";
   print $fh join("\t", map {s/\<.+?\>//g; $_} grep {defined($_)} @{$_})."\n" for @{$finished_stats->{general_stats}};
@@ -864,11 +878,15 @@ sub dump_html {
       join('', map {'<tr>'.join('', map {'<td>'.$_.'</td>'} @$_).'</tr>'} @{$finished_stats->{run_stats}}).
     '</table>';
 
-  print $fh
-    '<h3 id="data_version">Data version</h3>'.
-    '<table class="stats_table">'.
-      join('', map {'<tr>'.join('', map {'<td>'.$_.'</td>'} @$_).'</tr>'} @{$finished_stats->{data_version}}).
-    '</table>';
+  print $fh '<h3 id="data_version">Data version</h3>';
+  if (@{$finished_stats->{data_version}}) {
+    print $fh
+      '<table class="stats_table">'.
+        join('', map {'<tr>'.join('', map {'<td>'.$_.'</td>'} @$_).'</tr>'} @{$finished_stats->{data_version}}).
+      '</table>';
+  } else {
+    print $fh 'No data version information available.';
+  }
 
   # vars in/out stats
   print $fh

--- a/modules/Bio/EnsEMBL/VEP/Stats.pm
+++ b/modules/Bio/EnsEMBL/VEP/Stats.pm
@@ -684,7 +684,7 @@ sub generate_run_stats {
 
 sub generate_data_version {
   my $self = shift;
-  my %version_data = %{ $self->{info}->{version_data} };
+  my %version_data = %{ $self->{info}->{version_data} } if $self->{info}->{version_data};
   my @return = map { [ $_, $version_data{$_} ] } sort keys %version_data;
   return \@return;
 }


### PR DESCRIPTION
This PR fixes two issues with statistics output:

1. When running VEP using only FASTA and GTF with stats enabled, VEP will print the following message:
```
Can't use an undefined value as a HASH reference at /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/Stats.pm line 687.
```

This PR fixes this message by not printing the data version table when there is no such information.

2. Also, when using `--input_data`, the statistics will show (for both HTML and TXT files):
```
Input file	*Bio::EnsEMBL::VEP::Runner::IN
```

This PR will print `--input_data` when `--input_file` is `*Bio::EnsEMBL::VEP::Runner::IN`.

## Testing

For testing, you can use the FASTA and GTF from the [t/testdata](https://github.com/Ensembl/ensembl-vep/tree/main/t/testdata) folder. The following command should not print the message above:

```
vep --id "21 25587758 rs116645811 G A" \
    --fasta t/testdata/fasta/Homo_sapiens.GRCh38.toplevel.test.fa \
    --gtf t/testdata/custom/test.gtf.gz --stats_html --stats_text
```

This will output two summary files (in HTML and TXT). The file in TXT should report the following if using `--input_file`:

```
[VEP run statistics]
VEP version (API)        112.0 (112)
Annotation sources      Custom: t/testdata/custom/test.gtf.gz (overlap)
Species homo_sapiens
Command line options    --fasta t/testdata/fasta/Homo_sapiens.GRCh38.toplevel.test.fa --force_ove>
Start time      2024-02-21 15:17:28
End time        2024-02-21 15:17:28
Run time        0 seconds
Input file	    i.txt
Output file     variant_effect_output.txt

[Data version]
No data version information available.

[General statistics]
Lines of input read     1
Variants processed      1
```

And the same TXT file but when using `--input_data`:
```
[VEP run statistics]
VEP version (API)	 112.0 (112)
Annotation sources	Custom: t/testdata/custom/test.gtf.gz (overlap)
Species	homo_sapiens
Command line options	--fasta t/testdata/fasta/Homo_sapiens.GRCh38.toplevel.test.fa --force_overwrite --gtf t/testdata/custom/test.gtf.gz --input_data 21 25587758 rs116645811 G A --stats_html --stats_text
Start time	2024-02-21 15:29:01
End time	2024-02-21 15:29:02
Run time	1 seconds
Input data	21 25587758 rs116645811 G A
Output file	variant_effect_output.txt

[Data version]
No data version information available.

[General statistics]
Lines of input read	1
Variants processed	1
```

The HTML file should look like this if using `--input_file`:

![Screenshot 2024-02-21 at 15 27 52](https://github.com/Ensembl/ensembl-vep/assets/3199157/d3bf6df7-ab64-45b2-88d2-41e9091a9e7d)

And the HTML file should look like this if using `--input_data`:

![Screenshot 2024-02-21 at 15 29 13](https://github.com/Ensembl/ensembl-vep/assets/3199157/f2a878c8-5877-47ce-9867-ea7f834db819)
