### PR TITLE
Fix missing non reference seq region in VEP cache

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/CreateDumpJobs.pm
@@ -166,8 +166,7 @@ sub get_chr_jobs {
 
   # get slices
   my $sa = $dba->get_SliceAdaptor;
-  my @slices = @{$sa->fetch_all('toplevel')};
-  push @slices, map {$_->alternate_slice} map {@{$_->get_all_AssemblyExceptionFeatures}} @slices;
+  my @slices = @{$sa->fetch_all('toplevel', undef, 1)};
   push @slices, @{$sa->fetch_all('lrg', undef, 1, undef, 1)} if $self->param('lrg') && $self->param('group') ne 'otherfeatures';
 
   # remove/sort out duplicates, in human you get 3 Y slices


### PR DESCRIPTION
[ENSVAR-6377](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6377)
https://github.com/Ensembl/ensembl-vep/issues/1705

In e110, `assembly_exceptions` table was truncated which contained the sequence region for patches, haploptypes etc. due to changed mechanism of how those regions are showed in Ensembl genome browser.

The VEP cache pipeline depended on the `assembly_exceptions` table to grab those region. This PR aims to fix these issue by updating the current correct way to add non reference sequence regions.


### Test
pipeline url - http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=snhossain_dump_vep_human_113_test&passwd=xxxxx