### PR TITLE
Nextflow: Accept and split non-VCF input formats

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -61,7 +61,6 @@ The following config files are used and can be modified depending on user requir
                             NOTE: Do not use this parameter if you are expecting multiple output files.
 
   --sort                    Sort VCF results from VEP (only required if input is unsorted; slower if enabled). Default: false
-  --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
   --filters STRING          Comma-separated list of filter conditions to pass to filter_vep,
                             such as "AF < 0.01,Feature is ENST00000377918".
                             Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -52,7 +52,7 @@ The following config files are used and can be modified depending on user requir
 #### Options
 
 ```bash
-  --input FILE              Input file (if unsorted, use --sort to avoid errors). Alternatively, can also be a directory containing input files
+  --input FILE              Input file (if unsorted, use --sort to avoid errors in indexing the output file). Alternatively, can also be a directory containing input files
   --bin_size INT            Number of variants used to split input VCF into multiple jobs. Default: 100
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -1,9 +1,9 @@
 ## Nextflow VEP pipeline
 
-The nextflow pipeline aims to run VEP faster utilising simple parallelisation. It is deployable on an individual Linux machine or on computing clusters running lsf or slurm (not tested). The process can be summarised briefly by the following steps:
+The nextflow pipeline aims to run VEP faster utilising simple parallelisation. It is deployable on an individual Linux machine or on computing clusters running LSF or SLURM. The process can be summarised briefly by the following steps:
 
- * Splitting the VCF in a given number of bins (100 variants by default)
- * Running VEP on the split VCFs in parallel
+ * Splitting the input data into multiple files using a given number of bins (100 by default)
+ * Running VEP on the split files in parallel
  * Merging VEP outputs into a single file
 
 ##### Table of contents
@@ -45,14 +45,14 @@ The following config files are used and can be modified depending on user requir
 
 ```bash
   nextflow run workflows/run_vep.nf \
-  --vcf <path-to-vcf> \
+  --input <path-to-file> \
   -profile <standard or lsf or slurm>
 ```
 
 #### Options
 
 ```bash
-  --vcf VCF                 Sorted and bgzipped VCF. Alternatively, can also be a directory containing VCF files
+  --input FILE              Input file: if VCF, it must be sorted and bgzipped. Alternatively, can also be a directory containing input files
   --bin_size INT            Number of variants used to split input VCF into multiple jobs. Default: 100
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1
@@ -76,10 +76,10 @@ The following config files are used and can be modified depending on user requir
 
   nextflow \
     run workflows/run_vep.nf \
-    --vcf $PWD/examples/clinvar-testset/input.vcf.gz \
-    -profile lsf
+    --input $PWD/examples/clinvar-testset/input.vcf.gz \
+    -profile slurm
  ```
-The above commands start the pipeline and generate the output file upon completion.
+The above commands start the pipeline in SLURM and generate the output file upon completion.
 
 #### Output validation
 

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -59,6 +59,8 @@ The following config files are used and can be modified depending on user requir
   --outdir DIRNAME          Name of output directory. Default: outdir
   --output_prefix PREFIX    Output filename prefix. The generated output file will have name <output_prefix>_VEP.vcf.gz.
                             NOTE: Do not use this parameter if you are expecting multiple output files.
+
+  --sort                    Sort VCF results from VEP (only required if input is unsorted; slower if enabled). Default: false
   --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
   --filters STRING          Comma-separated list of filter conditions to pass to filter_vep,
                             such as "AF < 0.01,Feature is ENST00000377918".

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -52,7 +52,7 @@ The following config files are used and can be modified depending on user requir
 #### Options
 
 ```bash
-  --input FILE              Input file: if VCF, it must be sorted and bgzipped. Alternatively, can also be a directory containing input files
+  --input FILE              Input file (if unsorted, use --sort to avoid errors). Alternatively, can also be a directory containing input files
   --bin_size INT            Number of variants used to split input VCF into multiple jobs. Default: 100
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1

--- a/nextflow/nf_modules/generate_splits.nf
+++ b/nextflow/nf_modules/generate_splits.nf
@@ -22,13 +22,12 @@ process generateSplits {
 
   input:
   tuple val(meta), path(vcf), path(vcf_index), path(vep_config)
-  val(bin_size)
 
   output:
   tuple val(meta), path(vcf), path(vcf_index), path("x*"), path(vep_config)
 
   shell:
   """
-  bcftools query -f'%CHROM\t%POS\n' ${vcf} | uniq | split -a 3 -l ${bin_size}
+  bcftools query -f'%CHROM\t%POS\n' ${vcf} | uniq | split -a 3 -l ${params.bin_size}
   """
 }

