### PR TITLE
Check extension also when deciding runVEPonVCF process

### DIFF
--- a/nextflow/modules/check_VCF.nf
+++ b/nextflow/modules/check_VCF.nf
@@ -9,7 +9,7 @@ import java.util.zip.GZIPOutputStream
 
 def checkVCFheader (f) {
   // Check file extension
-  if (!f  =~ '\\.vcf\\.b?gz$') {
+  if (!(f  =~ '\\.vcf$') && !(f =~ '\\.vcf\\.b?gz$')) {
     return false
   }
 

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -74,7 +74,7 @@ workflow vep {
       branch {
         index: it.file =~ '\\.(tbi|csi)$'
         ignore: it.file =~ '\\.(ini|registry|config)$'
-        vcf_with_header: checkVCFheader(it.file)
+        vcf_with_header: (it.file =~ '\\.vcf$' || it.file =~ '\\.vcf\\.b?gz$') && checkVCFheader(it.file)
         other: true
       } |
       set { data }

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -74,7 +74,7 @@ workflow vep {
       branch {
         index: it.file =~ '\\.(tbi|csi)$'
         ignore: it.file =~ '\\.(ini|registry|config)$'
-        vcf_with_header: (it.file =~ '\\.vcf$' || it.file =~ '\\.vcf\\.b?gz$') && checkVCFheader(it.file)
+        vcf_with_header: checkVCFheader(it.file)
         other: true
       } |
       set { data }


### PR DESCRIPTION
In nextflow-vep pipeline we decide on extension of the file and the header content to decide if we go to `runVEPonVCF` process. Added back the extension checking.