### PR TITLE
Typo: avoid warning for un-initialized string

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -152,7 +152,7 @@ sub new {
   $self->file($hashref->{file});
 
   $hashref->{short_name} = $self->short_name($hashref->{short_name} || (
-      $hashref->{gff_type} eq "gencode_promoter" ? 
+      $hashref->{gff_type} && $hashref->{gff_type} eq "gencode_promoter" ? 
         "GENCODE_PROMOTER" :
         split '/', $self->file)[-1]
     );


### PR DESCRIPTION
Fixed a typo where a hashref field is used before checking existence. Does not cause failure but to avoid getting warning in the output.

**Test**
run `perl t/AnnotationSource_File_VCF.t`