### PR TITLE
Update delimiter for FILTER when used for custom option

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/VCF.pm
@@ -216,7 +216,7 @@ sub _create_records {
     }
     ## extract pass/fail info from filter column
     $fields_data->{FILTER} .= $parser->get_raw_filter_results();
-    $fields_data->{FILTER} =~ s/\;/\,/g;
+    $fields_data->{FILTER} =~ s/\;/\%3B/g; # a semi-colon have special meaning in VCF INFO column
   }
 
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VEP_output.pm
@@ -113,7 +113,11 @@ sub output_hash_to_line {
 
   push @line, (
     join(';',
-      map {$_.'='.convert_arrayref($extra{$_})}
+      map {
+        my $data = convert_arrayref($extra{$_});
+        $data =~ s/\;/\%3B/g;
+        $_.'='.$data;
+      }
       sort {
         (defined($field_order->{$a}) ? $field_order->{$a} : 100)
         <=>

--- a/modules/Bio/EnsEMBL/VEP/Utils.pm
+++ b/modules/Bio/EnsEMBL/VEP/Utils.pm
@@ -185,7 +185,7 @@ sub format_coords {
 sub convert_arrayref {
   my $arg    = shift;
   my $sep    = shift || ',';
-  my $subsep = shift || ':';
+  my $subsep = shift || ';';
 
   my $res;
   if(ref($arg) eq 'ARRAY') {

--- a/t/AnnotationSource_File_VCF.t
+++ b/t/AnnotationSource_File_VCF.t
@@ -219,7 +219,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'test.vcf.gz' => [
-        { name => 'test1', fields => { 'FOO' => 'BAR', 'GOO' => 'CAR,STAR', 'NOVALUE' => 1, 'FILTER' =>'PASS' } }
+        { name => 'test1', fields => { 'FOO' => 'BAR', 'GOO' => 'CAR,STAR', 'NOVALUE' => 1, 'FILTER' => ['PASS'] } }
       ]
     },
     'annotate_InputBuffer - fields'
@@ -235,10 +235,10 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'test.vcf.gz' => [
-        { name => 'test1', fields => { 'FOO' => 'BAR', 'GOO' => 'CAR,STAR', 'NOVALUE' => 1, 'FILTER' =>'PASS' } }
+        { name => 'test1', fields => { 'FOO' => 'BAR', 'GOO' => 'CAR,STAR', 'NOVALUE' => 1, 'FILTER' => ['PASS'] } }
       ],
       'foo' => [
-        { name => 'test1', allele => 'T', fields => { 'GOO' => 'CAR', 'FILTER' =>'PASS' } }
+        { name => 'test1', allele => 'T', fields => { 'GOO' => 'CAR', 'FILTER' => ['PASS'] } }
       ]
     },
     'annotate_InputBuffer - exact, info keyed on allele'
@@ -261,8 +261,8 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'test1', allele => 'A', fields => {'GOO' => 'CAR','FILTER' => 'PASS'} },
-        { name => 'test1', allele => 'C', fields => {'GOO' => 'STAR','FILTER' => 'PASS'} }
+        { name => 'test1', allele => 'A', fields => {'GOO' => 'CAR','FILTER' => ['PASS']} },
+        { name => 'test1', allele => 'C', fields => {'GOO' => 'STAR','FILTER' => ['PASS']} }
       ]
     },
     'annotate_InputBuffer - exact, multiple, rev strand input'
@@ -284,8 +284,8 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'del1', allele => '-', fields => {'GOO' => 'B','FILTER' => 'PASS'} },
-        { name => 'del2', allele => '-', fields => {'FILTER' => 'SEGDUP%3BRF'} }
+        { name => 'del1', allele => '-', fields => {'GOO' => 'B','FILTER' => ['PASS']} },
+        { name => 'del2', allele => '-', fields => {'FILTER' => ['SEGDUP', 'RF']} }
       ]
     },
     'annotate_InputBuffer - deletion'
