### PR TITLE
Fixing filter when value is hash and contains text and number

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/FilterSet.pm
+++ b/modules/Bio/EnsEMBL/VEP/FilterSet.pm
@@ -591,7 +591,7 @@ sub get_input {
 
     my ($text, $num) = ($1, $2);
     
-    if($num ne "") {
+    if($num ne '') {
       ## Value can also be a HASH, we pick a key to make it scalar
       ## Assumes that all the values are of similar format
       if (ref $value eq "HASH") {

--- a/modules/Bio/EnsEMBL/VEP/FilterSet.pm
+++ b/modules/Bio/EnsEMBL/VEP/FilterSet.pm
@@ -591,9 +591,17 @@ sub get_input {
 
     my ($text, $num) = ($1, $2);
     
-    if($num ne '') {
+    if($num ne "") {
+      ## Value can also be a HASH, we pick a key to make it scalar
+      ## Assumes that all the values are of similar format
+      if (ref $value eq "HASH") {
+        $value = (keys %{$value})[0];
+      }
       if($value && $value =~ /^[\-\d\.e]+$/) {
         $input = $text =~ /^\-?\d+\.?\d*(e\-?\d+)?$/ ? $text : $num;
+      }
+      elsif($value =~ /([\w\.\-]+)?\:?\(?([\-\d\.e]*)\)?/) {
+        return $input;
       }
       else {
         $input = $text;


### PR DESCRIPTION
Issue: https://github.com/Ensembl/ensembl-vep/issues/1723

### Testing
```
filter_vep -i input.vcf --filter "HGNC_ID in HGNC:4836,HGNC:4826" --only_matched 
filter_vep -i input.vcf --filter "HGNC_ID in hgnc.txt" --only_matched 
filter_vep -i input.vcf --filter "HGNC_ID is HGNC:4836" --only_matched 
```



