### PR TITLE
Support NCBI microbe annotation with no transcripts (CDS only)

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
@@ -459,10 +459,10 @@ sub _create_transcript {
   my $tr_record = shift;
   my $gene_record = shift;
 
-  return unless $tr_record->{_children};
+  return unless $tr_record->{_children} or $tr_record->{type} eq 'CDS';
 
   my $id = $tr_record->{attributes}->{transcript_id} || $self->_record_get_id($tr_record);
-  $id =~ s/^(gene|transcript)://i;
+  $id =~ s/^(gene|transcript|cds)[:-]//i;
 
   my $slice = $self->get_slice($tr_record->{chr});
 
@@ -518,8 +518,18 @@ sub _create_transcript {
 
   # check for exons for protein_coding biotype
   if ($biotype eq 'protein_coding' && scalar @exons == 0){
-    $self->warning_msg("WARNING: No exons found for protein_coding transcript $id");
-    return;
+    if ($tr_record->{type} eq 'CDS'){
+      # create single-exon transcript based on a CDS without transcript parent
+      # example: microbial annotations from NCBI
+      push @exons, {
+        start  => $tr_record->{start},
+        end    => $tr_record->{end},
+        strand => $tr_record->{strand},
+      };
+    } else {
+      $self->warning_msg("WARNING: No exons found for protein_coding transcript $id");
+      return;
+    }
   }
 
   # sort exons

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/GFF.pm
@@ -227,11 +227,11 @@ sub _record_get_biotype {
   my ($self, $record, $gene_record) = @_;
 
   if(!exists($record->{_biotype})) {
-
     # Ensembl-y GFFs have biotype as an attribute
     my $biotype = $record->{attributes}->{biotype} ||
                   $record->{attributes}->{transcript_type} ||
-                  $record->{attributes}->{transcript_biotype};
+                  $record->{attributes}->{transcript_biotype} ||
+                  $gene_record->{attributes}->{gene_biotype};
 
     # others we need to (guess) work it out
     if(!$biotype) {


### PR DESCRIPTION
Fixes #1620

Support NCBI GFF annotation that only contain CDS lines: these CDS lines contain gene IDs as parents (instead of transcript IDs)

## TODO
- [ ] Support NCBI GTF annotation
- [ ] Check if there are no issues with currently supported GTF/GFF annotation files
- [ ] Fix unit tests