### PR TITLE
Parse gene and transcript version from GFF/GTF file

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
@@ -478,12 +478,14 @@ sub _create_transcript {
     $tr_record->{strand}
   );
 
+  my $version = $tr_record->{attributes}->{version};
+
   my $tr = Bio::EnsEMBL::Transcript->new_fast({
     stable_id => $id,
     biotype   => $biotype,
     slice     => $slice,
     strand    => $tr_strand,
-    version   => 1,
+    version   => $version,
     dbID      => $self->{_tr_dbID}++,
     start     => $tr_start,
     end       => $tr_end,
@@ -632,8 +634,9 @@ sub _add_identifiers {
 
   $tr->{_source_cache} = $self->short_name;
 
-  # get gene ID
+  # get gene ID and version
   $tr->{_gene_stable_id} = $tr_record->{attributes}->{gene_id};
+  $tr->{_gene_version} = $gene_record->{attributes}->{version};
 
   if(!$tr->{_gene_stable_id}) {
     foreach my $pair(split(',', $tr_record->{attributes}->{dbxref} || $tr_record->{attributes}->{Dbxref} || '')) {

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1387,7 +1387,7 @@ sub BaseTranscriptVariationAllele_to_output_hash {
   # basics
   $hash->{Feature_type} = 'Transcript';
   $hash->{Feature}      = $tr->stable_id if $tr;
-  $hash->{Feature}     .= '.'.$tr->version if $hash->{Feature} && $self->{transcript_version} && $hash->{Feature} !~ /\.\d+$/;
+  $hash->{Feature}     .= '.'.$tr->version if $hash->{Feature} && $self->{transcript_version} && $tr->version && $hash->{Feature} !~ /\.\d+$/;
 
   # get gene
   $hash->{Gene} = $tr->{_gene_stable_id};


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2775

Transcript version is always `1` when GFF file is used. It seems it has been hard coded. This PR fixes this issue - 
- try to read version from GFF/GTF file
- if there is no version in the file reports no version even if `--transcript_version` is given.

### Test
Test with `rs699` and see if it matches transcript and gene version -
```
vep --id "1 230710048 rs699 A G" --force --gff /pathto/genes.gff3.bgz --fasta /pathto/Homo_sapiens.GRCh38.dna.toplevel.fa.gz --transcript_version --gene_version
```

Check the ticket for GFF and FASTA file location for testing.