### PR TITLE
[Custom annotation] SV insertion coord fix

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -526,7 +526,10 @@ sub _record_overlaps_VF {
   if (defined $self->{_format} && $self->{_format} eq 'vcf' && $parser->get_raw_alternatives =~ /INS/) {
     $ref_end = ($ref_start + length($parser->get_raw_reference) - 1);
   }
-  $ref_start += 1 if defined $self->{_format} && $self->{_format} eq 'bigwig';
+  elsif (defined $self->{_format} && $self->{_format} eq 'bigwig') {
+    # BigWig format is 0-based half-open
+    $ref_start += 1;
+  }
 
   if($type eq 'overlap' || $type eq 'within' || $type eq 'surrounding') {
     # account for insertions in Ensembl world where s = e+1

--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File.pm
@@ -521,6 +521,11 @@ sub _record_overlaps_VF {
   my $reciprocal = $self->{reciprocal};
 
   my ($ref_start, $ref_end) = ($parser->get_start, $parser->get_end);
+  # For VCF, insertion should not take alt length into account
+  # Note: File::VCF ensures we only have SV here
+  if (defined $self->{_format} && $self->{_format} eq 'vcf' && $parser->get_raw_alternatives =~ /INS/) {
+    $ref_end = ($ref_start + length($parser->get_raw_reference) - 1);
+  }
   $ref_start += 1 if defined $self->{_format} && $self->{_format} eq 'bigwig';
 
   if($type eq 'overlap' || $type eq 'within' || $type eq 'surrounding') {


### PR DESCRIPTION
https://github.com/Ensembl/ensembl-vep/issues/1645

For insertion the coord should be the flanking bases where the insertion happens. In custom annotation with a VCF file, the end position for an insertion type account for the SVLEN/END and thus add the whole length of the insertion.

Here, we update the end to be re-calculated based on start position in such case. 