### PR TITLE
Fix fork limit off-by-one in convert_cache.pl

### DIFF
--- a/convert_cache.pl
+++ b/convert_cache.pl
@@ -248,7 +248,7 @@ sub main {
           while(keys %$chr_files or $active_forks) {
 
             # only spawn new forks if we have space
-            if($active_forks <= $fork_number) {
+            if($active_forks < $fork_number) {
 
               my $chr = (keys %$chr_files)[0];
               my $files = delete($chr_files->{$chr});


### PR DESCRIPTION
## Summary
Fixes an off-by-one error in the parallel fork control logic in `convert_cache.pl`.

## Issue
The condition:
  if ($active_forks <= $fork_number)

allowed spawning one extra child process beyond the intended fork limit.

## Fix
Updated condition to:
  if ($active_forks < $fork_number)

This ensures the number of active child processes never exceeds the specified limit.

## Impact
- Prevents resource overuse during parallel execution
- Keeps fork pool size consistent with user-defined `--fork` value
- No API or behavioral changes beyond correcting the limit

## Scope
- Single-line fix in `convert_cache.pl`
- No additional changes included to keep PR minimal and focused

## Testing
Validated with:
perl convert_cache.pl --species hsapiens --version 109 --dir <cache_dir> --fork 4

Confirmed that no extra child processes are spawned beyond the specified fork limit.