### PR TITLE
Fix inconsistencies between --hgvs and --hgvsg

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Runner.pm
+++ b/modules/Bio/EnsEMBL/VEP/Runner.pm
@@ -731,11 +731,11 @@ sub post_setup_checks {
     $self->status_msg("INFO: Disabling --hgvs; using --offline and no FASTA file found\n");
     $self->param($_, 0) for qw(hgvs hgvsc hgvsp);
   }
-  
+
   # offline needs cache, can't use HGVS
   if($self->param('offline')) {
     unless($self->fasta_db) {
-      throw("ERROR: Cannot generate HGVS coordinates (--hgvs) in offline mode without a FASTA file (see --fasta)\n") if $self->param('hgvs') || $self->param('hgvsc') || $self->param('hgvsp');
+      throw("ERROR: Cannot generate HGVS coordinates (--hgvs and --hgvsg) in offline mode without a FASTA file (see --fasta)\n") if $self->param('hgvs') || $self->param('hgvsc') || $self->param('hgvsp') || $self->param('hgvsg');
       throw("ERROR: Cannot check reference sequences (--check_ref) without a FASTA file (see --fasta)\n") if $self->param('check_ref');
       throw("ERROR: Cannot look up reference sequences (--lookup_ref) without a FASTA file (see --fasta)\n") if $self->param('lookup_ref');
       throw("ERROR: Cannot use transcript reference sequences (--use_transcript_ref) without a FASTA file (see --fasta); you may wish to use --use_given_ref\n") if $self->param('use_transcript_ref');
@@ -755,7 +755,7 @@ sub post_setup_checks {
 
     # and these depend on either DB or FASTA DB
     unless($self->fasta_db) {
-      foreach my $param(grep {$self->param($_)} qw(hgvs hgvsc hgvsp lookup_ref check_ref use_transcript_ref)) {
+      foreach my $param(grep {$self->param($_)} qw(hgvs hgvsg lookup_ref check_ref use_transcript_ref)) {
         $self->status_msg("INFO: Database will be accessed when using --$param");
       }
     }


### PR DESCRIPTION
ENSVAR-3174

## Changelog

1. Currently, asking for HGVSg using offline and without FASTA, returns HGVSg using `N`s as reference sequence. The correct behaviour would be to mimic what is done with HGVS and error out.
2. When accessing the database to retrieve sequence for HGVSg, a warning should be printed informing the user of such (like done for HGVS).
3. When retrieving sequence from database using `--hgvs`, the message is printed three times:

```
2024-09-03 13:25:00 - INFO: Database will be accessed when using --hgvs
2024-09-03 13:25:00 - INFO: Database will be accessed when using --hgvsc
2024-09-03 13:25:00 - INFO: Database will be accessed when using --hgvsp
```

As `--hgvsc` and `--hgvsp` are internal parameters (not VEP arguments), they should be omitted from the message.

## Testing

1. `vep --hgvsg --offline --cache $vep_cache --id "1  230710048  rs699  A  G" --force` should raise an error:
    ```
    MSG: ERROR: Cannot generate HGVS coordinates (--hgvs and --hgvsg) in offline mode without a FASTA file (see --fasta)
    ```

2. `vep --hgvsg  --cache $vep_cache --id "1  230710048  rs699  A  G" --force` should warn that the database will be accessed to retrieve the sequence:
    ```
    2024-09-03 13:21:27 - INFO: Database will be accessed when using --hgvsg
    ```

4. `vep --hgvs --cache $vep_cache --id "1  230710048  rs699  A  G" --force` should only warn that the database is accessed to retrieve the sequence for `--hgvs`.