### PR TITLE
Allow filtering in nextflow-vep

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -61,7 +61,7 @@ The following config files are used and can be modified depending on user requir
                             NOTE: Do not use this parameter if you are expecting multiple output files.
   --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
   --filters STRING          Comma-separated list of filter conditions to pass to filter_vep,
-                            such as "amino_acids not match X[A-Za-z*]?\/,Feature is ENST00000377918".
+                            such as "AF < 0.01,Feature is ENST00000377918".
                             Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html
                             Default: null (filter_vep is not run)
 ```

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -60,6 +60,10 @@ The following config files are used and can be modified depending on user requir
   --output_prefix PREFIX    Output filename prefix. The generated output file will have name <output_prefix>_VEP.vcf.gz.
                             NOTE: Do not use this parameter if you are expecting multiple output files.
   --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
+  --filters STRING          Comma-separated list of filter conditions to pass to filter_vep,
+                            such as "amino_acids not match X[A-Za-z*]?\/,Feature is ENST00000377918".
+                            Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html
+                            Default: null (filter_vep is not run)
 ```
 
 ---

--- a/nextflow/nf_modules/run_vep.nf
+++ b/nextflow/nf_modules/run_vep.nf
@@ -30,6 +30,7 @@ process runVEP {
   script:
   index_type = meta.index_type
   out_vcf = "vep" + "-" + file(original_vcf).getSimpleName() + "-" + vep_config.getSimpleName() + "-" + vcf
+  tabix_arg = index_type == 'tbi' ? '' : '-C'
   
   if( !vcf.exists() ) {
     exit 1, "VCF file is not generated: ${vcf}"
@@ -49,22 +50,14 @@ process runVEP {
     bgzip filtered.vcf
     mv filtered.vcf.gz ${out_vcf}
     
-    if [[ "${index_type}" == "tbi" ]]; then
-      tabix -p vcf ${out_vcf}
-    else
-      tabix -C -p vcf ${out_vcf}
-    fi
+    tabix ${tabix_arg} -p vcf ${out_vcf}
     """
   }
   else {
     """
     vep -i ${vcf} -o ${out_vcf} --vcf --compress_output bgzip --format vcf --config ${vep_config}
     
-    if [[ "${index_type}" == "tbi" ]]; then
-      tabix -p vcf ${out_vcf}
-    else
-      tabix -C -p vcf ${out_vcf}
-    fi
+    tabix ${tabix_arg} -p vcf ${out_vcf}
     """
   }
 }

--- a/nextflow/nf_modules/run_vep.nf
+++ b/nextflow/nf_modules/run_vep.nf
@@ -37,8 +37,8 @@ process runVEP {
   else if ( !vcf_index.exists() ){
     exit 1, "VCF index file is not generated: ${vcf_index}"
   }
-  else if ( params.filters != null ){
-    def filters = params.filters.split(",")
+  else if ( meta.filters != null ){
+    def filters = meta.filters.split(",")
     def filter_arg = ""
     for (filter in filters) {
       filter_arg = filter_arg + "-filter \"" + filter + "\" "

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -44,6 +44,9 @@ Options:
   --outdir DIRNAME          Name of output directory. Default: outdir
   --output_prefix PREFIX    Output filename prefix. The generated output file will have name <vcf>-<output_prefix>.vcf.gz
   --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
+  --filter STRING           Comma-separated list of filter conditions to pass to filter_vep, such as "AF < 0.01,Feature is ENST00000377918".
+                            Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html
+                            Default: null (filter_vep is not run)
   """
   exit 1
 }

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -122,15 +122,20 @@ workflow {
 
   output_dir = createOutputChannel(params.outdir)
   
+  filters = Channel.of(params.filters)
+  
   vcf
     .combine( vep_config )
     .combine( one_to_many )
     .combine( output_dir )
+    .combine( filters )
     .map {
-      vcf, vep_config, one_to_many, output_dir ->
+      vcf, vep_config, one_to_many, output_dir, filters ->
         meta = [:]
         meta.one_to_many = one_to_many
         meta.output_dir = output_dir
+        meta.filters = filters
+        
         // NOTE: csi is default unless a tbi index already exists
         meta.index_type = file(vcf + ".tbi").exists() ? "tbi" : "csi"
 

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -12,6 +12,7 @@ params.cpus = 1
 
 params.vcf = null
 params.vep_config = null
+params.filters = null
 params.outdir = "outdir"
 
 params.output_prefix = ""


### PR DESCRIPTION
Added a param `--filters` which takes a string as an argument which can be comma separated list of filter condition. These condition are similar to what we can give in `filter_vep`.

As nextflow-vep can handle only VCF files the `filter_vep` arguments used here is also tailored for VCF file.

### Test Example

```
nextflow -C ${repositories}/ensembl-vep/nextflow/nextflow.config run ${repositories}/ensembl-vep/nextflow/workflows/run_vep.nf \
--vcf $input_file \
--vep_config $vep_config \
--outdir $output_dir \
--output_prefix $output_prefix \
--filters "amino_acids not match X[A-Za-z*]?\/,Feature is ENST00000377918"
```

example variant to check this filter
```
13      57725290        rs1160403026    AGTG    A
```