### PR TITLE
Fixing sort for large headers

### DIFF
--- a/nextflow/modules/check_VCF.nf
+++ b/nextflow/modules/check_VCF.nf
@@ -68,8 +68,9 @@ process checkVCF {
   sort_cmd = ""
   if( params.sort ) {
     isGzipped = vcf.extension == 'gz'
-    cat_cmd   = isGzipped ? "zcat ${vcf}" : "cat ${vcf}"
-    sort_cmd += "(${cat_cmd} | head -1000 | grep '^#'; ${cat_cmd} | grep -v '^#' | sort -k1,1d -k2,2n) > tmp.vcf; "
+    zip_cmd   = isGzipped ? "zcat ${vcf} | " : ""
+    overall_cmd   = "(awk '/^#/{print; next}{exit}' ${vcf}; awk '!/^#/' ${vcf} | sort -k1,1V -k2,2n) > tmp.vcf;"
+    sort_cmd += isGzipped ? "${zip_cmd} ${overall_cmd}" : "${overall_cmd}"  // Sort
     sort_cmd += isGzipped ? "bgzip -c tmp.vcf > ${vcf}" : "mv tmp.vcf ${vcf}"
   }
   """

--- a/nextflow/modules/check_VCF.nf
+++ b/nextflow/modules/check_VCF.nf
@@ -67,7 +67,7 @@ process checkVCF {
 
   sort_cmd = ""
   if( params.sort ) {
-    isGzipped = vcf.extension == 'gz'
+    isGzipped = vcf.extension.toLowerCase() in ['gz', 'bgz']
     zip_cmd   = isGzipped ? "zcat ${vcf} | " : ""
     overall_cmd   = "(awk '/^#/{print; next}{exit}' ${vcf}; awk '!/^#/' ${vcf} | sort -k1,1V -k2,2n) > tmp.vcf;"
     sort_cmd += isGzipped ? "${zip_cmd} ${overall_cmd}" : "${overall_cmd}"  // Sort

--- a/nextflow/modules/run_vep.nf
+++ b/nextflow/modules/run_vep.nf
@@ -50,22 +50,13 @@ process runVEP {
   }
   else {
     vep_cmd = "vep -i ${input} -o out.vcf --vcf --config ${vep_config}"
-
   }
-
-  if( params.sort ) {
-    sort_cmd = "(head -1000 out.vcf | grep '^#'; grep -v '^#' out.vcf | sort -k1,1d -k2,2n) > ${out}"
-  } else {
-    sort_cmd = "mv out.vcf ${out}"
-  }
-
 
   """
   ${vep_cmd}
 
   # Sort, bgzip and tabix VCF
-  ${sort_cmd}
-
+  mv out.vcf ${out}
   bgzip ${out}
   tabix ${tabix_arg} ${out}.gz
   """

--- a/nextflow/modules/run_vep.nf
+++ b/nextflow/modules/run_vep.nf
@@ -55,7 +55,7 @@ process runVEP {
   """
   ${vep_cmd}
 
-  # Sort, bgzip and tabix VCF
+  #Sort, bgzip and tabix VCF
   mv out.vcf ${out}
   bgzip ${out}
   tabix ${tabix_arg} ${out}.gz


### PR DESCRIPTION
Bug reported from web here: https://genomes-ebi.slack.com/archives/C0JUVJV6W/p1786694507190039 

After some digging I discovered it's the sort command that's breaking the header, we hardcoded a value of head -n 1000 when checking for the header in check_VCF.nf, but the file here has a massive amount of headers, so they were truncated and broke downstream processing.

Updated the command to actually check properly for header lines and separate the file for sorting that way.

In doing so it broke again, as there is an unnecessary secondary sort, using much the same command in run_vep.nf, which operates on the split files - but these have already been sorted prior to splitting. So I removed this.

You can test using input that caused the error here: `/nfs/production/flicek/ensembl/variation/webVEP_debug/tmpyq3ina2u/combCF4_459IL_inclDNA25_CFA2og202122232425.EuraNerv_2CAnotRefOrHet_morfarnotHomReforVar_ALLother_NOTHomVarorHet.vcf`

Enable --sort

VEP version 115 / docker 115.2

Making against 115 as there are more changes in 116 version that make it a pain to incorporate there. Will need a manual docker rebuild so web can pull.