--- a/nextflow/nf_modules/merge_VCF.nf
+++ b/nextflow/nf_modules/merge_VCF.nf
@@ -22,7 +22,7 @@ process mergeVCF {
   cache 'lenient'
    
   input:
-  tuple val(meta), val(original_vcf), path(vcf_files), path(index_files), val(vep_config)
+  tuple val(meta), val(original), path(vcf_files), path(index_files), val(vep_config)
   
   output:
   val("${output_dir}/${merged_vcf}")
@@ -32,7 +32,7 @@ process mergeVCF {
   one_to_many = meta.one_to_many
   output_dir = meta.output_dir
   
-  merged_vcf = merged_vcf ?: file(original_vcf).getName().replace(".vcf", "_VEP.vcf")
+  merged_vcf = merged_vcf ?: file(original).getSimpleName() + "_VEP.vcf.gz"
   merged_vcf = one_to_many ? merged_vcf.replace(
     "_VEP.vcf", 
     "_" + file(vep_config).getName().replace(".ini", "") + "_VEP.vcf"

--- a/nextflow/nf_modules/merge_VCF.nf
+++ b/nextflow/nf_modules/merge_VCF.nf
@@ -22,7 +22,7 @@ process mergeVCF {
   cache 'lenient'
    
   input:
-  tuple val(meta), val(original), path(vcf_files), path(index_files), val(vep_config)
+  tuple val(meta), val(original_file), path(vcf_files), path(index_files), val(vep_config)
   
   output:
   val("${output_dir}/${merged_vcf}")
@@ -32,7 +32,7 @@ process mergeVCF {
   one_to_many = meta.one_to_many
   output_dir = meta.output_dir
   
-  merged_vcf = merged_vcf ?: file(original).getSimpleName() + "_VEP.vcf.gz"
+  merged_vcf = merged_vcf ?: file(original_file).getSimpleName() + "_VEP.vcf.gz"
   merged_vcf = one_to_many ? merged_vcf.replace(
     "_VEP.vcf", 
     "_" + file(vep_config).getName().replace(".ini", "") + "_VEP.vcf"

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -18,6 +18,7 @@ params.outdir = "outdir"
 params.output_prefix = ""
 params.bin_size = 100
 params.skip_check = 0
+params.sort = false
 params.help = false
 
 // module imports
@@ -38,12 +39,14 @@ Usage:
   nextflow run workflows/run_vep.nf --input <path-to-file> --vep_config vep_config/vep.ini
 
 Options:
-  --input FILE                 Input file: if VCF, it must be sorted and bgzipped. Alternatively, can also be a directory containing input files
+  --input FILE              Input file: if VCF, it must be sorted and bgzipped. Alternatively, can also be a directory containing input files
   --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1
   --outdir DIRNAME          Name of output directory. Default: outdir
   --output_prefix PREFIX    Output filename prefix. The generated output file will have name <vcf>-<output_prefix>.vcf.gz
+
+  --sort                    Sort VCF results from VEP (only required if input is unsorted; slower if enabled). Default: false
   --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
   --filter STRING           Comma-separated list of filter conditions to pass to filter_vep, such as "AF < 0.01,Feature is ENST00000377918".
                             Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -38,7 +38,7 @@ Usage:
   nextflow run workflows/run_vep.nf --input <path-to-file> --vep_config vep_config/vep.ini
 
 Options:
-  --input FILE              Input file: if VCF, it must be sorted and bgzipped. Alternatively, can also be a directory containing input files
+  --input FILE              Input file (if unsorted, use --sort to avoid errors). Alternatively, can also be a directory containing input files
   --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -9,7 +9,8 @@ nextflow.enable.dsl=2
  // params default
 params.cpus = 1
 
-params.input = null
+params.vcf = null
+params.input = params.vcf
 params.vep_config = null
 params.filters = null
 params.outdir = "outdir"
@@ -129,6 +130,10 @@ workflow vep {
 workflow {
   if (!params.input) {
     exit 1, "Undefined --input parameter. Please provide the path to an input file."
+  }
+
+  if (params.vcf) {
+    log.warn "The --vcf parameter is deprecated in Nextflow VEP. Please use --input instead."
   }
 
   if (!params.vep_config) {

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -38,7 +38,7 @@ Usage:
   nextflow run workflows/run_vep.nf --input <path-to-file> --vep_config vep_config/vep.ini
 
 Options:
-  --input FILE              Input file (if unsorted, use --sort to avoid errors). Alternatively, can also be a directory containing input files
+  --input FILE              Input file (if unsorted, use --sort to avoid errors in indexing the output file). Alternatively, can also be a directory containing input files
   --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -1,8 +1,7 @@
 /* 
- * Workflow to run VEP on VCF files
+ * Workflow to run VEP on multiple input files
  *
- * This workflow relies on Nextflow (see https://www.nextflow.io/tags/workflow.html)
- *
+ * Requires Nextflow: https://nextflow.io
  */
 
 nextflow.enable.dsl=2
@@ -10,7 +9,7 @@ nextflow.enable.dsl=2
  // params default
 params.cpus = 1
 
-params.vcf = null
+params.input = null
 params.vep_config = null
 params.filters = null
 params.outdir = "outdir"
@@ -25,6 +24,7 @@ include { checkVCF } from '../nf_modules/check_VCF.nf'
 include { generateSplits } from '../nf_modules/generate_splits.nf'
 include { splitVCF } from '../nf_modules/split_VCF.nf' 
 include { mergeVCF } from '../nf_modules/merge_VCF.nf'  
+include { runVEP as runVEPonVCF } from '../nf_modules/run_vep.nf'
 include { runVEP } from '../nf_modules/run_vep.nf'
 
 // print usage
@@ -34,11 +34,11 @@ Pipeline to run VEP
 -------------------
 
 Usage:
-  nextflow run workflows/run_vep.nf --vcf <path-to-vcf> --vep_config vep_config/vep.ini
+  nextflow run workflows/run_vep.nf --input <path-to-file> --vep_config vep_config/vep.ini
 
 Options:
-  --vcf VCF                 Sorted and bgzipped VCF. Alternatively, can also be a directory containing VCF files
-  --bin_size INT            Number of variants used to split input VCF into multiple jobs. Default: 100
+  --input FILE                 Input file: if VCF, it must be sorted and bgzipped. Alternatively, can also be a directory containing input files
+  --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
   --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
   --cpus INT                Number of CPUs to use. Default: 1
   --outdir DIRNAME          Name of output directory. Default: outdir
@@ -81,37 +81,66 @@ workflow vep {
   take:
     inputs
   main:
-    // Prepare input VCF files (bgzip + tabix)
-    checkVCF(inputs)
-    
-    // Generate split files that each contain bin_size number of variants from VCF
-    generateSplits(checkVCF.out, params.bin_size)
+    // Process input based on file extension
+    inputs |
+      branch {
+        index: it.file =~ '\\.(tbi|csi)$'
+        registry: it.file =~ '\\.registry$'
+        ini: it.file =~ '\\.ini$'
+        vcf: it.file =~ '\\.vcf(.gz)?$'
+        other: true
+      } |
+      set { data }
 
-    // Split VCF using split files
-    splitVCF(generateSplits.out.transpose())
+    // Run VEP on VCF files
+    data.vcf |
+      checkVCF |
+      // Generate split files that each contain bin_size number of variants
+      generateSplits |
+      // Split VCF using split files
+      transpose | splitVCF |
+      // Run VEP for each split VCF file and for each VEP config
+      transpose | map { it + [format: 'vcf'] } | runVEPonVCF
 
-    // Run VEP for each split VCF file and for each VEP config
-    runVEP(splitVCF.out.transpose())
-    
+    // Run VEP on non-VCF files
+    data.other
+      .map {
+          // Split input by bin_size
+          files = it.file.splitText(by: params.bin_size, file: true)
+          res = []
+          for (f : files) {
+            // index is it.file simply to avoid Nexrflow errors
+            res += [ meta: it.meta, original: it.file, file: f, index: it.file, vep_config: it.vep_config, format: 'other' ]
+          }
+          res
+      }
+      .flatten() |
+      runVEP
+
+    // Merge all output data
+    out = runVEP.out.files
+            .mix(runVEPonVCF.out.files)
+            .groupTuple(by: [0, 1, 4])
+
     // Merge split VCF files (creates one output VCF for each input VCF)
-    mergeVCF(runVEP.out.files.groupTuple(by: [0, 1, 4]))
+    mergeVCF(out)
   emit:
     mergeVCF.out
 }
 
 workflow {
-  if (!params.vcf) {
-    exit 1, "Undefined --vcf parameter. Please provide the path to a VCF file."
+  if (!params.input) {
+    exit 1, "Undefined --input parameter. Please provide the path to an input file."
   }
 
   if (!params.vep_config) {
     exit 1, "Undefined --vep_config parameter. Please provide a VEP config file."
   }
 
-  vcf = createInputChannels(params.vcf, pattern="*.{vcf,gz}")
+  input = createInputChannels(params.input, pattern="*")
   vep_config = createInputChannels(params.vep_config, pattern="*.ini")
 
-  vcf.count()
+  input.count()
     .combine( vep_config.count() )
     .subscribe{ if ( it[0] != 1 && it[1] != 1 ) 
       exit 1, "Detected many-to-many scenario between VCF and VEP config files - currently not supported" 
@@ -119,7 +148,7 @@ workflow {
     
   // set if it is a one-to-many situation (single VCF and multiple ini file)
   // in this situation we produce output files with different names
-  one_to_many = vcf.count()
+  one_to_many = input.count()
     .combine( vep_config.count() )
     .map{ it[0] == 1 && it[1] != 1 }
 
@@ -127,24 +156,24 @@ workflow {
   
   filters = Channel.of(params.filters)
   
-  vcf
+  input
     .combine( vep_config )
     .combine( one_to_many )
     .combine( output_dir )
     .combine( filters )
     .map {
-      vcf, vep_config, one_to_many, output_dir, filters ->
+      data, vep_config, one_to_many, output_dir, filters ->
         meta = [:]
         meta.one_to_many = one_to_many
         meta.output_dir = output_dir
         meta.filters = filters
         
         // NOTE: csi is default unless a tbi index already exists
-        meta.index_type = file(vcf + ".tbi").exists() ? "tbi" : "csi"
+        meta.index_type = file(data + ".tbi").exists() ? "tbi" : "csi"
 
-        vcf_index = vcf + ".${meta.index_type}"
+        index = data + ".${meta.index_type}"
 
-        [ meta, vcf, vcf_index, vep_config ]
+        [ meta: meta, file: data, index: index, vep_config: vep_config ]
     }
     .set{ ch_input }
   

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -17,7 +17,6 @@ params.outdir = "outdir"
 
 params.output_prefix = ""
 params.bin_size = 100
-params.skip_check = 0
 params.sort = false
 params.help = false
 
@@ -47,7 +46,6 @@ Options:
   --output_prefix PREFIX    Output filename prefix. The generated output file will have name <vcf>-<output_prefix>.vcf.gz
 
   --sort                    Sort VCF results from VEP (only required if input is unsorted; slower if enabled). Default: false
-  --skip_check [0,1]        Skip check for tabix index file of input VCF. Enables use of cache with -resume. Default: 0
   --filter STRING           Comma-separated list of filter conditions to pass to filter_vep, such as "AF < 0.01,Feature is ENST00000377918".
                             Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html
                             Default: null (filter_vep is not run)


### PR DESCRIPTION
This PR improves the Nextlow pipeline to run VEP on non-VCF files.

## Changelog

* Replace argument `--vcf` with `--input`
    - 8d2b87c50: `--vcf` still supported for backwards compatibility (now prints deprecated message)
* When giving (a folder with) input data to run VEP on:
    - Ignore files with specific extensions: `ini`, `registry`, `tbi`, `csi`
    - If `vcf` or `vcf.gz` extension, parse using `checkVCF`, `generateSplits` and `splitVCF` (as previously) before running VEP
    - If any other extensions, split input files with `splitText` based on `params.bin_size` before running VEP
* In the end, merge split files (as previously)
* 37e4e5b2f: New option `--sort` to sort VCF input/output from VEP (disabled by default)
* 388339075: Remove mentions to deprecated `--skip_check`
* Update documentation

## Testing

Running the pipeline with different input files ([input.tar.gz](https://github.com/Ensembl/ensembl-vep/files/15349622/input.tar.gz)):

```
nextflow run ${ENSEMBL_ROOT_DIR}/ensembl-vep/nextflow/workflows/run_vep.nf \
  -profile slurm \
  -resume \
  --input input \
  --outdir outdir \
  --vep_config vep_config.ini
```
