### PR TITLE
Allow to add version to gene stable id

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/Transcript.pm
@@ -235,6 +235,7 @@ sub get_features_by_regions_uncached {
 
     foreach my $gene(map {$_->transfer($sr_slice)} @{$sub_slice->get_all_Genes(undef, undef, 1)}) {
       my $gene_stable_id = $gene->stable_id;
+      my $gene_version = $gene->version;
       my $canonical_tr_id = $gene->{canonical_transcript_id};
 
       # any phenotypes?
@@ -268,6 +269,7 @@ sub get_features_by_regions_uncached {
         next if @{ $tr->get_all_Attributes("readthrough_tra") };
         
         $tr->{_gene_stable_id} = $gene_stable_id;
+        $tr->{_gene_version} = $gene_version;
         $tr->{_gene} = $gene;
         $self->prefetch_gene_ids($tr);
 

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -184,6 +184,7 @@ our @VEP_PARAMS = (
   'hgnc',                    # add HGNC gene ID to extra column
   'symbol',                  # add gene symbol (e.g. HGNC)
   'transcript_version',      # add transcript version to stable id in feature column
+  'gene_version',            # add gene version to stable id in gene column
   'gene_phenotype',          # indicate if genes are phenotype-associated
   'mirna',                   # identify miRNA structural elements overlapped by variant
   'spdi',                    # add genomic SPDI

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -192,6 +192,7 @@ sub new {
     tsl
     appris
     transcript_version
+    gene_version
     gene_phenotype
     mirna
     ambiguity
@@ -1388,6 +1389,7 @@ sub BaseTranscriptVariationAllele_to_output_hash {
 
   # get gene
   $hash->{Gene} = $tr->{_gene_stable_id};
+  $hash->{Gene} .= '.'.$tr->{_gene_version} if $self->{gene_version} && $tr->{_gene_version} && $hash->{Gene} !~ /\.\d+$/;
 
   # strand
   $hash->{STRAND} = $tr->strand + 0;


### PR DESCRIPTION
[ENSVAR-6330](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6330)

Add new option `--gene_version` which similar to `--transcript_version` allow adding of version to the gene stable id in `Gene` column.

###Test
Test with a variant like rs699 with `--database` option.

- cache would not work as we do not have {_gene_version} in the transcript in the cache now. Once this PR is merged cache would have that and work with this option.
- Ensembl gff3/gtf do not have gene version currently.