### PR TITLE
Add no_missing_consequence_warning to filter_vep

### DIFF
--- a/filter_vep
+++ b/filter_vep
@@ -86,6 +86,7 @@ sub configure {
     'vcf_info_field=s',        # VCF INFO field name to parse
     'soft_filter',             # do not exclude variants failing the filter - add a flag to the FILTER value in the vcf
                                # 'filter_vep_pass' variant passed the filter; 'filter_vep_fail' variant failed the filter 
+    'no_missing_consequence_warning',  # do not output missing consequence warning
 
     'ontology|y',              # use ontology for matching consequence terms
     'host=s',                  # DB options
@@ -342,7 +343,7 @@ sub main {
   print $out_fh "$count\n" if defined($config->{count});
 
   # If the VEP annotations INFO field (default value: CSQ) hasn't been found (or recognised) in at least 1 VCF input line.
-  if ($missing_vcf_info_field) {
+  if ($missing_vcf_info_field and not $config->{no_missing_consequence_warning}) {
     warning("The script 'filter_vep' couldn't find the VEP annotations INFO field $vcf_info_field in $missing_vcf_info_field lines of the input file");
   }
 }
@@ -413,7 +414,7 @@ sub parse_line {
   for(@$headers) {
     $data{$_} = undef unless exists($data{$_});
   }
-  
+
   return \%data;
 }
 


### PR DESCRIPTION
Add `-no_missing_consequence_warning` option that can optionally avoid printing warning message for no CSQ field found like below -  

```
-------------------- WARNING ----------------------
MSG: The script 'filter_vep' couldn't find the VEP annotations INFO field CSQ in 252 lines of the input file
FILE: snhossain/ensembl-vep/filter_vep LINE: 346
CALLED BY: snhossain/ensembl-vep/filter_vep  LINE: 55
Date (localtime)    = Fri Jul 11 14:58:46 2025
Ensembl API version = 114
---------------------------------------------------
```

This can then be used in web VEP output filter. This warning message is not useful there and hampers parsing.