### PR TITLE
Remove redundant print in multi-file custom

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm
@@ -312,7 +312,6 @@ sub get_all_custom {
       my @valid_chromosomes = keys %{$self->chr_lengths} > 0 ? sort keys %{$self->chr_lengths}: ((1..22), qw(X Y MT));
       
       foreach my $chr (@valid_chromosomes){
-        print $chr."\n";
         my $new_file = $hash{"file"};
         my $new_opts = { %$opts };
         $new_file =~ s/\#\#\#CHR\#\#\#/$chr/;


### PR DESCRIPTION
There is a rogue print in custom annotation implementation of ingesting multiple files. 