### PR TITLE
Remove deprecated funcgen function

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/RegFeat.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Database/RegFeat.pm
@@ -219,13 +219,6 @@ sub get_features_by_regions_uncached {
 
     foreach my $mf(@motif_features) {
       $mf->get_BindingMatrix->summary_as_hash();
-      if($self->{cell_type} && scalar(@{$self->{cell_type}})) {
-        my %cl =  
-          map {$_->[0] => $_->[1]}
-          map {$_->[0] =~ s/ /\_/g; $_}
-          map { [$_->name, 1] } @{$mf->get_all_Epigenomes_with_experimental_evidence};
-        $mf->{cell_types} = \%cl;
-      }
     }
     push @region_features,
       map { $_->{_vep_feature_type} ||= $type; $_ }


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6436

### Test

example variants - 
```
Y 26671671 . A G
Y 17430762 . G T
```

Check database annotation as it changes the database annotation source -
```
vep -i input.txt --database --force --regulatory 
```

It will give no output no output for `--cell_type` parameter (`CELL_TYPE=` in default VEP format)