### PR TITLE
fix: reinstate changes from PR #1853

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -2372,6 +2372,16 @@ sub get_custom_headers {
 
     foreach my $field(@{$custom->{fields} || []}) {
       my $sub_id = sprintf("%s_%s", $custom->{short_name}, $field);
+
+      # Determine the description to use:
+      # - If the custom annotation already contains a proper description for this field,
+      #   use that description
+      # - Otherwise, use a default string that says "<field> field from <masked_file>"
+      my $desc =
+        exists $custom->{field_descriptions}->{$field}
+        ? $custom->{field_descriptions}->{$field}
+        : sprintf( "%s field from %s", $field, $masked_file );
+
       if (grep { /^$sub_id$/ } @flatten_header){
         my $pos = $pos{$sub_id} / 2;
         $headers[$pos][1] .= ",$masked_file";
@@ -2380,11 +2390,10 @@ sub get_custom_headers {
           $sub_id,
           sprintf($custom->{overlap_def} . " from %s", $masked_file)
         ];
+      
+      # Otherwise, add a new header row with the sub_id and the determined description above
       } else {
-        push @headers, [
-          $sub_id,
-          sprintf("%s field from %s", $field, $masked_file)
-        ];
+        push @headers, [ $sub_id, $desc ];
       }
     }
 

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm
@@ -95,6 +95,8 @@ use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 use Bio::EnsEMBL::VEP::Utils qw(convert_arrayref get_version_data);
 use Bio::EnsEMBL::VEP::Constants;
 
+use Bio::EnsEMBL::IO::Parser::VCF4Tabix;
+
 my @VCF_COLS = qw(
   Allele
   Consequence
@@ -166,6 +168,31 @@ sub new {
 
 sub headers {
   my $self = shift;
+
+  # load real INFO descriptions
+  foreach my $ci (@{ $self->header_info->{custom_info} || [] }) {
+
+    # only tabix-parse vcf/vcf.gz/.vcf.bgz for ## header fields
+    next unless $ci->{file} =~ /\.vcf(?:\.(?:gz|bgz))?$/i;
+    next if exists $ci->{field_descriptions};
+
+    my %desc;
+    eval {
+
+      # use tabix parser to grab header (##) rows
+      my $p = Bio::EnsEMBL::IO::Parser::VCF4Tabix->open($ci->{file});
+      my $meta = $p->get_metadata_by_pragma('INFO');
+
+      # loop over meta entries, keep only if 'ID' and 'Description' exist
+      for my $e (@{$meta||[]}) {
+        next unless defined $e->{ID} && defined $e->{Description};
+        $desc{ $e->{ID} } = $e->{Description};
+      }
+    };
+
+    # store in custom_info obj
+    $ci->{field_descriptions} = \%desc;
+  }
 
   my $info = $self->header_info;
   my $field_descs = \%Bio::EnsEMBL::VEP::Constants::FIELD_DESCRIPTIONS;


### PR DESCRIPTION
## Description

This PR fixes the issue reported in #918 where the INFO header fields for custom annotation VCF files (supplied via the `--custom flag`) were not displaying the actual description from the custom file’s header. Instead, the output VCF showed a generic masked file path description. This PR addresses this such that the output VCF header now displays the correct INFO field descriptions as specified in the header of the file supplied to `--custom`.

## Changes to the PR

 **1.**  **AnnotationSource/File/VCF.pm**
- **Previously:** I'd added the \_extract_info_descriptions helper and called it from the constructor sub. 
- **Why this caused an issue?**: At that point the file hadn’t been set up with its real parser, so I was repeatedly hitting the fallback parser (return \$self->{parser} ||= Bio::EnsEMBL::IO::Parser::VCF4Tabix->open($self->file);). An additional test failed as it didn't expected the new field_descriptions key in the custom‐info object.
- **Now**: I've removed this logic from AnnotationSource/File/VCF.pm, reverting it back to it's state on main branch - this logic now acts later on in the OutputFactory VCF module. 

**2.** **VEP/OutputFactory.pm**
- **The changes here remain** - this logic chooses whether a real or generic description is propagated.

**3.** **VEP/OutputFactory/VCF.pm**
- **This is a new change:** OutputFactory is where VEP assembles its VCF output headers - I have added, at the top of the headers method, a loop that opens any vcf/vcf.gz/vcf.bgz and stores any field descriptions. 
- **Why this change?**:
    - This means that custom header extraction is now carried out as the output is being prepared, and after the correct parser has been assigned.

## Use case

When a VCF file is supplied to the `--custom` flag, the expected behaviour is for the INFO header lines in the output VCF to reflect the field descriptions provided in the custom file’s header. For example, if the custom file has an INFO field defined as:

```
##INFO=<ID=gnomAD_AF_ASJ,Number=A,Type=Float,Description="Allele Frequency among Ashkenazi Jewish genotypes, for each ALT allele, in the same order as listed">
```

then the output VCF header should use that description. Prior to this fix, the output header would instead show:

```
##INFO=<ID=gnomAD_AF_ASJ,Number=.,Type=String,Description="AF_ASJ field from [PATH]/gnomad.genomes.v4.1.sites.chr2.vcf.bgz">
```

This PR addresses that discrepancy by correctly parsing and propagating the real description.

## Benefits

- The output VCF now reflects the actual INFO field descriptions from the custom file - this will reduce confusion, as the VEP output file will directly reflect the source file.

## Possible Drawbacks

- Minor changes in header formatting may require additional testing with various custom file formats to ensure compatibility.

## Testing

- Travis tests passed locally
- I used the following test to confirm the new behaviour: 

```
cd /hps/software/users/ensembl/variation/fairbrot/ensembl-vep/

./vep \
    --input_file /hps/nobackup/flicek/ensembl/variation/fairbrot/tickets/6365_918/chr2_subset_100_NA12878.vcf.gz \
    --output_file "/hps/nobackup/flicek/ensembl/variation/fairbrot/tickets/6365_918/reproduce.vcf" \
    --format vcf \
    --vcf \
    --offline \
    --cache \
    --cache_version 113 \
    --dir_cache /nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted \
    --assembly GRCh38 \
    --fasta /nfs/production/flicek/ensembl/variation/data/Homo_sapiens.GRCh38.dna.toplevel.fa.gz \
    --verbose \
    --force_overwrite \
    --custom file=/hps/nobackup/flicek/ensembl/variation/fairbrot/tickets/6365_918/gnomad_small_test.vcf.gz,short_name=gnomAD,fields=AC_afr%AF_afr%AN_afr,format=vcf,type=exact,coords=0

```
- The output file should contain the following INFO fields: 

```
##INFO=<ID=gnomAD_AC_afr,Number=.,Type=String,Description="Alternate allele count for samples in the African/African-American genetic ancestry group">
##INFO=<ID=gnomAD_AF_afr,Number=.,Type=String,Description="Alternate allele frequency in samples in the African/African-American genetic ancestry group">
##INFO=<ID=gnomAD_AN_afr,Number=.,Type=String,Description="Total number of alleles in samples in the African/African-American genetic ancestry group">
```