### PR TITLE
Bugfix: custom annotation reciprocal feature

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -546,21 +546,16 @@ sub _record_overlaps_VF {
     my $overlap_percentage = $length != 0 ? 100 * (1 + $overlap_end[0] - $overlap_start[1]) / $length : 100;
 
     unless ($reciprocal) {
-      # check bi-directional overlap - percentage of reference variant covered
+      # when reciprocal = 0, check percentage of reference (annotation) variant covered
       my $ref_length = $ref_end - $ref_start + 1;
 
       # in some cases $ref_length can be 0, for example in old VCF with single base deletion without INFO/SVLEN
       my $ref_overlap_percentage = $ref_length != 0 ? 100 * (1 + $overlap_end[0] - $overlap_start[1]) / $ref_length : 100;
-	  return 0 if $ref_overlap_percentage < $overlap_cutoff;
 
-      # report minimum overlap
-      if ($ref_overlap_percentage < $overlap_percentage) {
-        $overlap_percentage = $ref_overlap_percentage;
-      }
+      $overlap_percentage = $ref_overlap_percentage;
     }
-	else {
-		return 0 if $overlap_percentage < $overlap_cutoff;
-	}
+
+	return 0 if $overlap_percentage < $overlap_cutoff;
 
     $overlap_percentage = sprintf("%.3f", $overlap_percentage);
     return overlap($ref_start, $ref_end, $vs, $ve), $overlap_percentage;


### PR DESCRIPTION
https://github.com/Ensembl/ensembl-vep/issues/1914

According to [doc](https://www.ensembl.org/info/docs/tools/vep/script/vep_custom.html)

- `reciprocal=0` should calculate percentage of annotation - so `overlap length/annotation length`
- `reciprocal=1` should calculate percentage of variation - so `overlap length/variation length`

currently we are doing opposite.

Also, with checking `return 0 if $overlap_percentage < $overlap_cutoff;` we were not considering `reciprocal=1` in many cases.