### PR TITLE
nextflow-vep: consider file name containing dot (.)

### DIFF
--- a/nextflow/modules/merge_VCF.nf
+++ b/nextflow/modules/merge_VCF.nf
@@ -32,7 +32,7 @@ process mergeVCF {
   one_to_many = meta.one_to_many
   output_dir = meta.output_dir
   
-  merged_vcf = merged_vcf ?: file(original_file).getSimpleName() + "_VEP.vcf.gz"
+  merged_vcf = merged_vcf ?: file(original_file).getBaseName() + "_VEP.vcf.gz"
   merged_vcf = one_to_many ? merged_vcf.replace(
     "_VEP.vcf", 
     "_" + file(vep_config).getName().replace(".ini", "") + "_VEP.vcf"


### PR DESCRIPTION
When we have input file name with dot nextflow-vep remove all the text after the first dot to create the filename. We only only want to remove the extension.

e.g. - test.vcf.gz --> test.vcf_VEP.vcf.gz

[this PR does not consider if the file is bgzipped or not complications]

Support how client discovers VEP output file in beta site -
https://github.com/Ensembl/ensembl-web-tools-api/blob/main/app/vep/vep_resources.py#L119-L124


### Test
Any variant with file name ending with `.vcf` and `.vcf.gz`. 