### PR TITLE
Feature/protein version

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/File/BaseGXF.pm
@@ -724,11 +724,12 @@ sub _add_translation {
 
   # copy protein ID to transcript object for outputfactory
   $tr->{_protein} = $protein_id if $protein_id;
-
+  my $version = $ordered_cdss->[0]->{attributes}->{version} || 1;
+  
   # create translation object
   my $translation = $tr->{translation} ||= Bio::EnsEMBL::Translation->new(
     -TRANSCRIPT => $tr,
-    -VERSION    => 1,
+    -VERSION    => $version,
     -STABLE_ID  => $protein_id,
   );
   $translation->{transcript} = $tr;
@@ -736,7 +737,6 @@ sub _add_translation {
 
   # we need to use the first and last cds record to set the translation start and ends
   my $offset;
-
   if($ordered_cdss->[0]->{strand} > 0) {
     $offset = ($ordered_cdss->[0]->{start} - $ordered_cdss->[0]->{_exon}->start) + 1;
   }

--- a/modules/Bio/EnsEMBL/VEP/Config.pm
+++ b/modules/Bio/EnsEMBL/VEP/Config.pm
@@ -184,6 +184,7 @@ our @VEP_PARAMS = (
   'xref_refseq',             # output refseq mrna xref
   'uniprot',                 # output Uniprot identifiers (includes UniParc)
   'protein',                 # add e! protein ID to extra column
+  'protein_version',         # add protein version to e! protein ID
   'biotype',                 # add biotype of transcript to output
   'hgnc',                    # add HGNC gene ID to extra column
   'symbol',                  # add gene symbol (e.g. HGNC)

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -84,6 +84,8 @@ use Bio::EnsEMBL::VEP::OutputFactory::VEP_output;
 use Bio::EnsEMBL::VEP::OutputFactory::VCF;
 use Bio::EnsEMBL::VEP::OutputFactory::Tab;
 
+use Data::Dumper;
+
 our $CAN_USE_JSON;
 
 BEGIN {
@@ -184,6 +186,7 @@ sub new {
     refseq
     merged
     protein
+    protein_version
     uniprot
     canonical
     biotype
@@ -1556,6 +1559,12 @@ sub BaseTranscriptVariationAllele_to_output_hash {
     $self->{protein} &&
     defined($tr->{_protein}) &&
     $tr->{_protein} ne '-';
+  $hash->{ENSP} .= '.'.$tr->translation->version if 
+    $hash->{ENSP} && 
+    $self->{protein_version} &&
+    $tr->translation && 
+    $tr->translation->version && 
+    $hash->{ENSP} !~ /\.\d+$/;
 
   # uniprot
   if($self->{uniprot}) {

--- a/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
+++ b/modules/Bio/EnsEMBL/VEP/OutputFactory.pm
@@ -84,8 +84,6 @@ use Bio::EnsEMBL::VEP::OutputFactory::VEP_output;
 use Bio::EnsEMBL::VEP::OutputFactory::VCF;
 use Bio::EnsEMBL::VEP::OutputFactory::Tab;
 
-use Data::Dumper;
-
 our $CAN_USE_JSON;
 
 BEGIN {

--- a/t/Runner.t
+++ b/t/Runner.t
@@ -193,6 +193,7 @@ is_deeply($runner->get_OutputFactory, bless( {
   'af' => undef,
   'biotype' => undef,
   'protein' => undef,
+  'protein_version' => undef,
   'domains' => undef,
   'pick_allele_gene' => undef,
   'variant_class' => undef,


### PR DESCRIPTION
Adding cli param --protein_version to add protein version to ENSP.
Don't need to document this one, it's a bit niche and designed primarily for retrieval of the version data from the GFFs used to run web VEP.

