### PR TITLE
Docker: Raise error if VEP version and release branch mismatch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,16 @@ WORKDIR $OPT_SRC
 # Add ensembl-vep files from current context
 ADD . ensembl-vep
 
+# For release branches, raise an error if VEP version does not match the branch name
+RUN if expr "$BRANCH" : "^release/.*" > /dev/null ; \
+    then \
+      branch_version=$(echo $BRANCH | sed -E 's|release/([0-9]+).*|\1|g'); \
+      vep_version=$(grep VEP_VERSION */modules/Bio/EnsEMBL/VEP/Constants.pm | grep -Eo '[0-9]+'); \
+      if [ $branch_version -ne $vep_version ]; then \
+        echo "ERROR: VEP version $vep_version does not match version in branch name '$BRANCH'"; exit 1; \
+      fi; \
+    fi
+
 # Clone/download repositories/libraries
 RUN if [ "$BRANCH" = "main" ]; \
     then export BRANCH_OPT=""; \


### PR DESCRIPTION
When the branch name to build the Docker image starts with `release/` (release branch), raise an error if there is a mismatch between VEP version and the version in the release branch name.

## Testing

Check Docker image build completes depending on the branch argument:
- If `ARG BRANCH=main`, it should build successfully
- If `ARG BRANCH=release/113`, it should pass (depending on the VEP version in [modules/Bio/EnsEMBL/VEP/Constants.pm](https://github.com/Ensembl/ensembl-vep/blob/main/modules/Bio/EnsEMBL/VEP/Constants.pm))
- If `ARG BRANCH=release/113.4`, it should pass (subversions are ignored)
- If `ARG BRANCH=release/112`, it should fail