### PR TITLE
Force set --offline if no database setup

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -114,7 +114,11 @@ sub setup_db_connection {
   my $self = shift;
 
   return if $self->param('offline');
-  return unless $self->param('database') || $self->param('cache');
+  unless ( $self->param('database') || $self->param('cache') ) {
+    # set offline in case other parts of code tries to connect to db
+    $self->{_config}->param('offline', 1);
+    return;
+  }
 
   # doing this inits the registry and DB connection
   my $reg = $self->registry();

--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -116,6 +116,7 @@ sub setup_db_connection {
   return if $self->param('offline');
   unless ( $self->param('database') || $self->param('cache') ) {
     # set offline in case other parts of code tries to connect to db
+    $self->warning_msg("Setting offline mode. To create database connection use either --database or --cache.");
     $self->{_config}->param('offline', 1);
     return;
   }


### PR DESCRIPTION
When we do not provide `--database` or `--cache` VEP does not setup database connection just like `--offline`. But some part of the code is not aware of this fact and tries to connect to database and fails. 

An example is when VEP is used with `--gff` and `--fasta` and provided with input that contains variant ids which does not work without database. VEP will fail with message - 
```
Can't call method "db" on an undefined value at /opt/vep/src/ensembl-vep/modules/Bio/EnsEMBL/VEP/Parser/ID.pm line 159, <__ANONIO__> line 1
```

Which is misleading. Also VEP should not try to connect to database in this scenario.

In this PR we force set `--offline` if no database setup is made.
