### PR TITLE
Improving --gencode_primary and --flag_gencode_primary

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -606,6 +606,7 @@ our %INCOMPATIBLE = (
   af_gnomade    => [qw(af_gnomad)],
   quiet       => [qw(verbose)],
   refseq      => [qw(gencode_basic merged)],
+  gencode_primary => [qw(gencode_basic refseq)],
   json        => [qw(vcf tab)],
   vcf         => [qw(json tab)],
   tab         => [qw(vcf json)],
@@ -703,7 +704,16 @@ sub new {
     $config->{dir_cache} ||= $config->{cache} if -d "$config->{cache}";
     $config->{cache} = 1;
   }
+  
+  # throw a warning for GENCODE primary if assembly is not GRCh38
+  if (defined($config->{'gencode_primary'}) && lc($config->{'gencode_primary'}) && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {
+    printf("WARNING: --gencode_primary option is currently only available for human on the GRCh38 assembly\n");
+  }
 
+    # throw a warning for GENCODE primary if assembly is not GRCh38
+  if (defined($config->{'flag_gencode_primary'}) && lc($config->{'flag_gencode_primary'}) && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {
+    printf("WARNING: --flag_gencode_primary option is currently only available for human on the GRCh38 assembly\n");
+  }
   my $config_command = "";
 
   my @skip_opts = qw(web_output host port stats_file user warning_file input_data);

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -706,12 +706,12 @@ sub new {
   }
   
   # throw a warning for GENCODE primary if assembly is not GRCh38
-  if (defined($config->{'gencode_primary'}) && lc($config->{'gencode_primary'}) && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {
+  if (defined($config->{'gencode_primary'}) && $config->{'gencode_primary'} && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {
     printf("WARNING: --gencode_primary option is currently only available for human on the GRCh38 assembly\n");
   }
 
     # throw a warning for GENCODE primary if assembly is not GRCh38
-  if (defined($config->{'flag_gencode_primary'}) && lc($config->{'flag_gencode_primary'}) && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {
+  if (defined($config->{'flag_gencode_primary'}) && $config->{'flag_gencode_primary'} && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {
     printf("WARNING: --flag_gencode_primary option is currently only available for human on the GRCh38 assembly\n");
   }
   my $config_command = "";

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -704,6 +704,11 @@ sub new {
     $config->{dir_cache} ||= $config->{cache} if -d "$config->{cache}";
     $config->{cache} = 1;
   }
+
+   # throw a warning for GENCODE basic if assembly is not GRCh38
+  if (defined($config->{'gencode_basic'}) && $config->{'gencode_basic'} && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {
+    printf("WARNING: --gencode_basic option is currently only available for human on the GRCh38 assembly\n");
+  }
   
   # throw a warning for GENCODE primary if assembly is not GRCh38
   if (defined($config->{'gencode_primary'}) && $config->{'gencode_primary'} && defined($config->{'assembly'}) && lc($config->{'assembly'}) ne 'grch38') {

--- a/modules/Bio/EnsEMBL/VEP/Constants.pm
+++ b/modules/Bio/EnsEMBL/VEP/Constants.pm
@@ -259,7 +259,7 @@ our %FIELD_DESCRIPTIONS = (
   'CHECK_REF'	       => 'Reports variants where the input reference does not match the expected reference',
   'UPLOADED_ALLELE'    => 'The variant allele uploaded',
   'SHIFT_LENGTH'       => 'Reports the number of bases the insertion or deletion has been shifted relative to the underlying transcript due to right alignment before consequence calculation',
-  'GENCODE_PRIMARY'    => 'Reports if transcript is Gencode Primary'
+  'GENCODE_PRIMARY'    => 'Reports if transcript is GENCODE primary'
 );
 
 our @DEFAULT_OUTPUT_COLS = qw(


### PR DESCRIPTION
- Added incompatible flags
- Added warnings for unsupported assemblies
- Style changes in description of header for GENCODE_PRIMARY field
- Consistency with [public-plugins/pull/812](https://github.com/Ensembl/public-plugins/pull/812)

### Testing
```
vep -i input.vcf --gencode_primary --refseq   # Error 
vep -i input.vcf --gencode_primary --gencode_basic # Error
vep -i input.vcf --gencode_primary --merged # No error

vep -i input.vcf --gencode_primary --assembly GRCh37 # Warning 
vep -i input.vcf --gencode_primary  --flag_gencode_primary --species mus_musculus --assembly GRCm39 # Warning 
```