### PR TITLE
Small patches

### DIFF
--- a/nextflow/modules/run_vep.nf
+++ b/nextflow/modules/run_vep.nf
@@ -45,8 +45,9 @@ process runVEP {
     for (filter in filters) {
       filter_arg = filter_arg + "-filter \"" + filter + "\" "
     }
-    vep_cmd = "vep -i ${input} -o STDOUT --vcf --config ${vep_config} | filter_vep -o out.vcf --force_overwrite --only_matched ${filter_arg}"
-
+    // write VEP output to a file, then run filter_vep on that file
+    vep_cmd = "vep -i ${input} -o vep.raw.vcf --vcf --config ${vep_config}; " +
+              "filter_vep --format vcf -i vep.raw.vcf -o out.vcf --force_overwrite --only_matched ${filter_arg}"
   }
   else {
     vep_cmd = "vep -i ${input} -o out.vcf --vcf --config ${vep_config}"


### PR DESCRIPTION
Added one patch: 

- During the VEP step, vep passes the vcf via stdout to filter_vep, this errored because VEP was passing containing a header containing a WARNING line at the top, i.e.:
```
WARNING: --gencode_primary option is currently only available for human on the GRCh38 assembly
##fileformat=VCFv4.2
##FILTER=<ID=PASS,Description="All filters passed">
```
- So I patched it to generate one file, then the next, not passing through stdout. 