### PR TITLE
Fix option individual_zyg

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -930,7 +930,7 @@ sub VariationFeature_to_output_hash {
     }
   }
   
-  # individual_zig
+  # individual_zyg
   if(defined($vf->{genotype_ind})) {
     my @tmp;
     foreach my $geno_ind (keys %{$vf->{genotype_ind}}) {

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -935,7 +935,7 @@ sub VariationFeature_to_output_hash {
     my @tmp;
     foreach my $geno_ind (keys %{$vf->{genotype_ind}}) {
       my %unique = map {$_ => 1} @{$vf->{genotype_ind}->{$geno_ind}};
-      push @tmp, $geno_ind.":".(scalar keys %unique > 1 ? 'HET' : 'HOM').(defined($vf->{hom_ref}->{$geno_ind}) ? 'REF' : '');
+      push @tmp, $geno_ind.":".(scalar keys %unique > 1 ? 'HET' : 'HOM').(defined($vf->{hom_ref_samples}->{$geno_ind}) ? 'REF' : '');
     }
     $hash->{ZYG} = \@tmp;
   }

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -720,8 +720,8 @@ sub create_individuals_zyg_VariationFeature {
 
     # Genotype is reference
     if(!scalar keys %non_ref) {
-      $vf->{hom_ref}->{$ind} = 1;
-      $vf->{non_variant}->{$ind} = 1;
+      $vf->{hom_ref_samples}->{$ind} = 1;
+      $vf->{non_variant_samples}->{$ind} = 1;
 
       if($n_individuals == 1) {
         $vf->{allele_string} = $ref."/".$ref ;

--- a/t/OutputFactory.t
+++ b/t/OutputFactory.t
@@ -2041,6 +2041,23 @@ $genotype = join ',', sort(@{$result->{ZYG}});
 is($genotype, 'barry:HOM,dave:HET', 'VariationFeature_to_output_hash - individual_zyg correct sample name');
 delete($of->{individual_zyg});
 
+### individual_zyg with alt allele '.'
+$ib = get_annotated_buffer({
+  input_file => $test_cfg->create_input_file([
+    ['##fileformat=VCFv4.1'],
+    [qw(#CHROM POS ID REF ALT QUAL FILTER INFO FORMAT dave barry jeff)],
+    [qw(21 25607429 indtest A . . . . GT 0/0)],
+  ]),
+  individual_zyg => 'dave',
+});
+
+$of->{individual_zyg} = ['dave'];
+$result = $of->VariationFeature_to_output_hash($ib->buffer->[0]);
+$genotype = join ',', sort(@{$result->{ZYG}});
+
+is($genotype, 'dave:HOMREF', 'VariationFeature_to_output_hash - individual_zyg alt = .');
+
+delete($of->{individual_zyg});
 
 # done
 done_testing();

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -1192,7 +1192,7 @@ is_deeply($vf, bless( {
   'genotype_ind' => {'jeff' => ['A', 'A'], 'barry' => ['G', 'G'], 'dave' => ['A', 'G']},
   'non_variant' => { 'jeff' => 1 },
   'phased' => {'jeff' => 0, 'barry' => 0, 'dave' => 1},
-  'hom_ref' => { 'jeff' => 1 },
+  'hom_ref_samples' => { 'jeff' => 1 },
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'individual_zyg');
 
 ### individual_zyg data - test situation where a line has no valid ALT genotypes

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -1190,7 +1190,7 @@ is_deeply($vf, bless( {
   'seq_region_end' => 25587759,
   'seq_region_start' => 25587759,
   'genotype_ind' => {'jeff' => ['A', 'A'], 'barry' => ['G', 'G'], 'dave' => ['A', 'G']},
-  'non_variant' => { 'jeff' => 1 },
+  'non_variant_samples' => { 'jeff' => 1 },
   'phased' => {'jeff' => 0, 'barry' => 0, 'dave' => 1},
   'hom_ref_samples' => { 'jeff' => 1 },
 }, 'Bio::EnsEMBL::Variation::VariationFeature' ), 'individual_zyg');


### PR DESCRIPTION
Issue reported here: https://github.com/Ensembl/ensembl-vep/issues/1703

The option `individual_zyg` uses the following variables:

- `$vf->{hom_ref}->{$ind} = 1`
- `$vf->{non_variant}->{$ind} = 1`

However, these variables are used in other parts of the code as:
`vf->{hom_ref} = 1`
`$vf->{non_variant} = 1`

The solution is to rename the variables.

**Testing**
Input:
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  ind
chr1    115258730       .       C       .       .     .    .   GT 0/0