@@ -310,7 +310,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR','FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR','FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - mixed - insertion'
@@ -319,7 +319,7 @@ SKIP: {
     $ib->buffer->[1]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'ZAR', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - mixed - snp'
@@ -347,7 +347,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR','FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR','FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - trim input - insertion 1'
@@ -356,7 +356,7 @@ SKIP: {
     $ib->buffer->[1]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'C', fields => {'GOO' => 'YAR', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - trim input - insertion 2'
@@ -365,7 +365,7 @@ SKIP: {
     $ib->buffer->[2]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'CG', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'CG', fields => {'GOO' => 'ZAR', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 1'
@@ -374,7 +374,7 @@ SKIP: {
     $ib->buffer->[3]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'CGT', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'CGT', fields => {'GOO' => 'ZAR', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 2'
@@ -383,7 +383,7 @@ SKIP: {
     $ib->buffer->[4]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'ins1', allele => 'GGCG', fields => {'GOO' => 'ZAR', 'FILTER' => 'PASS'} },
+        { name => 'ins1', allele => 'GGCG', fields => {'GOO' => 'ZAR', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - trim input - snp 3'
@@ -409,7 +409,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'comp1', allele => '-', fields => {'FOO' => 'CAR', 'FILTER' => 'PASS'} },
+        { name => 'comp1', allele => '-', fields => {'FOO' => 'CAR', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - trim VCF - deletion 1'
@@ -418,7 +418,7 @@ SKIP: {
     $ib->buffer->[1]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'comp1', allele => '-', fields => {'FOO' => 'CAR', 'FILTER' => 'PASS'} },
+        { name => 'comp1', allele => '-', fields => {'FOO' => 'CAR', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - trim VCF - deletion 2'
@@ -442,7 +442,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'del2', fields => { 'FILTER' => 'SEGDUP%3BRF'} },
+        { name => 'del2', fields => { 'FILTER' => ['SEGDUP', 'RF']} },
       ]
     },
     'annotate_InputBuffer - SV reverts to overlap'
@@ -469,7 +469,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'refinc', allele => 'T', fields => {'FOO' => 0.1, 'FILTER' => 'PASS'} },
+        { name => 'refinc', allele => 'T', fields => {'FOO' => 0.1, 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - REF included in INFO chunks'
@@ -479,7 +479,7 @@ SKIP: {
     $ib->buffer->[1]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'countwrong', allele => 'T', fields => {'FOO' => '0.7,0.2,0.1', 'FILTER' => 'PASS'} },
+        { name => 'countwrong', allele => 'T', fields => {'FOO' => '0.7,0.2,0.1', 'FILTER' => ['PASS']} },
       ]
     },
     'annotate_InputBuffer - INFO chunk count doesnt match ALT count'

--- a/t/AnnotationSource_File_VCF.t
+++ b/t/AnnotationSource_File_VCF.t
@@ -285,7 +285,7 @@ SKIP: {
     {
       'foo' => [
         { name => 'del1', allele => '-', fields => {'GOO' => 'B','FILTER' => 'PASS'} },
-        { name => 'del2', allele => '-', fields => {'FILTER' => 'SEGDUP,RF'} }
+        { name => 'del2', allele => '-', fields => {'FILTER' => 'SEGDUP%3BRF'} }
       ]
     },
     'annotate_InputBuffer - deletion'
@@ -442,7 +442,7 @@ SKIP: {
     $ib->buffer->[0]->{_custom_annotations},
     {
       'foo' => [
-        { name => 'del2', fields => { 'FILTER' => 'SEGDUP,RF'} },
+        { name => 'del2', fields => { 'FILTER' => 'SEGDUP%3BRF'} },
       ]
     },
     'annotate_InputBuffer - SV reverts to overlap'

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -617,7 +617,7 @@ SKIP: {
           {
             "fields" => {
               "FOO" => "BAR",
-              "FILTER" => "PASS"
+              "FILTER" => ["PASS"]
             },
             "name" => "test1",
             "allele" => "T"


### PR DESCRIPTION
[ENSVAR-6276](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6276)
https://github.com/Ensembl/ensembl-vep/issues/1646

When we use `FILTER` field from a VCF file in `--custom` argument, the delimiter for FILTER, which is `;`, is replaced by `,` ([see](https://github.com/Ensembl/ensembl-vep/blob/31a3581b84495b617b2f3980da6c6313ca6d238f/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/VCF.pm#L219)). The reason is `;` have specific meaning in certain file type - for example, in VCF where this `FILTER` is going to put under `INFO`,`;` is used as delimiter to split up different fields in it.

But we also replace any `,` with `&` if found within any specific value under `CSQ` INFO field ([see](https://github.com/Ensembl/ensembl-vep/blob/31a3581b84495b617b2f3980da6c6313ca6d238f/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm#L373)). That is because in `CSQ` field `,` is used as delimiter to separate different records. 

And thus a `;` can become a `&` in VCF CSQ field. Which causes the confusion mentioned in the issue above.

To avoid error replace `;` with `%3B` which we are already doing for VCF file ([see](https://github.com/Ensembl/ensembl-vep/blob/31a3581b84495b617b2f3980da6c6313ca6d238f/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm#L374)).

**Cons:** 
Other output format (tab, vep text) will now have `%3B` instead of `,` as delimiter.
To avoid that, according to @nuno-agostinho's suggestion utilized  [convert_arrayref](https://github.com/Ensembl/ensembl-vep/blob/f167c3a4656b974f41f932a51217d347909d2c81/modules/Bio/EnsEMBL/VEP/Utils.pm#L185) function to keep the `;` and let the OutputFactory method handle the delimiter substitution. Default VEP format needed to replace `;` by `%3B` too.