### PR TITLE
Fix for BNDs causing mis-annotation of other unrelated variants

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm
@@ -105,7 +105,7 @@ sub annotate_InputBuffer {
     my $slice;
 
     # get overlapping VFs
-    my $vfs = $buffer->get_overlapping_vfs($fs, $fe);
+    my $vfs = $buffer->get_overlapping_vfs($tr->{slice}->{seq_region_name}, $fs, $fe);
     next unless @$vfs;
 
     # lazy load transcript

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -289,7 +289,6 @@ sub get_overlapping_vfs {
 
   if(@_ == 3) {
     ($chr, $start, $end) = @_;
-    $chr = $self->_normalise_chr_for_vf_overlap($chr);
   }
   else {
     ($start, $end) = @_;
@@ -321,15 +320,14 @@ sub get_overlapping_vfs {
   foreach my $vf (@all_vfs)  {
     my $vf_chr = $vf->{chr};
     $vf_chr ||= $vf->{slice}->{seq_region_name} if $vf->{slice};
-    $vf_chr = $self->_normalise_chr_for_vf_overlap($vf_chr);
 
     if (overlap($vf->{start}, $vf->{end}, $start, $end)){
-      push(@vfs, $vf) if !defined $chr || (defined $vf_chr && $vf_chr eq $chr);
+      push(@vfs, $vf) if $self->_chr_matches_for_vf_overlap($chr, $vf_chr);
     }
 
     if ((defined($vf->{unshifted_end}) && (defined($vf->{unshifted_start})))) {
       if (overlap($vf->{unshifted_start}, $vf->{unshifted_end}, $start, $end)) {
-        push(@vfs, $vf) if !defined $chr || (defined $vf_chr && $vf_chr eq $chr);
+        push(@vfs, $vf) if $self->_chr_matches_for_vf_overlap($chr, $vf_chr);
       }
     }
 
@@ -338,9 +336,8 @@ sub get_overlapping_vfs {
     for my $alt (@{ $vf->get_breakends }) {
       my $alt_chr = $alt->{chr};
       $alt_chr ||= $alt->{slice}->{seq_region_name} if $alt->{slice};
-      $alt_chr = $self->_normalise_chr_for_vf_overlap($alt_chr);
       push(@vfs, $vf) if
-        (!defined $chr || (defined $alt_chr && $alt_chr eq $chr)) &&
+        $self->_chr_matches_for_vf_overlap($chr, $alt_chr) &&
         overlap($alt->{pos}, $alt->{pos}, $start, $end);
     }
   }
@@ -348,29 +345,15 @@ sub get_overlapping_vfs {
 }
 
 
-sub _normalise_chr_for_vf_overlap {
-  my ($self, $chr) = @_;
-  return undef unless defined $chr;
+sub _chr_matches_for_vf_overlap {
+  my ($self, $query_chr, $vf_chr) = @_;
 
-  my %names = ($chr => 1);
-  $names{$self->get_source_chr_name($chr)} = 1;
+  return 1 unless defined $query_chr;
+  return 0 unless defined $vf_chr;
+  return 1 if $vf_chr eq $query_chr;
 
-  my $synonyms = $self->chromosome_synonyms || {};
-  foreach my $name (keys %names) {
-    $names{$_} = 1 for keys %{$synonyms->{$name} || {}};
-  }
-
-  foreach my $name (keys %names) {
-    $names{$self->get_source_chr_name($name)} = 1;
-  }
-
-  my @names = map {
-    my $name = $_;
-    $name =~ s/^chr//i;
-    $name;
-  } keys %names;
-
-  return (sort { length($a) <=> length($b) || $a cmp $b } @names)[0];
+  my $set = sprintf(q{vf_overlap_%s}, $query_chr);
+  return $self->get_source_chr_name($vf_chr, $set, [$query_chr]) eq $query_chr;
 }
 
 =head2 interval_tree

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -269,11 +269,13 @@ sub next {
 
 =head2 get_overlapping_vfs
   
-  Arg 1      : int $start
-  Arg 2      : int $end
+  Arg 1      : optional string $chr
+  Arg 2      : int $start
+  Arg 3      : int $end
   Example    : $vfs = $ib->get_overlapping_vfs($start, $end);
+               $vfs = $ib->get_overlapping_vfs($chr, $start, $end);
   Description: Gets all VariationFeatures overlapping the coordinate
-               range given by $start, $end
+               range given by $start, $end, optionally restricted to $chr
   Returntype : arrayref of Bio::EnsEMBL::Variation::VariationFeature
   Exceptions : none
   Caller     : AnnotationSource
@@ -283,8 +285,15 @@ sub next {
 
 sub get_overlapping_vfs {
   my $self = shift;
-  my $start = shift;
-  my $end = shift;
+  my ($chr, $start, $end);
+
+  if(@_ == 3) {
+    ($chr, $start, $end) = @_;
+    $chr = $self->_normalise_chr_for_vf_overlap($chr);
+  }
+  else {
+    ($start, $end) = @_;
+  }
 
   my @all_vfs;
   ($start, $end) = ($end, $start) if $start > $end;
@@ -310,25 +319,44 @@ sub get_overlapping_vfs {
 
   my @vfs;
   foreach my $vf (@all_vfs)  {
+    my $vf_chr = $vf->{chr};
+    $vf_chr ||= $vf->{slice}->{seq_region_name} if $vf->{slice};
+    $vf_chr = $self->_normalise_chr_for_vf_overlap($vf_chr);
+
     if (overlap($vf->{start}, $vf->{end}, $start, $end)){
-      push(@vfs, $vf);
+      push(@vfs, $vf) if !defined $chr || (defined $vf_chr && $vf_chr eq $chr);
     }
 
     if ((defined($vf->{unshifted_end}) && (defined($vf->{unshifted_start})))) {
       if (overlap($vf->{unshifted_start}, $vf->{unshifted_end}, $start, $end)) {
-        push(@vfs, $vf);
+        push(@vfs, $vf) if !defined $chr || (defined $vf_chr && $vf_chr eq $chr);
       }
     }
 
     # check overlap with complex alternative alleles (such as breakend structural variants)
     next unless Scalar::Util::blessed($vf) and $vf->can('get_breakends');
     for my $alt (@{ $vf->get_breakends }) {
-      push(@vfs, $vf) if overlap($alt->{pos}, $alt->{pos}, $start, $end);
+      my $alt_chr = $alt->{chr};
+      $alt_chr ||= $alt->{slice}->{seq_region_name} if $alt->{slice};
+      $alt_chr = $self->_normalise_chr_for_vf_overlap($alt_chr);
+      push(@vfs, $vf) if
+        (!defined $chr || (defined $alt_chr && $alt_chr eq $chr)) &&
+        overlap($alt->{pos}, $alt->{pos}, $start, $end);
     }
   }
   return [@vfs];
 }
 
+
+sub _normalise_chr_for_vf_overlap {
+  my ($self, $chr) = @_;
+  return undef unless defined $chr;
+
+  $chr = $self->get_source_chr_name($chr);
+  $chr =~ s/^chr//i;
+
+  return $chr;
+}
 
 =head2 interval_tree
   

--- a/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
+++ b/modules/Bio/EnsEMBL/VEP/InputBuffer.pm
@@ -352,10 +352,25 @@ sub _normalise_chr_for_vf_overlap {
   my ($self, $chr) = @_;
   return undef unless defined $chr;
 
-  $chr = $self->get_source_chr_name($chr);
-  $chr =~ s/^chr//i;
+  my %names = ($chr => 1);
+  $names{$self->get_source_chr_name($chr)} = 1;
 
-  return $chr;
+  my $synonyms = $self->chromosome_synonyms || {};
+  foreach my $name (keys %names) {
+    $names{$_} = 1 for keys %{$synonyms->{$name} || {}};
+  }
+
+  foreach my $name (keys %names) {
+    $names{$self->get_source_chr_name($name)} = 1;
+  }
+
+  my @names = map {
+    my $name = $_;
+    $name =~ s/^chr//i;
+    $name;
+  } keys %names;
+
+  return (sort { length($a) <=> length($b) || $a cmp $b } @names)[0];
 }
 
 =head2 interval_tree

--- a/t/InputBuffer.t
+++ b/t/InputBuffer.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2025] EMBL-European Bioinformatics Institute
+# Copyright [2016-2026] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/InputBuffer.t
+++ b/t/InputBuffer.t
@@ -487,6 +487,56 @@ is_deeply(
   'minimal - doesnt affect non-minimisable'
 );
 
+{
+  package Bio::EnsEMBL::VEP::Test::BreakendVF;
+  sub get_breakends { return $_[0]->{breakends}; }
+}
+
+SKIP: {
+  no warnings "once";
+  skip "Set::IntervalTree not installed", 4 unless $Bio::EnsEMBL::VEP::InputBuffer::CAN_USE_INTERVAL_TREE;
+
+  my $chr_vf = bless({
+    chr => "21",
+    start => 100,
+    end => 101,
+  }, "Bio::EnsEMBL::Variation::VariationFeature");
+
+  my $bnd_vf = bless({
+    chr => "1",
+    start => 1,
+    end => 1,
+    breakends => [{ chr => "22", pos => 100 }],
+  }, "Bio::EnsEMBL::VEP::Test::BreakendVF");
+
+  my $chr_ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg, variation_features => []});
+  $chr_ib->buffer([$chr_vf, $bnd_vf]);
+
+  is_deeply(
+    $chr_ib->get_overlapping_vfs("21", 100, 100),
+    [$chr_vf],
+    "get_overlapping_vfs chr filter keeps same chromosome VF"
+  );
+
+  is_deeply(
+    $chr_ib->get_overlapping_vfs("chr21", 100, 100),
+    [$chr_vf],
+    "get_overlapping_vfs chr filter normalises chr prefix"
+  );
+
+  is_deeply(
+    $chr_ib->get_overlapping_vfs("22", 100, 100),
+    [$bnd_vf],
+    "get_overlapping_vfs chr filter keeps matching breakend mate"
+  );
+
+  is_deeply(
+    $chr_ib->get_overlapping_vfs("1", 100, 100),
+    [],
+    "get_overlapping_vfs chr filter excludes breakend mate on another chromosome"
+  );
+}
+
 # Check non ordered variants
 my $max_non_ordered_variants = 5;
 my $max_not_ordered_variants_distance = 5;

--- a/t/InputBuffer.t
+++ b/t/InputBuffer.t
@@ -1,4 +1,4 @@
-# Copyright [2016-2026] EMBL-European Bioinformatics Institute
+# Copyright [2016-2025] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -486,56 +486,6 @@ is_deeply(
   }, 'Bio::EnsEMBL::Variation::VariationFeature' ),
   'minimal - doesnt affect non-minimisable'
 );
-
-{
-  package Bio::EnsEMBL::VEP::Test::BreakendVF;
-  sub get_breakends { return $_[0]->{breakends}; }
-}
-
-SKIP: {
-  no warnings "once";
-  skip "Set::IntervalTree not installed", 4 unless $Bio::EnsEMBL::VEP::InputBuffer::CAN_USE_INTERVAL_TREE;
-
-  my $chr_vf = bless({
-    chr => "21",
-    start => 100,
-    end => 101,
-  }, "Bio::EnsEMBL::Variation::VariationFeature");
-
-  my $bnd_vf = bless({
-    chr => "1",
-    start => 1,
-    end => 1,
-    breakends => [{ chr => "22", pos => 100 }],
-  }, "Bio::EnsEMBL::VEP::Test::BreakendVF");
-
-  my $chr_ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg, variation_features => []});
-  $chr_ib->buffer([$chr_vf, $bnd_vf]);
-
-  is_deeply(
-    $chr_ib->get_overlapping_vfs("21", 100, 100),
-    [$chr_vf],
-    "get_overlapping_vfs chr filter keeps same chromosome VF"
-  );
-
-  is_deeply(
-    $chr_ib->get_overlapping_vfs("chr21", 100, 100),
-    [$chr_vf],
-    "get_overlapping_vfs chr filter normalises chr prefix"
-  );
-
-  is_deeply(
-    $chr_ib->get_overlapping_vfs("22", 100, 100),
-    [$bnd_vf],
-    "get_overlapping_vfs chr filter keeps matching breakend mate"
-  );
-
-  is_deeply(
-    $chr_ib->get_overlapping_vfs("1", 100, 100),
-    [],
-    "get_overlapping_vfs chr filter excludes breakend mate on another chromosome"
-  );
-}
 
 # Check non ordered variants
 my $max_non_ordered_variants = 5;


### PR DESCRIPTION
This PR aims to fix the bug reported in issue #2017. This bug caused incorrect transcript annotation of unrelated variants in the presence of BND records.

During transcript annotation, VEP identifies input variants that overlap each transcript. This was based only on start/end coords, not chr. BND records make this difficult because they refer to two genomic locs - that of the record and it's mate which is on another chr. VEP includes both when deciding which input variants may overlap a transcript. As such, a BND mate on one chr could cause VEP to consider variants from a different chr if their numeric coords happened to be in the same range. An unrelated variant in the same input file as a BND can thus be incorrectly annotated. 

Example highlighted by #2017: 
  - two BND records on chr9, with mates on chr6
  - a small deletion on chr9

```vcf
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
chr9	37015062	MantaBND:2936:1:2:0:1:0:0	C	[chr6:116311629[C	.	MaxDepth	SVTYPE=BND;MATEID=MantaBND:2936:1:2:0:1:0:1;CIPOS=0,1;HOMLEN=1;HOMSEQ=C
chr9	37020792	MantaBND:4862:0:1:0:3:0:0	C	[chr6:136912382[C	.	MaxDepth	SVTYPE=BND;MATEID=MantaBND:4862:0:1:0:3:0:1;CIPOS=0,1;HOMLEN=1;HOMSEQ=C
chr9	136496196	.	CAG	C	.	PASS	.
```

This resulted in the small deletion being annotated incorrectly, including the wrong hgvs string and the wrong gene, NOTCH1, which is on chr6. 

Changes this PR introduces to fix this behaviour: 

- `InputBuffer::get_overlapping_vfs` 
  - chr additionally supplied as an optional arg
- `Transcript.pm`: 
  - `get_overlapping_vfs` can now optionally take a chromosome, but old usage still works and if no chromosome is passed, behaviour stays the same
   - if a chromosome is passed, returned variants must match that chromosome - this chromosome check is applied to normal variant coordinates, unshifted/original variant coordinates and to BND mate coordinates
  - to handle chr synonyms, chr matching reuses VEP’s existing get_source_chr_name synonym handling sub

Overall, these changes prevent variants on different chromosomes being matched just because their numeric coordinates overlap