### PR TITLE
Fix --freq_filter dropping rare insertions via colliding allele names (#1404)

### DIFF
--- a/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/BaseCacheVariation.pm
+++ b/modules/Bio/EnsEMBL/VEP/AnnotationSource/Cache/BaseCacheVariation.pm
@@ -410,27 +410,27 @@ sub _add_check_freq_data_to_vf {
   foreach my $alt(@$alts) {
     my $pass = 0;
 
+    # $freq_data is keyed on the known variant's alleles, $alt is the input's,
+    # and the two representations need not agree. Where compare_existing() has
+    # recorded which known allele this input allele matched, that mapping is
+    # the only safe way to look up the frequency; a bare $freq_data->{$alt} hit
+    # can be a coincidence. An insertion minimised to "-/G" has ALT "G", while
+    # the same known variant stored as "G/GG" has REF "G", and the "fill in by
+    # subtracting" in get_frequency_data() gives that REF a frequency of ~1 -
+    # so a variant seen once in gnomAD looks fixed in the population and is
+    # wrongly dropped by --freq_filter exclude.
+    my $match_b = $matched_alleles->{$alt};
+
     # set freq to 'NA' if the alternate allele hasn't been observed, or
     # the reference allele is the minor allele and the overlapping variant
     # is multiallelic (more than 1 alternative allele), e.g.:
     # Input: 17:7676154 => G/C
     # Minor allele: G (0.4571)
     # Overlapping variant: rs1042522 (G/C/T)
-    my $f = $freq_data->{$alt} || 'NA';
+    my $f = (defined($match_b) ? $freq_data->{$match_b} : $freq_data->{$alt}) || 'NA';
 
-    if ($f eq 'NA') {
-      $pass = 0;
+    $pass = $self->check_pass($pass, $f, $freq_freq, $freq_gt_lt) unless $f eq 'NA';
 
-      # check if there is frequency for the matched alleles
-      my $match_b = $matched_alleles->{$alt};
-      if($match_b && $freq_data->{$match_b}) {
-        $f = $freq_data->{$match_b};
-        $pass = $self->check_pass($pass, $f, $freq_freq, $freq_gt_lt);
-      }
-    }
-    else {
-      $pass = $self->check_pass($pass, $f, $freq_freq, $freq_gt_lt);
-    }
     $used_freqs{$alt} = $f;
 
     $pass_count += $pass;

--- a/t/AnnotationSource_Cache_Variation.t
+++ b/t/AnnotationSource_Cache_Variation.t
@@ -471,6 +471,101 @@ $c->annotate_InputBuffer($ib);
 is($ib->buffer->[0]->{existing}->[0]->{AMR}, 0.0014, 'old_maf');
 $c->{old_maf} = 0;
 
+
+## FREQUENCY FILTERING ACROSS DIFFERING ALLELE REPRESENTATIONS
+##############################################################
+# https://github.com/Ensembl/ensembl-vep/issues/1404
+# VEP minimises an inserted base to allele_string "-/G", so the input ALT is
+# "G". The same known variant can be held in the cache in anchored form,
+# "G/GG", whose REF is also "G". get_frequency_data() fills in the known REF's
+# frequency by subtracting the ALT frequencies from 1, so looking the input ALT
+# up by name alone returns ~1 and a variant seen once in gnomAD is dropped by
+# --freq_filter exclude. The matched_alleles mapping from compare_existing()
+# is what tells the two "G"s apart.
+
+my %freq_bak = map {$_ => $c->{$_}} qw(freq_pop freq_freq freq_gt_lt freq_filter);
+
+$c->{freq_pop}    = 'gnomADe';
+$c->{freq_freq}   = 0.05;
+$c->{freq_gt_lt}  = 'gt';
+$c->{freq_filter} = 'exclude';
+
+sub freq_check_insertion {
+  my $gnomade = shift;
+
+  my $vf = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
+    chr            => 21,
+    start          => 25585734,
+    end            => 25585733,
+    strand         => 1,
+    allele_string  => '-/G',
+    variation_name => 'insertion_input',
+  });
+
+  my $existing = {
+    variation_name => 'rs755283040',
+    chr            => 21,
+    start          => 25585734,
+    end            => 25585734,
+    strand         => 1,
+    allele_string  => 'G/GG',
+    gnomADe        => $gnomade,
+  };
+
+  $vf->{existing} = [$c->compare_existing($vf, $existing)];
+  $c->get_frequency_data($vf);
+
+  return $vf;
+}
+
+my $rare_ins = freq_check_insertion('GG:6.365e-06');
+
+is_deeply(
+  $rare_ins->{existing}->[0]->{matched_alleles},
+  [{a_index => 0, a_allele => 'G', b_index => 0, b_allele => 'GG'}],
+  'insertion frequency - input ALT "G" matches known ALT "GG"'
+);
+
+is_deeply(
+  $rare_ins->{_freq_check_freqs},
+  {'GNOMADE' => {'G' => '6.365e-06'}},
+  'insertion frequency - uses the matched allele frequency, not the known REF'
+);
+
+is_deeply(
+  $rare_ins->{_freq_check_pass},
+  {'G' => 0},
+  'insertion frequency - rare insertion does not meet the frequency threshold'
+);
+
+is($rare_ins->{_freq_check_all_failed}, 1, 'insertion frequency - rare insertion all_failed');
+ok(!$rare_ins->{_freq_check_all_passed}, 'insertion frequency - rare insertion not all_passed');
+
+# a genuinely common insertion must still be filtered
+my $common_ins = freq_check_insertion('GG:0.4');
+
+is_deeply(
+  $common_ins->{_freq_check_freqs},
+  {'GNOMADE' => {'G' => '0.4'}},
+  'insertion frequency - common insertion frequency'
+);
+
+is($common_ins->{_freq_check_all_passed}, 1, 'insertion frequency - common insertion all_passed');
+
+# and end to end through the buffer: the rare one is kept, the common one dropped
+foreach my $case([$rare_ins, 1, 'rare insertion kept'], [$common_ins, 0, 'common insertion excluded']) {
+  my ($vf, $expected, $desc) = @$case;
+
+  my $freq_ib = Bio::EnsEMBL::VEP::InputBuffer->new({config => $cfg});
+  $freq_ib->buffer([$vf]);
+  $c->frequency_check_buffer($freq_ib);
+
+  is(scalar @{$freq_ib->buffer}, $expected, 'frequency_check_buffer - '.$desc);
+}
+
+$c->{$_} = $freq_bak{$_} for keys %freq_bak;
+
+
 # done
 done_testing();
 


### PR DESCRIPTION
Fixes #1404 — a variant with a gnomAD AF of `6.365e-06` is dropped by `--freq_freq 0.05 --freq_gt_lt gt --freq_filter exclude`.

## Root cause

Two hashes in `AnnotationSource/Cache/BaseCacheVariation.pm` are keyed by allele name, but in two different allele namespaces:

- `get_frequency_data()` builds `%freq_data` keyed on the **known (cache) variant's** allele strings, and fills in the unobserved allele as `1 - sum(observed)`.
- `_add_check_freq_data_to_vf()` then looked up each of the **input VF's** ALT alleles directly in that hash.

For the reported variant, `chr4:105259626 T>TG` is minimised by VEP to `-/G`, so the input ALT is `G`. The colocated rs755283040 is held in the cache in anchored form, `G/GG` — whose REF is also `G`:

```
freq_data{GG} = 6.365e-06        # true gnomADe AF of the insertion
freq_data{G}  = 1 - 6.365e-06    # interpolated frequency of the known REF
              = 0.999993635
input ALT      = "G"             # collides with the known REF
0.999993635 >= 0.05 → "common" → _freq_check_all_passed → excluded
```

The correct mapping was already available: `compare_existing()` records `matched_alleles = {G -> GG}`. But `_add_check_freq_data_to_vf` only consulted it *after* a direct `$freq_data->{$alt}` lookup missed, so the wrong-but-present value won.

The second example on the issue (ASXL1) is the same shape: input `-/A`, known variant `A/AA`.

## Fix

Prefer the matched-allele mapping, falling back to the direct key only where no match was recorded (`--no_check_alleles`, known variants with unknown alleles such as `COSMIC_MUTATION`).

This also makes the filter agree with the annotation. `OutputFactory::add_colocated_frequency_data()` already resolves through `matched_alleles` (and restricts interpolation to the 1KG `AF` key, with a comment explaining why). That is why the reporter's own JSON shows `gnomade: 6.365e-06` for the allele while the filter was using `0.999993635` for it.

## Scope

The collision needs the input's minimised ALT to equal one of the known variant's allele names. That happens for insertions held in anchored form, and for representation swaps generally; deletions look unaffected, since an input deletion minimises to ALT `-`, which cannot collide with an `AG/A`-style entry. The README "Known Bugs" entry describes this as affecting "insertions / deletions" — I have deliberately not edited it, since narrowing that wording is a maintainer call.

## Tests

Adds 9 assertions to `t/AnnotationSource_Cache_Variation.t` covering the rare insertion (kept), a genuinely common insertion of the same shape (still correctly excluded), and both end to end through `frequency_check_buffer`. 5 of the 9 fail on the unpatched code, including "rare insertion kept".

Full `t/` suite passes (51 files, ~2100 assertions, no failures). DB-backed tests self-skip — no `MultiTestDB.conf` in my environment.

## Related, not included here

`$freq_data->{$alt} || 'NA'` treats a frequency of exactly `0` as "not observed". That is harmless for `--freq_gt_lt gt`, but under `--freq_filter include --freq_gt_lt lt` ("keep only variants rarer than X") a variant absent from the chosen population is silently dropped. Zeros are common in the cache — in the 1Mb chr21 test slice, `gnomADe_MID` is all-zero for 1779/1779 records, `gnomADe_ASJ` for 1702/1779, and the global `gnomADe` column for 37. It is a distinct defect with its own blast radius, so I have filed it separately rather than bundling it into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4wH6acuwsuTKtyfZNWzFt
