### PR TITLE
Add flag to turn off cache path leaking in header

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -417,7 +417,7 @@ sub get_output_header_info {
       $info->{version_data}->{$_} ||= $as_info->{$_} for grep {$_ ne 'custom_info'} keys %$as_info;
       if($as->can('dir')) {
         my $cache_dir = $as->dir;
-        $cache_dir = Bio::EnsEMBL::VEP::Config::mask_data_paths($cache_dir) if $self->param('mask_cache_path');
+        $cache_dir = Bio::EnsEMBL::VEP::Config::mask_data_paths($cache_dir) if $self->param('mask_header_cache_path');
         $info->{cache_dir} ||= $cache_dir if defined $cache_dir;
       }
       push @{$info->{custom_info}}, $as_info->{custom_info} if $as_info->{custom_info};

--- a/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
+++ b/modules/Bio/EnsEMBL/VEP/BaseRunner.pm
@@ -415,7 +415,11 @@ sub get_output_header_info {
     foreach my $as(@{$self->get_all_AnnotationSources}) {
       my $as_info = $as->info;
       $info->{version_data}->{$_} ||= $as_info->{$_} for grep {$_ ne 'custom_info'} keys %$as_info;
-      $info->{cache_dir} ||= $as->dir if $as->can('dir');
+      if($as->can('dir')) {
+        my $cache_dir = $as->dir;
+        $cache_dir = Bio::EnsEMBL::VEP::Config::mask_data_paths($cache_dir) if $self->param('mask_cache_path');
+        $info->{cache_dir} ||= $cache_dir if defined $cache_dir;
+      }
       push @{$info->{custom_info}}, $as_info->{custom_info} if $as_info->{custom_info};
     }
 

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -165,7 +165,7 @@ our @VEP_PARAMS = (
   'output_file|o=s@',        # output file name
   'compress_output=s',       # compress output with e.g. bgzip, gzip
   'no_headers',              # don't print headers
-  'mask_cache_path',         # mask cache directory in output headers/stats metadata
+  'mask_header_cache_path',  # mask cache directory in output headers/stats metadata
   'stats_file|sf=s',         # stats file name
   'stats_text',              # write stats as text
   'stats_html',              # write stats as html
@@ -768,9 +768,9 @@ sub new {
 =head2 mask_data_paths
 
   Arg 1      : string $value
-  Example    : $masked = mask_data_paths('/foo/bar/cache/homo_sapiens/115_GRCh38')
+  Example    : $masked = mask_data_paths('/path/to/cache/homo_sapiens/11X_GRCh38')
   Description: Replaces internal path components with [PATH]/ while preserving
-               the final filename/directory component.
+               the final filename.
   Returntype : string
   Exceptions : none
   Caller     : new(), BaseRunner

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -165,6 +165,7 @@ our @VEP_PARAMS = (
   'output_file|o=s@',        # output file name
   'compress_output=s',       # compress output with e.g. bgzip, gzip
   'no_headers',              # don't print headers
+  'mask_cache_path',         # mask cache directory in output headers/stats metadata
   'stats_file|sf=s',         # stats file name
   'stats_text',              # write stats as text
   'stats_html',              # write stats as html
@@ -729,8 +730,7 @@ sub new {
     $value = join(" --$flag ", @{$value}) if ref($value) eq "ARRAY";
 
     # replace most of the provided path with [PATH]/
-    my $delim = $^O eq "MSWin32" ? '\\' : '/';
-    $value =~ s|[^,=]+$delim(?! )(?!,)(?!$)|[PATH]$delim|g;
+    $value = mask_data_paths($value);
 
     $config_command .= $value eq 1? "--$flag "  : "--$flag $value ";
   }
@@ -762,6 +762,30 @@ sub new {
   $self->{_params} = $config;
     
   return $self;
+}
+
+
+=head2 mask_data_paths
+
+  Arg 1      : string $value
+  Example    : $masked = mask_data_paths('/foo/bar/cache/homo_sapiens/115_GRCh38')
+  Description: Replaces internal path components with [PATH]/ while preserving
+               the final filename/directory component.
+  Returntype : string
+  Exceptions : none
+  Caller     : new(), BaseRunner
+  Status     : Stable
+
+=cut
+
+sub mask_data_paths {
+  my $value = shift;
+  return $value unless defined $value;
+
+  my $delim = $^O eq "MSWin32" ? '\\' : '/';
+  $value =~ s|[^,=]+$delim(?! )(?!,)(?!$)|[PATH]$delim|g;
+
+  return $value;
 }
 
 


### PR DESCRIPTION
See ENSVAR-6971 & issue #1971.

This PR fixes the cache path leaking in the VEP output file header line.  Masking behaviour for cache in header off by default, `--mask_header_cache_path` switches masking on. 

Before: 
```
##VEP="v115.0" API="v115" time="2026-02-13 15:08:56" cache="/nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted/homo_sapiens/115_GRCh38" 1000genomes="phase3" ....
```

After: 
```
##VEP="v115.0" API="v115" time="2026-02-13 15:08:57" cache="[PATH]/115_GRCh38" 1000genomes="phase3" ....
```