### PR TITLE
Fix feature coords for undefined coordinates 

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory/JSON.pm
@@ -334,7 +334,7 @@ sub add_VariationFeatureOverlapAllele_info {
         my $coord_type = lc($1);
         my ($s, $e) = split('-', $tmp);
         $vfoa_hash->{$coord_type.'_start'} = $s;
-        $vfoa_hash->{$coord_type.'_end'} = $e;
+        $vfoa_hash->{$coord_type.'_end'} = defined($e) && ($e =~ /^\d+$/ || $e =~ /\?/) ? $e : $s;
 
         # on rare occasions coord can be "?"; for now just don't print anything
         delete $vfoa_hash->{$coord_type.'_start'} if defined($s)  && $vfoa_hash->{$coord_type.'_start'} !~ /^\d+(\/\d)?\d*$/ ;

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -69,7 +69,7 @@ SKIP: {
         {
           'gene_id' => 'ENSG00000154719',
           'variant_allele' => 'T',
-          'cdna_end' => undef,
+          'cdna_end' => '1122',
           'consequence_terms' => [
             '3_prime_UTR_variant'
           ],
@@ -82,14 +82,14 @@ SKIP: {
           'gene_id' => 'ENSG00000154719',
           'cds_start' => '991',
           'variant_allele' => 'T',
-          'cdna_end' => undef,
+          'cdna_end' => '1033',
           'protein_start' => '331',
           'codons' => 'Gca/Aca',
-          'cds_end' => undef,
+          'cds_end' => '991',
           'consequence_terms' => [
             'missense_variant'
           ],
-          'protein_end' => undef,
+          'protein_end' => '331',
           'amino_acids' => 'A/T',
           'strand' => -1,
           'transcript_id' => 'ENST00000352957',
@@ -244,7 +244,7 @@ SKIP: {
           ],
           'variant_allele' => 'T',
           'strand' => -1,
-          'cdna_end' => undef,
+          'cdna_end' => 1122,
           'cdna_start' => 1122,
           'transcript_id' => 'ENST00000307301',
           'impact' => 'MODIFIER'
@@ -253,14 +253,14 @@ SKIP: {
           'cds_start' => 991,
           'gene_id' => 'ENSG00000154719',
           'variant_allele' => 'T',
-          'cdna_end' => undef,
-          'protein_start' => 331,
+          'cdna_end' => '1033',
+          'protein_start' => '331',
           'codons' => 'Gca/Aca',
-          'cds_end' => undef,
+          'cds_end' => '991',
           'consequence_terms' => [
             'missense_variant'
           ],
-          'protein_end' => undef,
+          'protein_end' => '331',
           'strand' => -1,
           'amino_acids' => 'A/T',
           'cdna_start' => 1033,
@@ -354,7 +354,7 @@ SKIP: {
       'transcript_consequences' => [
         {
           'variant_allele' => 'T',
-          'cdna_end' => undef,
+          'cdna_end' => '1122',
           'swissprot' => [
             'Q9NYK5'
           ],
@@ -383,14 +383,14 @@ SKIP: {
         {
           'hgvsp' => 'ENSP00000284967.6:p.Ala331Thr',
           'variant_allele' => 'T',
-          'cdna_end' => undef,
+          'cdna_end' => '1033',
           'polyphen_score' => '0.001',
           'codons' => 'Gca/Aca',
           'swissprot' => [
             'Q9NYK5'
           ],
           'hgvsc' => 'ENST00000352957.8:c.991G>A',
-          'protein_end' => undef,
+          'protein_end' => '331',
           'strand' => -1,
           'amino_acids' => 'A/T',
           'hgnc_id' => 'HGNC:14027',
@@ -411,7 +411,7 @@ SKIP: {
           'biotype' => 'protein_coding',
           'gene_symbol_source' => 'HGNC',
           'sift_score' => '0.17',
-          'cds_end' => undef,
+          'cds_end' => 991,
           'consequence_terms' => [
             'missense_variant'
           ],
@@ -526,7 +526,7 @@ SKIP: {
       'cdna_end' => 2348,
       'codons' => 'atc/atTc',
       'used_ref' => '-',
-      'protein_end' => undef,
+      'protein_end' => 716,
       'amino_acids' => 'I/IX',
       'strand' => -1,
       'cdna_start' => 2347,
@@ -556,7 +556,7 @@ SKIP: {
   is_deeply($json->decode($lines[0])->{'transcript_consequences'}, [{
     'gene_id' => 'ENSG00000154719',
     'variant_allele' => 'T',
-    'cdna_end' => undef,
+    'cdna_end' => '1122/1199',
     'consequence_terms' => [
       '3_prime_UTR_variant'
     ],
@@ -569,14 +569,14 @@ SKIP: {
     'cds_start' => '991/1017',
     'gene_id' => 'ENSG00000154719',
     'variant_allele' => 'T',
-    'cdna_end' => undef,
+    'cdna_end' => '1033/1110',
     'protein_start' => '331/338',
     'codons' => 'Gca/Aca',
-    'cds_end' => undef,
+    'cds_end' => '991/1017',
     'consequence_terms' => [
       'missense_variant'
     ],
-    'protein_end' => undef,
+    'protein_end' => '331/338',
     'strand' => -1,
     'amino_acids' => 'A/T',
     'cdna_start' => '1033/1110',

--- a/t/OutputFactory_JSON.t
+++ b/t/OutputFactory_JSON.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2026] EMBL-European Bioinformatics Institute
+# Copyright [2016-2025] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -253,14 +253,14 @@ SKIP: {
           'cds_start' => 991,
           'gene_id' => 'ENSG00000154719',
           'variant_allele' => 'T',
-          'cdna_end' => '1033',
-          'protein_start' => '331',
+          'cdna_end' => 1033,
+          'protein_start' => 331,
           'codons' => 'Gca/Aca',
-          'cds_end' => '991',
+          'cds_end' => 991,
           'consequence_terms' => [
             'missense_variant'
           ],
-          'protein_end' => '331',
+          'protein_end' => 331,
           'strand' => -1,
           'amino_acids' => 'A/T',
           'cdna_start' => 1033,
@@ -354,7 +354,7 @@ SKIP: {
       'transcript_consequences' => [
         {
           'variant_allele' => 'T',
-          'cdna_end' => '1122',
+          'cdna_end' => 1122,
           'swissprot' => [
             'Q9NYK5'
           ],
@@ -383,14 +383,14 @@ SKIP: {
         {
           'hgvsp' => 'ENSP00000284967.6:p.Ala331Thr',
           'variant_allele' => 'T',
-          'cdna_end' => '1033',
+          'cdna_end' => 1033,
           'polyphen_score' => '0.001',
           'codons' => 'Gca/Aca',
           'swissprot' => [
             'Q9NYK5'
           ],
           'hgvsc' => 'ENST00000352957.8:c.991G>A',
-          'protein_end' => '331',
+          'protein_end' => 331,
           'strand' => -1,
           'amino_acids' => 'A/T',
           'hgnc_id' => 'HGNC:14027',
@@ -595,6 +595,57 @@ SKIP: {
     'impact' => 'MODIFIER'
   }], "use total_length 1");
 
+  # test when variant is outside of cdna or cds or protein sequence - coords should be undefined
+  
+  $ib = get_annotated_buffer({
+    input_file => $test_cfg->create_input_file([qw(21 25585652 sv_del T . . . SVTYPE=DEL;END=25585700)]),
+  });
+  $of = Bio::EnsEMBL::VEP::OutputFactory::JSON->new({config => $ib->config});
+  
+  @lines = @{$of->get_all_lines_by_InputBuffer($ib)};
+  use Data::Dumper;
+  is_deeply($json->decode($lines[0])->{'transcript_consequences'}, [
+  {
+    'cdna_start' => 1155,
+    'bp_overlap' => 45,
+    'gene_id' => 'ENSG00000154719',
+    'transcript_id' => 'ENST00000307301',
+    'impact' => 'HIGH',
+    'percentage_overlap' => '0.21',
+    'consequence_terms' => [
+      'feature_truncation',
+      '3_prime_UTR_variant'
+    ],
+    'variant_allele' => 'deletion',
+    'strand' => -1
+  },
+  {
+    'consequence_terms' => [
+      'feature_truncation',
+      '3_prime_UTR_variant'
+    ],
+    'percentage_overlap' => '0.21',
+    'variant_allele' => 'deletion',
+    'strand' => -1,
+    'bp_overlap' => 45,
+    'cdna_start' => 1066,
+    'gene_id' => 'ENSG00000154719',
+    'transcript_id' => 'ENST00000352957',
+    'impact' => 'HIGH'
+  },
+  {
+    'consequence_terms' => [
+      'upstream_gene_variant'
+    ],
+    'distance' => 2327,
+    'gene_id' => 'ENSG00000260583',
+    'transcript_id' => 'ENST00000567517',
+    'impact' => 'MODIFIER',
+    'variant_allele' => 'deletion',
+    'strand' => -1
+  }
+  ], "check coordinates when variant is outside of feature");
+  
   # test custom
   use_ok('Bio::EnsEMBL::VEP::AnnotationSource::File');
 

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -1195,21 +1195,21 @@ SKIP: {
             'strand' => -1,
             'transcript_id' => 'ENST00000307301',
             'cdna_start' => 1122,
-            'cdna_end' => undef,
+            'cdna_end' => 1122,
             'impact' => 'MODIFIER'
           },
           {
             'gene_id' => 'ENSG00000154719',
             'cds_start' => 991,
             'variant_allele' => 'T',
-            'cdna_end' => undef,
+            'cdna_end' => 1033,
             'protein_start' => 331,
             'codons' => 'Gca/Aca',
-            'cds_end' => undef,
+            'cds_end' => 991,
             'consequence_terms' => [
               'missense_variant'
             ],
-            'protein_end' => undef,
+            'protein_end' => 331,
             'amino_acids' => 'A/T',
             'strand' => -1,
             'transcript_id' => 'ENST00000352957',


### PR DESCRIPTION
https://github.com/Ensembl/ensembl-vep/pull/1963 attempted to fix coordinates when end is undefined but SNPs may not have end and borrow the end coordinates from start. 
Fixed tests and added a new test
```
17:g.7668407_7668436del
17:g.7669572_7669647del
17:g.7668407_7669647del
17:g.7668407_7687502del

GRCh37
6:g.1102327G>T 
 ```