### PR TITLE
Update slurm profile and resource limits

### DIFF
--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -39,6 +39,8 @@ profiles {
   }
   slurm {
     process.executor = 'slurm'
+    singularity.enabled    = true
+    singularity.autoMounts = true
   }
 
   conda {

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -24,7 +24,6 @@ process {
   }
 
   withName: runVEP {
-    time = 4.h
     memory = 32.GB
   }
 }

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -39,8 +39,6 @@ profiles {
   }
   slurm {
     process.executor = 'slurm'
-    singularity.enabled    = true
-    singularity.autoMounts = true
   }
 
   conda {

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -24,7 +24,6 @@ process {
   }
 
   withName: runVEP {
-    cpus = 1
     time = 4.h
     memory = 32.GB
   }

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -22,6 +22,12 @@ process {
   withLabel: vep {
     container = 'docker://ensemblorg/ensembl-vep'
   }
+
+  withName: runVEP {
+    cpus = 1
+    time = 4.h
+    memory = 32.GB
+  }
 }
 
 profiles {
@@ -33,6 +39,8 @@ profiles {
   }
   slurm {
     process.executor = 'slurm'
+    singularity.enabled    = true
+    singularity.autoMounts = true
   }
 
   conda {

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -96,12 +96,16 @@ profiles {
     executor.cpus          = 16
     executor.memory        = 60.GB
   }
-  ensembl{
-    process.executor = 'slurm'
-    singularity.enabled    = true
-    singularity.autoMounts = true
-    withName: runVEP {
-      memory = '32GB'
+  ensembl {
+    singularity {
+      enabled    = true
+      autoMounts = true
+    }
+    process {
+      executor = 'slurm'
+      withName:runVEP {
+        memory = '32GB'
+      }
     }
   }
 }

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -22,10 +22,6 @@ process {
   withLabel: vep {
     container = 'docker://ensemblorg/ensembl-vep'
   }
-
-  withName: runVEP {
-    memory = 32.GB
-  }
 }
 
 profiles {
@@ -37,10 +33,7 @@ profiles {
   }
   slurm {
     process.executor = 'slurm'
-    singularity.enabled    = true
-    singularity.autoMounts = true
   }
-
   conda {
     conda.enabled          = true
     docker.enabled         = false
@@ -102,6 +95,14 @@ profiles {
     executor.name          = 'local'
     executor.cpus          = 16
     executor.memory        = 60.GB
+  }
+  ensembl{
+    process.executor = 'slurm'
+    singularity.enabled    = true
+    singularity.autoMounts = true
+    withName: runVEP {
+      memory = '32GB'
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates the slurm profile based on testing on our slurm cluster:
* Enable singularity on slurm
* Increase memory limit for VEP (for running without caches)