### PR TITLE
VEP 88: Update Dockerfile to build VEP 88.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,17 @@ addons:
       - mysql-client-core-5.6
 
 before_install:
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-io.git
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
-  # - git clone --branch master --depth 1 https://github.com/Ensembl/Bio-HTS
+  - export ENSEMBL_BRANCH=release/88
+  - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
+  - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
+  - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-io.git
+  - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
+  - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
+
+  # - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/Bio-HTS
   # - wget https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip
   # - unzip release-1-6-924.zip
+
   - export CWD=$PWD
   - export DEPS=$HOME/dependencies
   - mkdir -p $DEPS

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
   - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-io.git
   - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
   - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-variation.git
-
   # - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/Bio-HTS
   # - wget https://github.com/bioperl/bioperl-live/archive/release-1-6-924.zip
   # - unzip release-1-6-924.zip

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'DBI';
 requires 'Set::IntervalTree';
 requires 'JSON';
 requires 'CGI';
-recommends 'DBD::mysql';
+recommends 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 recommends 'PerlIO::gzip';
 recommends 'IO::Uncompress::Gunzip';
 recommends 'Bio::DB::BigFile';

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,61 +1,169 @@
-### docker container for ensembl-vep
-FROM ubuntu
+###################################################
+# Stage 1 - docker container to build ensembl-vep #
+###################################################
+FROM ubuntu:18.04 as builder
 
-# update aptitude and install some required packages
+# Update aptitude and install some required packages
 # a lot of them are required for Bio::DB::BigFile
