### PR TITLE
Fix Uploaded_variation

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -897,7 +897,8 @@ sub VariationFeature_to_output_hash {
         # Try to reconstruct the user-style variant using to_VCF_record to get an un-minimised version
         # This is because original_start, original_end are polluted with minimisation
         my ($chr, $pos, undef, $ref, $alt) = @{$vf->to_VCF_record}[0..4];
-        die "multi-allelic" if defined $alt && $alt =~ /,/;   # skip if multi-allelic
+        # skip if multi-allelic
+        die "multi-allelic" if defined $alt && $alt =~ /,/;
         $uv = join('_', $chr, $pos+0, ($ref // '-').'/'.($alt // '-'));
       };
       # Fallback to legacy behaviour if multi-allelic or to_VCF_record fails


### PR DESCRIPTION
This PR aims to fix #1930. 

Previously, `Uploaded_variation` was displaying a minimised start position instead of the original input. 

Example input: 
```
##fileformat=VCFv4.2
##source=test
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
chr2	47806652	.	G	GTAAC	.	PASS	.
chr2	47806652	.	GTAAC	G	.	PASS	.
chr2	47806652	.	G	A	.	PASS	.
chr2	47806652	.	GT	G	.	PASS	.
chr2	47806652	.	G	GTAAC,A	.	PASS	.
```

VEP command: 
```bash
./vep \
-i in.vcf \
-o out.tsv \
--offline \
--dir_cache tabixconverted \
--cache_version 115 \
--format vcf \
--cache \
--fasta Homo_sapiens.GRCh38.dna.toplevel.fa.gz \
--refseq \
--pick \
--hgvs \
--symbol \
--canonical \
--tab \
--assembly GRCh38 \
--force_overwrite \
--no_escape \
--show_ref_allele \
--uploaded_allele
```

Output **before** fix: 
```
#Uploaded_variation
chr2_47806653_G/GTAAC
chr2_47806653_GTAAC/G
chr2_47806652_G/A
chr2_47806653_GT/G
chr2_47806652_G/GTAAC/A
```

Output **after** fix: 
```
chr2_47806652_G/GTAAC
chr2_47806652_GTAAC/G
chr2_47806652_G/A
chr2_47806652_GT/G
chr2_47806652_G/GTAAC/A
```

For multi-allelic inputs, this simply reverts to legacy behaviour, as this output seems acceptable, but also multi-allelic/Uploaded_allele handling is a known bug, and out of scope for this PR.