### PR TITLE
Bugfix: division by zero in overlaps

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -532,14 +532,16 @@ sub _record_overlaps_VF {
     # check overlap percentage
     my @overlap_start = sort { $a <=> $b } ($vs, $ref_start);
     my @overlap_end   = sort { $a <=> $b } ($ve, $ref_end);
-    my $overlap_percentage = 100 * (1 + $overlap_end[0] - $overlap_start[1]) / $length;
+    my $overlap_percentage = $length != 0 ? 100 * (1 + $overlap_end[0] - $overlap_start[1]) / $length : 100;
 
     return 0 if $overlap_percentage < $overlap_cutoff;
 
     if ($reciprocal) {
       # check bi-directional overlap - percentage of reference variant covered
       my $ref_length = $ref_end - $ref_start + 1;
-      my $ref_overlap_percentage = 100 * (1 + $overlap_end[0] - $overlap_start[1]) / $ref_length;
+
+      # in some cases $ref_length can be 0, for example in old VCF with single base deletion without INFO/SVLEN
+      my $ref_overlap_percentage = $ref_length != 0 ? 100 * (1 + $overlap_end[0] - $overlap_start[1]) / $ref_length : 100;
       return 0 if $ref_overlap_percentage < $overlap_cutoff;
 
       # report minimum overlap


### PR DESCRIPTION
https://github.com/Ensembl/ensembl-vep/issues/1765

The issue should primarily be fixed by - https://github.com/Ensembl/ensembl-io/pull/171
But this PR add checks for length to be zero and if so set the overlap percentage to be 100%. This can happen for old VCF format where `INFO/SVLEN` is missing and end position is calculated from `INFO/END`.

### Test
input.vcf - 
```
2	240692045	.	G	<DEL>	.	PASS	SVLEN=100
```

custom.vcf -
```
2       240692045       nssv211104      G       <DEL>   .       .       DBVARID=nssv211104;SVTYPE=DEL;END=240692045
```

CMD:
```
vep -i input.vcf --force --cache <cache_dir> --offline --cache_version 111 -a GRCh38 --custom file=custom.vcf,short_name=test,fields=DBVARID,num_records=all,reciprocal=1,format=vcf,coords=1,type=overlap,overlap_cutoff=0
```