### PR TITLE
Nextflow: add parameter to specify VEP version

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -55,10 +55,10 @@ The following config files are used and can be modified depending on user requir
 ```bash
 [Mandatory]
   --input FILE              Input file (if unsorted, use --sort to avoid errors in indexing the output file). Alternatively, can also be a directory containing input files
+  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: 'vep_config/vep.ini'
 
 [OPTIONAL]
   --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
-  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: 'vep_config/vep.ini'
   --vep_version VERSION     VEP version to use from Docker Hub (such as 113.0); only required when using Docker or Singularity profile. Default: 'latest'
   --cpus INT                Number of CPUs to use. Default: 1
   --outdir DIRNAME          Name of output directory. Default: outdir
@@ -76,12 +76,16 @@ The following config files are used and can be modified depending on user requir
 
 ### Example
 
+You need to create a `vep.ini` file based on `vep_config/vep.ini.template`.
+Always use absolute paths in `vep.ini` when indicating directories.
+
 ```bash
   nextflow run main.nf \
     --input ../examples/clinvar-testset/input.vcf \
+    --vep_config ../vep_config/vep.ini
     -profile slurm,singularity
  ```
-The above commands start the pipeline in SLURM using the Singularity image and
+The above command starts the pipeline in SLURM using the Singularity image and
 generates the output file upon completion.
 
 #### Output validation

--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -22,18 +22,21 @@ The nextflow pipeline requires **[Nextflow](https://www.nextflow.io)** (tested o
 <a id="setup"></a>
 ### Pipeline setup
 
-#### Config files
-
 The following config files are used and can be modified depending on user requirements:
 
 * VEP config file
     ``` bash
     cp vep_config/vep.ini.template vep_config/vep.ini
     ```
-
 * Nextflow config file
-
     `nextflow.config` has the default options for running the pipeline. The default options can be changed by directly modifying this file or by overriding them using command line options.
+* VEP cache (optional, but faster than using `database`)
+    VEP cache can be downloaded and extracted from the [Ensembl FTP][].
+    The VEP config file needs to contain the absolute path to the cache directory.
+    More detailed instructions are available in our [VEP cache documentation][].
+
+[Ensembl FTP]: https://ftp.ensembl.org/pub/current_variation/indexed_vep_cache
+[VEP cache documentation]: https://www.ensembl.org/info/docs/tools/vep/script/vep_cache.html#cache
 
 ---
 <a id="usage"></a>
@@ -42,24 +45,28 @@ The following config files are used and can be modified depending on user requir
 
 ```bash
   nextflow run main.nf \
+  -profile <profiles-to-use> \
   --input <path-to-file> \
-  -profile <standard or lsf or slurm>
+  --vep_config <path-to-vep-config>
 ```
 
 #### Options
 
 ```bash
+[Mandatory]
   --input FILE              Input file (if unsorted, use --sort to avoid errors in indexing the output file). Alternatively, can also be a directory containing input files
-  --bin_size INT            Number of variants used to split input VCF into multiple jobs. Default: 100
-  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
+
+[OPTIONAL]
+  --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
+  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: 'vep_config/vep.ini'
+  --vep_version VERSION     VEP version to use from Docker Hub (such as 113.0); only required when using Docker or Singularity profile. Default: 'latest'
   --cpus INT                Number of CPUs to use. Default: 1
   --outdir DIRNAME          Name of output directory. Default: outdir
   --output_prefix PREFIX    Output filename prefix. The generated output file will have name <output_prefix>_VEP.vcf.gz.
                             NOTE: Do not use this parameter if you are expecting multiple output files.
 
   --sort                    Sort VCF results from VEP (only required if input is unsorted; slower if enabled). Default: false
-  --filters STRING          Comma-separated list of filter conditions to pass to filter_vep,
-                            such as "AF < 0.01,Feature is ENST00000377918".
+  --filters STRING          Comma-separated list of filter conditions to pass to filter_vep, such as "AF < 0.01,Feature is ENST00000377918".
                             Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html
                             Default: null (filter_vep is not run)
 ```
@@ -72,9 +79,10 @@ The following config files are used and can be modified depending on user requir
 ```bash
   nextflow run main.nf \
     --input ../examples/clinvar-testset/input.vcf \