-RUN apt-get update && apt-get -y install build-essential cpanminus curl git manpages perl perl-base vim wget mysql-client libmysqlclient-dev libssl-dev unzip apache2 libmysqlclient-dev libpng12-dev libssl-dev openssl
+RUN apt-get update && apt-get -y install \
+    build-essential \
+    git \
+    libpng-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    perl \
+    perl-base \
+    unzip \
+    wget && \
+    rm -rf /var/lib/apt/lists/*
 
-# install ensembl dependencies
-RUN cpanm DBI DBD::mysql
+# Setup VEP environment
+ENV OPT /opt/vep
+ENV OPT_SRC $OPT/src
+ENV HTSLIB_DIR $OPT_SRC/htslib
+ENV BRANCH release/88
 
-# create vep user
-RUN useradd -r -m -U -d /home/vep -s /bin/bash -c "VEP User" -p '' vep
-RUN usermod -a -G sudo vep
-USER vep
-ENV HOME /home/vep
-WORKDIR $HOME
+# Working directory
+WORKDIR $OPT_SRC
 
-# clone git repositories
-RUN mkdir -p src
-WORKDIR $HOME/src
-RUN git clone https://github.com/Ensembl/ensembl.git
-RUN git clone https://github.com/Ensembl/ensembl-vep.git
+# Clone/download repositories/libraries
+RUN if [ "$BRANCH" = "main" ]; \
+    then export BRANCH_OPT=""; \
+    else export BRANCH_OPT="-b $BRANCH"; \
+    fi && \
+    # Get ensembl cpanfile in order to get the list of the required Perl libraries
+    wget -q "https://raw.githubusercontent.com/Ensembl/ensembl/$BRANCH/cpanfile" -O "ensembl_cpanfile" && \
+    # Clone ensembl-vep git repository
+    git clone $BRANCH_OPT --depth 1 https://github.com/Ensembl/ensembl-vep.git && chmod u+x ensembl-vep/*.pl && \
+    # Clone ensembl-variation git repository and compile C code
+    git clone $BRANCH_OPT --depth 1 https://github.com/Ensembl/ensembl-variation.git && \
+    mkdir var_c_code && \
+    cp ensembl-variation/C_code/*.c ensembl-variation/C_code/Makefile var_c_code/ && \
+    rm -rf ensembl-variation && \
+    chmod u+x var_c_code/* && \
+    # Clone bioperl-ext git repository - used by Haplosaurus
+    git clone --depth 1 https://github.com/bioperl/bioperl-ext.git && \
+    # Download ensembl-xs - it contains compiled versions of certain key subroutines used in VEP
+    wget https://github.com/Ensembl/ensembl-xs/archive/2.3.2.zip -O ensembl-xs.zip && \
+    unzip -q ensembl-xs.zip && mv ensembl-xs-2.3.2 ensembl-xs && rm -rf ensembl-xs.zip && \
+    # Clone/Download other repositories: bioperl-live is needed so the cpanm dependencies installation from the ensembl-vep/cpanfile file takes less disk space
+    ensembl-vep/travisci/get_dependencies.sh && \
+    # Only keep the bioperl-live "Bio" library
+    #mv bioperl-live bioperl-live_bak && mkdir bioperl-live && mv bioperl-live_bak/Bio bioperl-live/ && rm -rf bioperl-live_bak && \
+    ## A lot of cleanup on the imported libraries, in order to reduce the docker image ##
+    rm -rf Bio-HTS/.??* Bio-HTS/Changes Bio-HTS/DISCLAIMER Bio-HTS/MANIFEST* Bio-HTS/README Bio-HTS/scripts Bio-HTS/t Bio-HTS/travisci \
+           bioperl-ext/.??* bioperl-ext/Bio/SeqIO bioperl-ext/Bio/Tools bioperl-ext/Makefile.PL bioperl-ext/README* bioperl-ext/t bioperl-ext/examples \
+           ensembl-vep/.??* ensembl-vep/docker \
+           ensembl-xs/.??* ensembl-xs/TODO ensembl-xs/Changes ensembl-xs/INSTALL ensembl-xs/MANIFEST ensembl-xs/README ensembl-xs/t ensembl-xs/travisci \
+           htslib/.??* htslib/INSTALL htslib/NEWS htslib/README* htslib/test && \
+    # Only keep needed kent-335_base libraries for VEP - used by Bio::DB::BigFile (bigWig parsing)
+    mv kent-335_base kent-335_base_bak && mkdir -p kent-335_base/src && \
+    cp -R kent-335_base_bak/src/lib kent-335_base_bak/src/inc kent-335_base_bak/src/jkOwnLib kent-335_base/src/ && \
+    cp kent-335_base_bak/src/*.sh kent-335_base/src/ && \
+    rm -rf kent-335_base_bak
 
-# get VEP dependencies
-WORKDIR $HOME/src
-RUN ensembl-vep/travisci/get_dependencies.sh
-ENV PERL5LIB $PERL5LIB:$HOME/src/bioperl-live-release-1-6-924
-ENV KENT_SRC $HOME/src/kent-335_base/src
-ENV HTSLIB_DIR $HOME/src/htslib
-ENV MACHTYPE x86_64
-ENV CFLAGS "-fPIC"
-ENV DEPS $HOME/src
+# Setup bioperl-ext
+WORKDIR bioperl-ext/Bio/Ext/Align/
+RUN perl -pi -e"s|(cd libs.+)CFLAGS=\\\'|\$1CFLAGS=\\\'-fPIC |" Makefile.PL
 
-# and run the complilation/install as root
-USER root
-RUN ensembl-vep/travisci/build_c.sh
-
-# install htslib binaries (need bgzip, tabix)
+# Install htslib binaries (for 'bgzip' and 'tabix')
+# htslib requires the packages 'zlib1g-dev', 'libbz2-dev' and 'liblzma-dev'
 WORKDIR $HTSLIB_DIR
-RUN make install
+RUN make install && rm -f Makefile *.c
 
-# install perl dependencies
-WORKDIR $HOME/src
-RUN cpanm --installdeps --with-recommends --notest --cpanfile ensembl/cpanfile .
-RUN cpanm --installdeps --with-recommends --notest --cpanfile ensembl-vep/cpanfile .
+# Compile Variation LD C scripts
+WORKDIR $OPT_SRC/var_c_code
+RUN make && rm -f Makefile *.c
 
-# switch back to vep user
+
+###################################################
+# Stage 2 - docker container to build ensembl-vep #
+###################################################
+FROM ubuntu:18.04
+
+# Update aptitude and install some required packages
+# a lot of them are required for Bio::DB::BigFile
+RUN apt-get update && apt-get -y install \
+    build-essential \
+    cpanminus \
+    curl \
+    libmysqlclient-dev \
+    libpng-dev \
+    libssl-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    locales \
+    openssl \
+    perl \
+    perl-base \
+    unzip \
+    vim && \
+    apt-get -y purge manpages-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Setup VEP environment
+ENV OPT /opt/vep
+ENV OPT_SRC $OPT/src
+ENV PERL5LIB_TMP $PERL5LIB:$OPT_SRC/ensembl-vep:$OPT_SRC/ensembl-vep/modules
+ENV PERL5LIB $PERL5LIB_TMP:$OPT_SRC/bioperl-live
+ENV KENT_SRC $OPT/src/kent-335_base/src
+ENV HTSLIB_DIR $OPT_SRC/htslib
+ENV MACHTYPE x86_64
+ENV DEPS $OPT_SRC
+ENV PATH $OPT_SRC/ensembl-vep:$OPT_SRC/var_c_code:$PATH
+ENV LANG_VAR en_US.UTF-8
+
+# Create vep user
+RUN useradd -r -m -U -d "$OPT" -s /bin/bash -c "VEP User" -p '' vep && usermod -a -G sudo vep && mkdir -p $OPT_SRC
 USER vep
 
-# update bash profile
-RUN echo >> $HOME/.profile && \
-echo PATH=$HOME/src/ensembl-vep:\$PATH >> $HOME/.profile && \
-echo export PATH >> $HOME/.profile
+# Copy downloaded libraries (stage 1) to this image (stage 2)
+COPY --chown=vep:vep --from=builder $OPT_SRC $OPT_SRC
+#############################################################
 
-# setup environment
-ENV PATH $HOME/src/ensembl-vep:$PATH
+# Change user to root for the following complilations/installations
+USER root
 
-# run INSTALL.pl
-WORKDIR $HOME/src/ensembl-vep
-RUN chmod u+x *.pl
-RUN ./INSTALL.pl -a a -l
+# Install bioperl-ext, faster alignments for haplo (XS-based BioPerl extensions to C libraries)
+WORKDIR $OPT_SRC/bioperl-ext/Bio/Ext/Align/
+RUN perl Makefile.PL && make && make install && rm -f Makefile*
+
+# Install ensembl-xs, faster run using re-implementation in C of some of the Perl subroutines
+WORKDIR $OPT_SRC/ensembl-xs
+RUN perl Makefile.PL && make && make install && rm -f Makefile* cpanfile
+
+WORKDIR $OPT_SRC
+# Install/compile more libraries
+RUN cpanm DBI DBD::mysql@4.051
+RUN ensembl-vep/travisci/build_c.sh && \
+    # Remove unused Bio-DB-HTS files
+    rm -rf Bio-HTS/cpanfile Bio-HTS/Build.PL Bio-HTS/Build Bio-HTS/_build Bio-HTS/INSTALL.pl && \
+    # Install ensembl perl dependencies (cpanm)
+    cpanm --installdeps --with-recommends --notest --cpanfile ensembl_cpanfile . && \
+    cpanm --installdeps --with-recommends --notest --cpanfile ensembl-vep/cpanfile . && \
+    # Delete bioperl and cpanfiles after the cpanm installs as bioperl will be reinstalled by the INSTALL.pl script
+    rm -rf bioperl-live ensembl_cpanfile ensembl-vep/cpanfile && \
+    # Configure "locale", see https://github.com/rocker-org/rocker/issues/19
+    echo "$LANG_VAR UTF-8" >> /etc/locale.gen && locale-gen en_US.utf8 && \
+    /usr/sbin/update-locale LANG=$LANG_VAR && \
+    # Copy htslib executables. It also requires the packages 'zlib1g-dev', 'libbz2-dev' and 'liblzma-dev'
+    cp $HTSLIB_DIR/bgzip $HTSLIB_DIR/tabix $HTSLIB_DIR/htsfile /usr/local/bin/
+
+ENV LC_ALL $LANG_VAR
+ENV LANG $LANG_VAR
+
+# Switch back to vep user
+USER vep
+ENV PERL5LIB $PERL5LIB_TMP
+
+# Final steps
+WORKDIR $OPT_SRC/ensembl-vep
+# Update bash profile
+RUN echo >> $OPT/.profile && \
+    echo PATH=$PATH:\$PATH >> $OPT/.profile && \
+    echo export PATH >> $OPT/.profile && \
+    # Run INSTALL.pl and remove the ensemb-vep tests and travis
+    ./INSTALL.pl -a a -l -n && rm -rf t travisci .travis.yml


### PR DESCRIPTION
The current Dockerfile for 88.14 contains VEP 90. This is probably because the script to build the Docker image was run after releasing 90, given that the Dockerfile simply retrieves the latest default branch from the repo.

This PR intends to improve the situation by using instructions that more recent VEP Docker builds use, including the possibility of choosing the VEP version to install.

## Testing

Locally build the image and run VEP with some options to see if it works.