### PR TITLE
Downstream changes for get_end fix in VCF parser

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -551,7 +551,7 @@ sub create_StructuralVariationFeatures {
     $parser->get_outer_end,
   );
 
-  if($start >= $end && $so_term =~ /del/i) {
+  if($start > $end && $so_term =~ /del/i) {
     $self->skipped_variant_msg("deletion looks incomplete");
     $skip_line = 1;
   }

--- a/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm
@@ -551,7 +551,7 @@ sub create_StructuralVariationFeatures {
     $parser->get_outer_end,
   );
 
-  if($start > $end && $so_term =~ /del/i) {
+  if(($start > $end || (!defined $info->{SVLEN} && !defined $info->{END})) && $so_term =~ /del/i) {
     $self->skipped_variant_msg("deletion looks incomplete");
     $skip_line = 1;
   }

--- a/t/AnnotationSource_File_VCF.t
+++ b/t/AnnotationSource_File_VCF.t
@@ -431,7 +431,7 @@ SKIP: {
     config => $cfg,
     parser => Bio::EnsEMBL::VEP::Parser::VCF->new({
       config => $cfg,
-      file => $test_cfg->create_input_file([qw(21 25585735 . G . . . SVTYPE=DEL;SVLEN=2)]),
+      file => $test_cfg->create_input_file([qw(21 25585735 . T . . . SVTYPE=DEL;SVLEN=1)]),
       valid_chromosomes => [21]
     })
   });

--- a/t/Parser_VCF.t
+++ b/t/Parser_VCF.t
@@ -767,11 +767,11 @@ is_deeply($bnd_vf, bless( {
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
-                 'end' => 68914095,
-                 'inner_end' => 68914095,
-                 'outer_end' => 68914095,
+                 'end' => 68914093,
+                 'inner_end' => 68914093,
+                 'outer_end' => 68914093,
                  'seq_region_start' => 68914093,
-                 'seq_region_end' => 68914095
+                 'seq_region_end' => 68914093
                },
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
                'StructuralVariationFeature - BND with unsupported INFO/END field');
@@ -869,14 +869,14 @@ is_deeply($bnd5_vf, bless( {
                  'start' => 68914093,
                  'inner_start' => 68914093,
                  'outer_start' => 68914093,
-                 'end' => 68914095,
-                 'inner_end' => 68914095,
-                 'outer_end' => 68914095,
+                 'end' => 68914094,
+                 'inner_end' => 68914094,
+                 'outer_end' => 68914094,
                  'seq_region_start' => 68914093,
-                 'seq_region_end' => 68914095
+                 'seq_region_end' => 68914094
                },
                'Bio::EnsEMBL::Variation::StructuralVariationFeature' ) ,
-               'StructuralVariationFeature - BND with unsupported INFO/END field');
+               'StructuralVariationFeature - BND with undefined INFO/END field');
 
 ## test tandem repeats
 


### PR DESCRIPTION
Depends on https://github.com/Ensembl/ensembl-io/pull/171

### Skipping variant:
We were skipping SV deletion type variant if `start >= end`. The case `start = end` can be a valid case, for example, when SVLEN=1. 
Fixed that check to see if `start > end` or if there is no SVLEN or END information.

### Unit test fix:
#### AnnotationSource_File_VCF.t
The type is `exact` and the custom line is as follows -
```
21	25585735	del2	TG	T	67	SEGDUP;RF
```
So it deletes the G at 25585736 position. Correct way to represent it in SVLEN is with POS=25585736, REF=T (always use the base before polymorphism happens) and SVELN=1 (the difference between ref and alt sequence).

#### Parser_VCF.t
The BND are case affected by the ensembl-io change because it does not have any SVLEN and END. The end here we will  be now `end=start`. Before it was getting `end=start+ref length-1`. END position are not exactly clear for BND but the former ones seems more clear.