-    -profile slurm
+    -profile slurm,singularity
  ```
-The above commands start the pipeline in SLURM and generates the output file upon completion.
+The above commands start the pipeline in SLURM using the Singularity image and
+generates the output file upon completion.
 
 #### Output validation
 

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -9,6 +9,39 @@ params.output_prefix = ""
 params.bin_size = 100
 params.sort = false
 params.help = false
+params.vep_version = 'latest'
+
+// Check available VEP versions from Docker Hub
+vep_docker_tag = null
+if (params.vep_version) {
+  vep_docker_tag = params.vep_version == 'latest' ? 'latest' : "release_${params.vep_version}"
+  vep_docker = "ensemblorg/ensembl-vep:${vep_docker_tag}"
+
+  if (vep_docker_tag != 'latest') {
+    ANSI_RED    = "\u001B[31m"
+    ANSI_YELLOW = "\u001B[33m"
+    ANSI_RESET  = "\u001B[0m"
+
+    // Raise error message if there are issues getting the image
+    url = "https://hub.docker.com/v2/namespaces/ensemblorg/repositories/ensembl-vep/tags/${vep_docker_tag}"
+    con = new URL(url).openConnection()
+    status = con.responseCode
+    if (status != 200) {
+      msg = status == 404 ?
+        "image ${vep_docker} not found on Docker Hub" :
+        con.errorStream.text
+      System.err.println "\n" + ANSI_RED + "ERROR: " + msg + ANSI_RESET
+
+      // Warn if --vep_version does not contain VEP subversion
+      if ( params.vep_version ==~ /^\d+$/ ) {
+        msg = "Make sure you are including the VEP subversion in your command, such as: --vep_version ${params.vep_version}.0"
+        System.err.println ANSI_RED + msg.indent(0) + ANSI_RESET
+      }
+      System.exit 1
+    }
+    System.out.println ANSI_YELLOW + "Using image ${vep_docker}" + ANSI_RESET
+  }
+}
 
 process {
   cpus = 1
@@ -16,11 +49,11 @@ process {
   time = '8h'
 
   withLabel: bcftools {
-    container = 'docker://quay.io/biocontainers/bcftools:1.13--h3a49de5_0'
+    container = 'quay.io/biocontainers/bcftools:1.13--h3a49de5_0'
   }
 
   withLabel: vep {
-    container = 'docker://ensemblorg/ensembl-vep'
+    container = vep_docker
   }
 }
 

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -21,18 +21,25 @@ Pipeline to run VEP
 -------------------
 
 Usage:
-  nextflow run workflows/run_vep.nf --input <path-to-file> --vep_config vep_config/vep.ini
+  nextflow run main.nf -profile <profiles-to-use> --input <path-to-file> --vep_config <path-to-vep-config>
 
-Options:
+Parameters:
+
+[Mandatory]
   --input FILE              Input file (if unsorted, use --sort to avoid errors in indexing the output file). Alternatively, can also be a directory containing input files
+
+[OPTIONAL]
   --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
-  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: vep_config/vep.ini
+  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: 'vep_config/vep.ini'
+  --vep_version VERSION     VEP version to use from Docker Hub (such as 113.0); only required when using Docker or Singularity profile. Default: 'latest'
   --cpus INT                Number of CPUs to use. Default: 1
   --outdir DIRNAME          Name of output directory. Default: outdir
-  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <vcf>-<output_prefix>.vcf.gz
+  --output_prefix PREFIX    Output filename prefix. The generated output file will have name <output_prefix>_VEP.vcf.gz.
+                            NOTE: Do not use this parameter if you are expecting multiple output files.
 
   --sort                    Sort VCF results from VEP (only required if input is unsorted; slower if enabled). Default: false
-  --filter STRING           Comma-separated list of filter conditions to pass to filter_vep, such as "AF < 0.01,Feature is ENST00000377918".
+  --filters STRING          Comma-separated list of filter conditions to pass to filter_vep,
+                            such as "AF < 0.01,Feature is ENST00000377918".
                             Read more on how to write filters at https://ensembl.org/info/docs/tools/vep/script/vep_filter.html
                             Default: null (filter_vep is not run)
   """

--- a/nextflow/workflows/run_vep.nf
+++ b/nextflow/workflows/run_vep.nf
@@ -27,10 +27,10 @@ Parameters:
 
 [Mandatory]
   --input FILE              Input file (if unsorted, use --sort to avoid errors in indexing the output file). Alternatively, can also be a directory containing input files
+  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: 'vep_config/vep.ini'
 
 [OPTIONAL]
   --bin_size INT            Number of lines to split input into multiple jobs. Default: 100
-  --vep_config FILENAME     VEP config file. Alternatively, can also be a directory containing VEP INI files. Default: 'vep_config/vep.ini'
   --vep_version VERSION     VEP version to use from Docker Hub (such as 113.0); only required when using Docker or Singularity profile. Default: 'latest'
   --cpus INT                Number of CPUs to use. Default: 1
   --outdir DIRNAME          Name of output directory. Default: outdir


### PR DESCRIPTION
## Changelog

- New `--vep_version` parameter allows to specify the VEP version of the image downloaded from Docker Hub
- Add information on downloading VEP cache
- Improve documentation