### PR TITLE
DumpVEP: fix QC step for using non-reference sequence

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
+++ b/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/QCDump.pm
@@ -234,7 +234,7 @@ sub check_dirs {
 
   # get slices
   my $sa = $dba->get_SliceAdaptor;
-  my @slices = @{$sa->fetch_all('toplevel')};
+  my @slices = @{$sa->fetch_all('toplevel', undef, 1)};
   push @slices, map {$_->alternate_slice} map {@{$_->get_all_AssemblyExceptionFeatures}} @slices;
   push @slices, @{$sa->fetch_all('lrg', undef, 1, undef, 1)} if $self->param('lrg');
 


### PR DESCRIPTION
Related PR: https://github.com/Ensembl/ensembl-vep/pull/1718

In above PR we updated the pipeline to consider non-reference sequence. We also need to update the QC step so it does not fail.

A pipeline w/t fix:
http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=snhossain_dump_vep_human_113&passwd=xxxxx