### PR TITLE
Input full path to cache directory

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/CacheDir.pm
+++ b/modules/Bio/EnsEMBL/VEP/CacheDir.pm
@@ -104,7 +104,9 @@ sub new {
 
   # need to either specify full path (dir) e.g. ~/.vep/homo_sapiens/78_GRCh38/
   # or root path (root_dir) e.g. ~/.vep/ where species and version are drawn from config and assembly from config, DB or scanning dir
-  throw("ERROR: No root_dir or dir specified") unless $hashref && ($hashref->{root_dir} or $hashref->{dir});
+  my $dir = $hashref->{dir};
+  throw("ERROR: No root_dir or dir specified") unless $hashref && ($hashref->{root_dir} or $dir);
+  throw("ERROR: Directory $dir does not exist") if defined $dir && !-d $dir;
 
   $self->{$_} = $hashref->{$_} for keys %$hashref;
 

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -227,11 +227,12 @@ our @VEP_PARAMS = (
 
   # cache stuff
   'database',                # must specify this to use DB now
-  'cache:s',                 # use cache (optional param treated like --cache-dir)
+  'cache:s',                 # use cache (optional param treated like --dir_cache)
   'cache_version=i',         # specify a different cache version
   'show_cache_info',         # print cache info and quit
   'dir=s',                   # dir where cache is found (defaults to $HOME/.vep/)
   'dir_cache=s',             # specific directory for cache
+  'full_cache_dir=s',        # directory to specific cache to use (ignores --dir_cache if set)
   'dir_plugins=s',           # specific directory for plugins
   'offline',                 # offline mode uses minimal set of modules installed in same dir, no DB connection
   'fasta|fa=s',              # file or dir containing FASTA files with reference sequence


### PR DESCRIPTION
Add new `--full_cache_dir` option to set cache directory directly and check if given directory exists

@nakib103, should we improve the logic to check if the directory is a VEP cache dir? How would we do this?

## Testing

Run VEP with:
- `--full_cache_dir` with a non-existing directory: should raise error
- `--full_cache_dir` with a VEP cache dir: should work as expected
- `--cache_dir` and `--full_cache_dir` with a VEP cache dir: should ignore `--cache_dir`
- `--cache_dir` as usual: should work as expected
