### PR TITLE
Fix unit test with updated incompatibility list

### DIFF
--- a/t/Runner.t
+++ b/t/Runner.t
@@ -771,13 +771,6 @@ $runner = Bio::EnsEMBL::VEP::Runner->new({
 });
 throws_ok {$runner->post_setup_checks} qr/Cannot use transcript reference sequences/, 'post_setup_checks - use_transcript_ref + offline with no fasta';
 
-$runner = Bio::EnsEMBL::VEP::Runner->new({
-  %$cfg_hash,
-  lrg => 1,
-  offline => 1,
-});
-throws_ok {$runner->post_setup_checks} qr/Cannot map to LRGs in offline mode/, 'post_setup_checks - lrg + offline';
-
 ## status_msg tests require we mess with STDOUT
 ###############################################
 


### PR DESCRIPTION
In https://github.com/Ensembl/ensembl-vep/pull/1642 we have updated incompatible option list. We also need to remove a test that uses one pair of incompatible options. 