### PR TITLE
Proper allele matching for fetching HGVSg

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -1328,7 +1328,8 @@ sub VariationFeatureOverlapAllele_to_output_hash {
       $vf->{_hgvs_genomic} ||= $vf->hgvs_genomic($vf->slice, $self->{hgvsg_use_accession} ? undef : $vf->{chr});
     }
 
-    if(my $hgvsg = $vf->{_hgvs_genomic}->{$vfoa->variation_feature_seq}) {
+    my $allele_string = (split(/\//,$vf->{allele_string}))[$vfoa->allele_number];
+    if(my $hgvsg = $vf->{_hgvs_genomic}->{$allele_string}) {
       $hash->{HGVSg} = $hgvsg; 
     }
   }


### PR DESCRIPTION
### Issue
Reported in https://github.com/Ensembl/ensembl-vep/issues/1867. VEP result mismatch for HGVSg and ClinVar custom annotation when using shift_3prime and not.

#### HGVSg
We store hgvsg in a hash with allele as a key. This allele is taken from the allele_string of vf - [see](https://github.com/Ensembl/ensembl-variation/blob/ebfce7401437567284b8d6b4e8bbcdb0cc64b898/modules/Bio/EnsEMBL/Variation/VariationFeature.pm#L2039)
But when we try to derive it in VEP OutputFactory we query by allele derived from TranscriptOverlap object - [see](https://github.com/Ensembl/ensembl-vep/blob/a6786e4357f442a81624f58d9e79f343909d717f/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1317). 

#### ClinVar custom annotation
With shift_hgvs the allele has been shifted. And, with `exact` option VEP will try to do an exact allele match. So it is correct that we are not seeing any overlaps. Except the last transcript, which is non coding transcript, the allele is not getting shifted. It turns now that non coding transcript does not get their allele shifted even if shift_3prime is enabled. This should be known bug for now.